### PR TITLE
Run adjacency on splits: per-panel claims, family-relative gate licenses, parent supersession (#135, #256)

### DIFF
--- a/mapsnap/adjacency_gate.py
+++ b/mapsnap/adjacency_gate.py
@@ -239,22 +239,27 @@ def edge_contradictions(
 def hard_signal(
     page: FittedPage, median_theta_deg: float, median_log_scale: float
 ) -> str | None:
-    """The demotion-licensing signal, or None when the fit looks structurally sound."""
+    """The demotion-licensing signal, or None when the fit looks structurally sound.
+
+    Both pose deviations are FAMILY-relative, not raw volume-median-relative
+    (#256): volumes legitimately contain 90-deg-rotated sheets (fargo has
+    seven at ~91 deg; grand_rapids panel p724__2 sits at 91) and half/double
+    scale families (fargo: 65 pages at one rung, 11 at a 2x rung), and a raw
+    median comparison hands every minority-family page a permanent demotion
+    license -- an 8-GCP 11 ft fargo fit died that way, and the first per-panel
+    A/B demoted champaign's correct 2x inset p23__1 [scale_dev=0.67]. Rotation
+    is compared mod 90 (sheet rotations are quarter-turns); scale against the
+    nearest log-2 rung of the volume median (the SAME/HALF/DOUBLE family
+    structure the georef scale bands already model).
+    """
     if page.gcps <= GATE_MAX_GCPS:
         return f"gcps={page.gcps}"
-    rot = abs((page.theta_deg - median_theta_deg + 180.0) % 360.0 - 180.0)
+    rot = abs((page.theta_deg - median_theta_deg + 45.0) % 90.0 - 45.0)
     if rot > GATE_ROT_DEV_DEG:
         return f"rot_dev={rot:.0f}deg"
-    # Scale deviation from the VOLUME median licenses nothing for a split
-    # panel: insets are drawn at their own scales (a 100ft-per-inch inset on a
-    # 200ft volume sits at |log dev| ~0.69), so the #256 multi-family flaw
-    # fires on exactly the pages #135 gave the gate reach over. Measured: the
-    # first per-panel A/B demoted champaign p23__1 [scale_dev=0.67], a correct
-    # inset fit, costing the volume 4.0 score points. Rotation stays licensed:
-    # insets share the sheet's orientation.
-    if "__" in page.stem:
-        return None
-    scale = abs(page.log_scale - median_log_scale)
+    dev = page.log_scale - median_log_scale
+    rung = round(dev / math.log(2.0))
+    scale = abs(dev - rung * math.log(2.0))
     if scale > GATE_SCALE_DEV_LOG:
         return f"scale_dev={scale:.2f}"
     return None

--- a/mapsnap/adjacency_gate.py
+++ b/mapsnap/adjacency_gate.py
@@ -162,15 +162,30 @@ def load_fitted_pages(volume: Path, adjacency: dict) -> dict[str, FittedPage]:
 def stamp_worlds(
     adjacency: dict, page: FittedPage, other_stem: str
 ) -> list[tuple[float, float]]:
-    """World (lon, lat) of ``page``'s printed claims of ``other_stem``'s key."""
+    """World (lon, lat) of ``page``'s printed claims of ``other_stem``'s key.
+
+    Detection fractions are PARENT-image-relative (adjacency scans the parent
+    sheet even for split panels, #135), while a panel stem's pose maps
+    split-image pixels to world. The unit's recorded ``panel_bbox`` (the crop,
+    in parent pixels — split images are exact bbox crops at native resolution)
+    translates between the two frames; unsplit pages have no bbox and the
+    parent frame IS the pose frame.
+    """
     want = (page_key(other_stem) or "").upper()
     out: list[tuple[float, float]] = []
-    for det in adjacency["pages"].get(page.stem, {}).get("detections", []):
+    info = adjacency["pages"].get(page.stem, {})
+    bbox = info.get("panel_bbox")
+    for det in info.get("detections", []):
         key = str(det.get("key") or det.get("number") or "").upper()
         if not det.get("claim") or key != want:
             continue
-        px = det["x_frac"] * page.width
-        py = det["y_frac"] * page.height
+        px = det["x_frac"] * info.get("width", page.width)
+        py = det["y_frac"] * info.get("height", page.height)
+        if bbox:
+            bx0, by0, bx1, by1 = bbox
+            if bx1 > bx0 and by1 > by0:
+                px = (px - bx0) * page.width / (bx1 - bx0)
+                py = (py - by0) * page.height / (by1 - by0)
         a = page.affine
         out.append(
             (

--- a/mapsnap/adjacency_gate.py
+++ b/mapsnap/adjacency_gate.py
@@ -245,6 +245,15 @@ def hard_signal(
     rot = abs((page.theta_deg - median_theta_deg + 180.0) % 360.0 - 180.0)
     if rot > GATE_ROT_DEV_DEG:
         return f"rot_dev={rot:.0f}deg"
+    # Scale deviation from the VOLUME median licenses nothing for a split
+    # panel: insets are drawn at their own scales (a 100ft-per-inch inset on a
+    # 200ft volume sits at |log dev| ~0.69), so the #256 multi-family flaw
+    # fires on exactly the pages #135 gave the gate reach over. Measured: the
+    # first per-panel A/B demoted champaign p23__1 [scale_dev=0.67], a correct
+    # inset fit, costing the volume 4.0 score points. Rotation stays licensed:
+    # insets share the sheet's orientation.
+    if "__" in page.stem:
+        return None
     scale = abs(page.log_scale - median_log_scale)
     if scale > GATE_SCALE_DEV_LOG:
         return f"scale_dev={scale:.2f}"

--- a/mapsnap/adjacency_gate_test.py
+++ b/mapsnap/adjacency_gate_test.py
@@ -285,3 +285,37 @@ def test_fine_pair_over_metric_bar_is_still_contradicted(tmp_path):
     pages = load_fitted_pages(volume, adjacency)
     contradictions, _ = edge_contradictions(adjacency, pages)
     assert [(c.a, c.b) for c in contradictions] == [("p2", "p3")]
+
+
+def test_stamp_worlds_translates_panel_frame():
+    """A panel unit's detection (parent-frame fracs) maps through the panel crop."""
+    import numpy as np
+
+    from mapsnap.adjacency_gate import FittedPage, stamp_worlds
+
+    # Identity-ish pose over a 40x100 split image cropped from parent x:[60,100].
+    page = FittedPage(
+        stem="p63__2",
+        affine=np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+        width=40,
+        height=100,
+        channel_paths=[],
+        gcps=4,
+        theta_deg=0.0,
+        log_scale=0.0,
+    )
+    adjacency = {
+        "pages": {
+            "p63__2": {
+                "width": 100,
+                "height": 100,
+                "panel_bbox": [60.0, 0.0, 100.0, 100.0],
+                "detections": [
+                    {"key": "64", "claim": True, "x_frac": 0.8, "y_frac": 0.5}
+                ],
+            }
+        }
+    }
+    worlds = stamp_worlds(adjacency, page, "p64")
+    # Parent pixel (80, 50) -> split pixel (20, 50) -> identity affine.
+    assert worlds == [(20.0, 50.0)]

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -93,8 +93,11 @@ CLAIM_HEIGHT_FRACTION = 0.75
 def volume_page_images(volume: Path) -> list[Path]:
     """The whole-page images to scan: top-level ``p*.jpg``, skipping split panels and key maps.
 
-    Split panels (``__`` stems) are cuts of a parent sheet, so the printed margin references
-    live on the parent; the parent is scanned even when panels supersede it for OCR. Key-map
+    Split panels (``__`` stems) are cuts of a parent sheet, so the parent image is what gets
+    SCANNED — its margin numbers are intact where a panel crop would clip them at the cut
+    line — but detections are then ATTRIBUTED to panels via ``<stem>.panels.json`` (#135):
+    Sanborn prints adjacency references per panel, and each panel has its own pose in the
+    pipeline, so a claim is only usable evidence when it names which panel made it. Key-map
     sheets are excluded: their faces are covered in page numbers, which would all read as
     spurious claims.
 
@@ -118,6 +121,67 @@ def volume_page_images(volume: Path) -> list[Path]:
             continue
         images.append(image)
     return images
+
+
+def page_panels(
+    volume: Path, stem: str, width: int, height: int
+) -> list[tuple[str, list[list[float]], tuple[float, float, float, float]]]:
+    """The attribution units of a page: (unit_stem, polygon, bbox) per panel.
+
+    A split page's ``<stem>.panels.json`` (parent pixel coords, panel order matching the
+    ``__k`` split indices) yields one unit per panel; an unsplit page is a single unit
+    covering the whole image. Panels are returned even when no ``p<stem>__k.jpg`` exists on
+    disk (OIM panels that never became pages): their claims still reciprocate a neighbor's,
+    and consumers that need a pose simply find no sidecar for the stem.
+    """
+    panels_path = volume / f"{stem}.panels.json"
+    if not panels_path.exists():
+        bbox = (0.0, 0.0, float(width), float(height))
+        return [
+            (stem, [[0.0, 0.0], [width, 0.0], [width, height], [0.0, height]], bbox)
+        ]
+    doc = json.loads(panels_path.read_text())
+    units = []
+    for index, polygon in enumerate(doc.get("panels") or []):
+        xs = [p[0] for p in polygon]
+        ys = [p[1] for p in polygon]
+        units.append(
+            (
+                f"{stem}__{index + 1}",
+                [[float(x), float(y)] for x, y in polygon],
+                (min(xs), min(ys), max(xs), max(ys)),
+            )
+        )
+    if not units:
+        bbox = (0.0, 0.0, float(width), float(height))
+        return [
+            (stem, [[0.0, 0.0], [width, 0.0], [width, height], [0.0, height]], bbox)
+        ]
+    return units
+
+
+def assign_panel(
+    point: tuple[float, float],
+    units: list[tuple[str, list[list[float]], tuple[float, float, float, float]]],
+) -> tuple[str, tuple[float, float, float, float]]:
+    """The (unit_stem, bbox) whose polygon the point falls in, else the nearest one.
+
+    Nearest matters: a printed reference sits on or just past its panel's neat line — in
+    the gutter between panels or the sheet margin — so strict point-in-polygon would orphan
+    exactly the detections adjacency exists to find.
+    """
+    from shapely.geometry import Point, Polygon
+
+    p = Point(point)
+    best = None
+    for stem, polygon, bbox in units:
+        distance = Polygon(polygon).distance(p)
+        if best is None or distance < best[0]:
+            best = (distance, stem, bbox)
+        if distance == 0.0:
+            break
+    assert best is not None
+    return best[1], best[2]
 
 
 def classify_edge(x_frac: float, y_frac: float, band: float = EDGE_BAND) -> str:
@@ -284,6 +348,8 @@ def digit_detections(
     reader,
     valid_keys: set[str],
     craft_boxes: tuple[list, list] | None = None,
+    units: list[tuple[str, list[list[float]], tuple[float, float, float, float]]]
+    | None = None,
 ) -> list[dict]:
     """All digit reads on one page that resolve to a valid volume page key.
 
@@ -351,10 +417,26 @@ def digit_detections(
             letter_text = str(letter_read[1])
         resolved = resolve_page_key(text, letter_text, valid_keys)
         if resolved is None:
-            continue
+            # An explicit printed "0" means "no neighbor on this side" (#135) —
+            # negative evidence worth recording, not a failed resolution. Only a
+            # clean bare-zero read qualifies; anything longer is a house number.
+            if text.strip() == "0" and not letter_text.strip().strip("0Oo"):
+                resolved = (None, "zero")
+            else:
+                continue
         key, via = resolved
         x_frac = sum(p[0] for p in bbox) / 4 / width
         y_frac = sum(p[1] for p in bbox) / 4 / height
+        # Attribute the detection to its panel; the edge classification is
+        # panel-relative (a number on an interior cut line is at ITS PANEL's
+        # edge even though it is nowhere near the page's).
+        panel_stem: str | None = None
+        panel_x_frac, panel_y_frac = x_frac, y_frac
+        if units is not None:
+            panel_stem, (bx0, by0, bx1, by1) = assign_panel((cx, cy), units)
+            if bx1 > bx0 and by1 > by0:
+                panel_x_frac = (cx - bx0) / (bx1 - bx0)
+                panel_y_frac = (cy - by0) / (by1 - by0)
         glyph_height = float(max(p[1] for p in bbox) - min(p[1] for p in bbox))
         nearest_box = min(
             (
@@ -368,17 +450,18 @@ def digit_detections(
             {
                 "key": key,
                 "via": via,
-                "number": int("".join(c for c in key if c.isdigit())),
+                "number": int("".join(c for c in key if c.isdigit())) if key else 0,
                 "text": text,
                 "confidence": round(float(confidence), 4),
                 "polygon": [[int(p[0]), int(p[1])] for p in bbox],
                 "height": round(glyph_height, 1),
                 "x_frac": round(x_frac, 4),
                 "y_frac": round(y_frac, 4),
-                "edge": classify_edge(x_frac, y_frac),
+                "edge": classify_edge(panel_x_frac, panel_y_frac),
                 "nearest_box": round(nearest_box, 1)
                 if nearest_box != math.inf
                 else None,
+                **({"panel": panel_stem} if panel_stem is not None else {}),
             }
         )
     return detections
@@ -451,7 +534,8 @@ def is_claim(
     coincidence, so reciprocity alone cannot vouch for them.
     """
     if (
-        detection["key"] == own_key
+        detection["key"] is None  # an explicit "0": no-neighbor evidence, not a claim
+        or detection["key"] == own_key
         or detection["edge"] == "center"
         or detection["height"] < min_height
         or detection["confidence"] < min_confidence
@@ -617,13 +701,29 @@ def main() -> None:
                 f"No usable CRAFT boxes for {image.name} (missing, or computed at "
                 f"different image dimensions).\nRun: {craft_hint([str(image)])}"
             )
-        pages[stem] = {
-            "key": page_key(stem),
-            "number": page_number(stem),
-            "width": width,
-            "height": height,
-            "detections": digit_detections(image, reader, valid_keys, craft_boxes),
-        }
+        # One unit per panel (#135): the parent image is scanned, but claims are
+        # attributed and gated per panel, because each panel has its own pose and
+        # its own printed margin references. Unsplit pages are one unit.
+        units = page_panels(args.volume, stem, width, height)
+        detections = digit_detections(
+            image, reader, valid_keys, craft_boxes, units=units
+        )
+        for unit_stem, _polygon, unit_bbox in units:
+            unit_detections = [
+                d for d in detections if d.get("panel", unit_stem) == unit_stem
+            ]
+            pages[unit_stem] = {
+                "key": page_key(unit_stem),
+                "number": page_number(unit_stem),
+                "width": width,
+                "height": height,
+                **(
+                    {"parent": stem, "panel_bbox": [round(v, 1) for v in unit_bbox]}
+                    if unit_stem != stem
+                    else {}
+                ),
+                "detections": unit_detections,
+            }
 
     def compute_claims(
         height_band: tuple[float, float] | None,
@@ -691,6 +791,7 @@ def main() -> None:
         )
 
     claims_by_page = compute_claims(height_band, min_gap, claim_floor)
+    no_neighbor: dict[str, list[str]] = {}
     for stem, page in pages.items():
         for detection in page["detections"]:
             detection["claim"] = is_claim(
@@ -702,6 +803,22 @@ def main() -> None:
                 height_band=height_band,
                 min_gap=min_gap,
             )
+            # An explicit "0" that would have qualified as a claim (same physical
+            # bar, including full single-digit strictness) is recorded as
+            # no-neighbor evidence for its unit's edge: the map ends there (#135).
+            if detection["key"] is None and is_claim(
+                {
+                    **detection,
+                    "key": "\x00",
+                },  # sentinel: run every check but the key ones
+                page["key"],
+                min_height=claim_floor,
+                min_confidence=args.min_confidence,
+                single_digit_min_confidence=args.single_digit_min_confidence,
+                height_band=height_band,
+                min_gap=min_gap,
+            ):
+                no_neighbor.setdefault(stem, []).append(detection["edge"])
 
     edges = mutual_edges(claims_by_page)
     one_sided = one_sided_edges(claims_by_page)
@@ -718,6 +835,9 @@ def main() -> None:
         "pages": pages,
         "adjacency": [list(edge) for edge in edges],
         "one_sided": [list(edge) for edge in one_sided],
+        "no_neighbor": {
+            stem: sorted(edges) for stem, edges in sorted(no_neighbor.items())
+        },
     }
     output = args.output or (args.volume / "adjacency.json")
     output.write_text(json.dumps(doc, indent=2))

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -2,12 +2,14 @@ import math
 from pathlib import Path
 
 from mapsnap.page_adjacency import (
+    assign_panel,
     bbox_gap,
     claim_height_floor,
     classify_edge,
     is_claim,
     mutual_edges,
     one_sided_edges,
+    page_panels,
     polygon_rotation_deg,
     resolve_page_key,
     single_digit_height_band,
@@ -278,3 +280,43 @@ def test_is_text_veto():
     assert not is_text_veto("31NJ", 0.9, 0.5)  # number + short annotation: keep
     assert not is_text_veto("AL", 0.88, 0.95)  # genuine "41": digits read wins
     assert not is_text_veto("", 0.9, 0.1)
+
+
+def test_page_panels_unsplit_is_single_unit(tmp_path: Path):
+    units = page_panels(tmp_path, "p7", 100, 200)
+    assert [u[0] for u in units] == ["p7"]
+    assert units[0][2] == (0.0, 0.0, 100.0, 200.0)
+
+
+def test_page_panels_reads_panel_polygons(tmp_path: Path):
+    (tmp_path / "p63.panels.json").write_text(
+        '{"panels": [[[0,0],[60,0],[60,100],[0,100],[0,0]],'
+        " [[60,0],[100,0],[100,100],[60,100],[60,0]]]}"
+    )
+    units = page_panels(tmp_path, "p63", 100, 100)
+    assert [u[0] for u in units] == ["p63__1", "p63__2"]
+    assert units[0][2] == (0.0, 0.0, 60.0, 100.0)
+    assert units[1][2] == (60.0, 0.0, 100.0, 100.0)
+
+
+def test_assign_panel_inside_and_gutter(tmp_path: Path):
+    (tmp_path / "p63.panels.json").write_text(
+        '{"panels": [[[0,0],[60,0],[60,100],[0,100],[0,0]],'
+        " [[65,0],[100,0],[100,100],[65,100],[65,0]]]}"
+    )
+    units = page_panels(tmp_path, "p63", 100, 100)
+    assert assign_panel((30, 50), units)[0] == "p63__1"
+    # A margin number in the gutter between panels attaches to the nearest one.
+    assert assign_panel((63, 50), units)[0] == "p63__2"
+
+
+def test_is_claim_rejects_explicit_zero():
+    detection = {
+        "key": None,
+        "number": 0,
+        "edge": "L",
+        "height": 40.0,
+        "confidence": 0.99,
+        "polygon": [[0, 0], [20, 0], [20, 40], [0, 40]],
+    }
+    assert not is_claim(detection, "7")

--- a/mapsnap/reconcile.py
+++ b/mapsnap/reconcile.py
@@ -786,8 +786,17 @@ def build_nodes(volume: Path, sidecar_dir: Path, vctx) -> dict[str, PageNode]:
         # candidates from before the split. Left as an energy contest, a claim
         # or evidence term can nudge such a pose over the abstention bar --
         # philadelphia p203 published a pre-split snap alias at 473 ft while
-        # its panel held the real fit at 10.6 -- so supersession is a rule.
+        # its panel held the real fit at 10.6 -- so supersession is a rule:
+        # the parent's node offers ONLY the unplaced state, and its final
+        # sidecar (corners: null) still claims the page key per the contract.
         if any(s.startswith(unit.stem + "__") for s in stems):
+            nodes[unit.stem] = PageNode(
+                unit=unit,
+                is_panel=False,
+                base=None,
+                hypotheses=[Hypothesis(source=UNPLACED, affine=None)],
+                published_index=None,
+            )
             continue
         hypotheses, published = collect_hypotheses(
             sidecar_dir,

--- a/mapsnap/reconcile.py
+++ b/mapsnap/reconcile.py
@@ -775,9 +775,19 @@ def build_nodes(volume: Path, sidecar_dir: Path, vctx) -> dict[str, PageNode]:
     """PageNodes for every base page and split panel with any hypothesis."""
     snap_records, street_records = load_channel_records(volume)
     nodes: dict[str, PageNode] = {}
-    for unit in [*vctx.units, *vctx.panel_units]:
+    all_units = [*vctx.units, *vctx.panel_units]
+    stems = {u.stem for u in all_units}
+    for unit in all_units:
         base = panel_base(unit.stem)
         if base is not None and any(u.stem == unit.stem for u in vctx.units):
+            continue
+        # A split page's PARENT is never publishable: its panels supersede it
+        # (list_pages semantics), and the parent's only poses are stale
+        # candidates from before the split. Left as an energy contest, a claim
+        # or evidence term can nudge such a pose over the abstention bar --
+        # philadelphia p203 published a pre-split snap alias at 473 ft while
+        # its panel held the real fit at 10.6 -- so supersession is a rule.
+        if any(s.startswith(unit.stem + "__") for s in stems):
             continue
         hypotheses, published = collect_hypotheses(
             sidecar_dir,

--- a/mapsnap/utils.py
+++ b/mapsnap/utils.py
@@ -31,9 +31,24 @@ def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
 
 
 def run_cmd(cmd: list[str]) -> None:
-    """Print and run a subprocess command, exiting with its return code on failure."""
+    """Print and run a subprocess command, exiting with its return code on failure.
+
+    A stage killed by a SIGNAL (negative returncode) is retried once: #296 is
+    a sporadic, non-input-deterministic SIGSEGV inside snap's chamfer_refine
+    (two captures, different pages and lines, same volume rerun passes), and
+    the stage caches -- snap's incremental candidates.jsonl above all -- make
+    a retry resume in seconds. One retry converts a dead overnight lane into
+    a logged hiccup; a second failure still kills the run, so a genuinely
+    broken stage cannot loop.
+    """
     print("+ " + " ".join(cmd), flush=True)
     result = subprocess.run(cmd, check=False)
+    if result.returncode < 0:
+        print(
+            f"stage died with signal {-result.returncode} (#296); retrying once",
+            flush=True,
+        )
+        result = subprocess.run(cmd, check=False)
     if result.returncode != 0:
         sys.exit(result.returncode)
 


### PR DESCRIPTION
Closes #135. Fixes #256. Four co-diagnosed changes, measured over four A/B rounds against a shared seed-pinned control (18 volumes; the adjacency arm re-fit the 7 with graph changes).

## What changed

- **Per-panel claim attribution (#135)**: the parent sheet is still what gets scanned (margin numbers intact at panel cut lines), but each detection is attributed to its panel via `panels.json` (nearest polygon — printed references sit on or past the neat line). Edge classification is panel-relative, so cut-line numbers stop dying the page-level "center" test. `claim_resolver`/`mutual_edges` already handled multi-stem keys, so panel-level reciprocity required no edge-logic changes. `stamp_worlds` translates parent-frame detections into the panel pose's frame via the recorded `panel_bbox`. Explicit printed `0` is recorded as per-unit `no_neighbor` evidence (no consumer yet).
- **Family-relative hard signal (#256)**: rotation deviation folds mod 90 (fargo's seven legitimate ~91° sheets; GR panel p724__2); scale measures against the nearest log-2 rung of the volume median (fargo's 65/11 two-rung split; champaign's correct 2× inset). A raw volume-median comparison hands every minority-family page a permanent demotion license — #256 documents an 8-GCP 11 ft fit destroyed by exactly that. Residual documented: arbitrary-orientation volumes (NO-1896) aren't served by mod-90; that volume currently produces no gate contradictions.
- **Parent supersession is a rule**: reconcile never publishes a split page's parent — its panels supersede it, and its only poses are stale pre-split candidates. Philadelphia p203 published a rank-2 snap alias at 473 ft (claim-derived energy nudged it over the abstention bar) while p203__1 held the real fit at 10.6. The parent's node now offers only the unplaced state, and its poseless final still claims the page key.
- **#296 mitigation**: a fit stage killed by a signal retries once (stage caches make the retry resume in seconds). Two faulthandler captures during these A/Bs pinned #296 as a sporadic SIGSEGV in `chamfer_refine` — different pages, different lines, same volume passing on rerun.

## A/B history (score vs shared control)

| volume | r1 | r2 (panel scale license off) | r3 (family-relative) | r4 (+supersession) |
|---|---|---|---|---|
| fargo | +1.2 | +1.2 | +1.0 | +1.0 |
| washington_dc | +1.0 | +1.0 | +1.0 | +1.0 |
| champaign | **−4.0** | 0.0 | 0.0 | 0.0 |
| miami | **−3.6** | 0.0 | 0.0 | 0.0 |
| grand_rapids | −1.7 | −1.7 | 0.0 | 0.0 |
| philadelphia | −2.7 | crash | −2.7 | **0.0** |
| los_angeles | +0.3 | +0.3 | 0.0 | 0.0 |

Final: **fargo +1.0 and DC +1.0, zero regressions**, both wins pure disaster-cuts (the gate demoting split-panel junk it previously couldn't see — the page class where disasters concentrate). Round-1's regressions were all instructive: champaign/GR exposed #256 on exactly the pages panels gave the gate reach over; philly exposed the supersession hole.

Validation detail: fargo's graph gained 21 panel-attributed mutual edges and the mis-split disaster panels (p63__1/2/4, p58__2) carry claims the gate can now test. `adjacency.json.pre135` backups preserved per volume; `.panel135` graphs ready to promote on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)