### PR TITLE
Snap explorer in the volume viewer (#325 phase 1)

### DIFF
--- a/app/src/components/InfoPanel.tsx
+++ b/app/src/components/InfoPanel.tsx
@@ -90,6 +90,9 @@ interface InfoPanelProps {
    * nowhere to put it, in which case the labels stay plain links.
    */
   onOpenDebugView?: (files: string[], label: string) => void;
+  /** Opens the snap-channel explorer for the selected page (#325); absent when
+   * the volume has no snap record for it. */
+  onOpenSnapView?: () => void;
   /**
    * The run's own artifact directory and the page stems it holds sidecars for,
    * from GET /iiif-api/run-artifacts. Links prefer these over the top-level
@@ -223,6 +226,7 @@ export function InfoPanel(props: InfoPanelProps) {
     volume,
     runArtifacts,
     onOpenDebugView,
+    onOpenSnapView,
     onClose,
   } = props;
 
@@ -355,6 +359,11 @@ export function InfoPanel(props: InfoPanelProps) {
               onOpen={onOpenDebugView}
             />
           ))}
+          {onOpenSnapView && (
+            <button className="debug-view-link" onClick={onOpenSnapView}>
+              snap
+            </button>
+          )}
         </div>
       </div>
     );

--- a/app/src/components/SnapPanel.tsx
+++ b/app/src/components/SnapPanel.tsx
@@ -1,0 +1,220 @@
+import { rankedCandidates } from '../snap';
+import type { SnapCandidate, SnapRecord } from '../snap';
+
+/**
+ * Per-page snap explorer (#325 phase 1): what the matcher searched, every
+ * pose it weighed (winners AND losers), and each pose's evidence components.
+ * Selecting a row overlays that pose's P(road) map on the volume map.
+ *
+ * Everything shown is read from candidates.jsonl — recorded by the pipeline's
+ * own scoring; nothing is recomputed here.
+ */
+
+interface SnapPanelProps {
+  record: SnapRecord;
+  /** Index into rankedCandidates(record), -1 for the incumbent, null for none. */
+  selected: number | null;
+  onSelect: (index: number | null) => void;
+  onClose: () => void;
+}
+
+// A component bar: label, value in [0, 1]-ish range, red for penalties.
+function EvidenceBar({
+  label,
+  value,
+  max,
+  penalty,
+  detail,
+}: {
+  label: string;
+  value: number | undefined;
+  max: number;
+  penalty?: boolean;
+  detail?: string;
+}) {
+  if (value === undefined) return null;
+  const frac = Math.max(0, Math.min(1, Math.abs(value) / max));
+  return (
+    <div className="snap-bar-row" title={detail}>
+      <span className="snap-bar-label">{label}</span>
+      <span className="snap-bar-track">
+        <span
+          className={
+            penalty ? 'snap-bar-fill snap-bar-penalty' : 'snap-bar-fill'
+          }
+          style={{ width: `${Math.round(frac * 100)}%` }}
+        />
+      </span>
+      <span className="snap-bar-value">{value.toFixed(3)}</span>
+    </div>
+  );
+}
+
+function CandidateRow({
+  label,
+  candidate,
+  isSelected,
+  isBest,
+  onClick,
+}: {
+  label: string;
+  candidate: SnapCandidate | (SnapRecord['incumbent'] & object);
+  isSelected: boolean;
+  isBest: boolean;
+  onClick: () => void;
+}) {
+  const c = candidate as SnapCandidate;
+  return (
+    <tr
+      className={(isSelected ? 'selected ' : '') + (isBest ? 'snap-best' : '')}
+      onClick={onClick}
+      style={{ cursor: 'pointer' }}
+    >
+      <td>{label}</td>
+      <td className="num">{c.select_score?.toFixed(2) ?? '—'}</td>
+      <td className="num">{c.verification?.toFixed(2) ?? '—'}</td>
+      <td className="num">{c.inlier_frac?.toFixed(2) ?? '—'}</td>
+      <td className="num">{c.ncc_fine?.toFixed(2) ?? '—'}</td>
+      <td className="num">
+        {c.chamfer_mean_m !== undefined
+          ? `${c.chamfer_mean_m.toFixed(1)}m`
+          : '—'}
+      </td>
+      <td className="num">
+        {c.theta_deg !== undefined ? `${c.theta_deg.toFixed(1)}°` : '—'}
+      </td>
+      <td>{c.scale_source ?? '—'}</td>
+      <td className="num">
+        {c.rmse_ft !== undefined ? `${c.rmse_ft.toFixed(0)}ft` : ''}
+      </td>
+    </tr>
+  );
+}
+
+export function SnapPanel({
+  record,
+  selected,
+  onSelect,
+  onClose,
+}: SnapPanelProps) {
+  const ranked = rankedCandidates(record);
+  const active =
+    selected === null
+      ? null
+      : selected === -1
+        ? (record.incumbent ?? null)
+        : (ranked[selected] ?? null);
+  const activeCandidate = active as SnapCandidate | null;
+
+  return (
+    <div className="snap-panel">
+      <div className="snap-panel-header">
+        <strong>snap · {record.target}</strong>
+        <span className="snap-meta">
+          fit_state {record.fit_state} · status {record.status}
+          {record.elapsed_s !== undefined && ` · ${record.elapsed_s}s`}
+        </span>
+        <button onClick={onClose}>close</button>
+      </div>
+
+      {record.search && (
+        <p className="snap-search">
+          search: {record.search.centers.length} center
+          {record.search.centers.length === 1 ? '' : 's'} · radius{' '}
+          {Math.round(record.search.radius_m)} m ({record.search.radius_source})
+          {record.search.demoted_seed && ' · demoted-pose seed'}
+          {' · priors: '}
+          {(record.priors?.rotation ?? [])
+            .map(
+              (p) => `${p.theta_deg.toFixed(0)}°±${p.sigma_deg} (${p.source})`,
+            )
+            .join(', ') || 'none'}
+        </p>
+      )}
+
+      <table className="snap-table">
+        <thead>
+          <tr>
+            <th>pose</th>
+            <th>select</th>
+            <th>verif</th>
+            <th>inlier</th>
+            <th>ncc</th>
+            <th>chamfer</th>
+            <th>θ</th>
+            <th>scale src</th>
+            <th>truth</th>
+          </tr>
+        </thead>
+        <tbody>
+          {record.incumbent && (
+            <CandidateRow
+              label="incumbent"
+              candidate={record.incumbent}
+              isSelected={selected === -1}
+              isBest={false}
+              onClick={() => onSelect(selected === -1 ? null : -1)}
+            />
+          )}
+          {ranked.map((candidate, i) => (
+            <CandidateRow
+              key={i}
+              label={`C${i}${candidate.plausible === false ? ' ✗' : ''}`}
+              candidate={candidate}
+              isSelected={selected === i}
+              isBest={i === 0}
+              onClick={() => onSelect(selected === i ? null : i)}
+            />
+          ))}
+        </tbody>
+      </table>
+      {record.has_truth && (
+        <p className="snap-note">
+          truth column is each pose's grid RMSE; a truth-pose row (scored with
+          the same evidence) lands with the phase-2 pipeline record.
+        </p>
+      )}
+
+      {activeCandidate && (
+        <div className="snap-evidence">
+          <EvidenceBar
+            label="inlier_frac"
+            value={activeCandidate.inlier_frac}
+            max={1}
+            detail="share of P(road) pixels within the chamfer inlier distance of OSM"
+          />
+          <EvidenceBar
+            label="ncc_fine"
+            value={activeCandidate.ncc_fine}
+            max={1}
+            detail="fine-scale normalized cross-correlation, P(road) vs OSM raster"
+          />
+          <EvidenceBar
+            label="chamfer"
+            value={activeCandidate.chamfer_mean_m}
+            max={30}
+            penalty
+            detail="mean P(road)→OSM distance in metres (penalty)"
+          />
+          <EvidenceBar
+            label="verification"
+            value={activeCandidate.verification}
+            max={1.5}
+            detail="inlier_frac + ncc_fine − chamfer penalty"
+          />
+          <EvidenceBar
+            label="select"
+            value={activeCandidate.select_score}
+            max={3}
+            detail="the ranking score gates compare against (rescue bar 1.25)"
+          />
+          {(activeCandidate.gate_reasons?.length ?? 0) > 0 && (
+            <p className="snap-note">
+              gates: {activeCandidate.gate_reasons!.join(' · ')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -28,6 +28,21 @@ interface VolumeMapProps {
   /** Whether the missing-page footprints are drawn and clickable. */
   showMissing: boolean;
   /**
+   * A snap-debugger pose overlay (#325): the selected candidate's P(road) map
+   * warped to its pose. Null removes the layer. The image is the cached
+   * road-probability PNG; the corners come straight from the candidate's
+   * world_affine, so what you see is exactly what the matcher scored.
+   */
+  snapOverlay: {
+    url: string;
+    corners: [
+      [number, number],
+      [number, number],
+      [number, number],
+      [number, number],
+    ];
+  } | null;
+  /**
    * Show only the selected page's warped image, hiding every other sheet.
    * No-op while nothing is selected -- isolating "nothing" would blank the map.
    */
@@ -122,6 +137,7 @@ export function VolumeMap(props: VolumeMapProps) {
     missingPages,
     truthPages,
     showMissing,
+    snapOverlay,
     isolateSelected,
     selectedItemIndex,
     onSelectPage,
@@ -450,6 +466,43 @@ export function VolumeMap(props: VolumeMapProps) {
       setMapReady(false);
     };
   }, []);
+
+  // The snap-debugger pose overlay (#325): the selected candidate's P(road)
+  // map as an image source at the pose's corner coordinates. Added/updated/
+  // removed reactively; drawn above the warped sheets so alignment against
+  // the basemap's streets is directly visible.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapReady) return;
+    const existing = map.getSource('snap-overlay') as
+      | maplibregl.ImageSource
+      | undefined;
+    if (!snapOverlay) {
+      if (existing) {
+        if (map.getLayer('snap-overlay')) map.removeLayer('snap-overlay');
+        map.removeSource('snap-overlay');
+      }
+      return;
+    }
+    if (existing) {
+      existing.updateImage({
+        url: snapOverlay.url,
+        coordinates: snapOverlay.corners,
+      });
+    } else {
+      map.addSource('snap-overlay', {
+        type: 'image',
+        url: snapOverlay.url,
+        coordinates: snapOverlay.corners,
+      });
+      map.addLayer({
+        id: 'snap-overlay',
+        type: 'raster',
+        source: 'snap-overlay',
+        paint: { 'raster-opacity': 0.75 },
+      });
+    }
+  }, [mapReady, snapOverlay]);
 
   // Show the annotation's pages, replacing any previous volume's, and fit the view.
   useEffect(() => {

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -32,6 +32,9 @@ import {
   unfittedPages,
 } from '../iiif/pages';
 import { DebugView } from '../App';
+import { SnapPanel } from './SnapPanel';
+import { parseSnapRecords, poseCorners, rankedCandidates } from '../snap';
+import type { SnapRecord } from '../snap';
 import { InfoPanel, type RunArtifacts } from './InfoPanel';
 import { PageList } from './PageList';
 import { VolumeMap } from './VolumeMap';
@@ -126,6 +129,19 @@ export function VolumeViewer() {
     files: string[];
     label: string;
   } | null>(null);
+  // Snap-channel records for the volume (candidates.jsonl, #325), keyed by
+  // page stem; empty when the volume has no snap artifacts.
+  const [snapRecords, setSnapRecords] = useState<Map<string, SnapRecord>>(
+    new Map(),
+  );
+  // Whether the snap panel is open for the selected page, and which pose row
+  // is highlighted (index into rankedCandidates, -1 for the incumbent).
+  const [snapOpen, setSnapOpen] = useState(false);
+  const [snapSelected, setSnapSelected] = useState<number | null>(null);
+  useEffect(() => {
+    setSnapOpen(false);
+    setSnapSelected(null);
+  }, [selectedStem]);
   // The selected volume's adjacency.json (per-page claims + mutual graph), or null when absent.
   const [osmRelation, setOsmRelation] = useState<{
     id: string;
@@ -268,6 +284,20 @@ export function VolumeViewer() {
         setGeorefSidecars(new Map());
         setVolumeStems([]);
       });
+    setSnapRecords(new Map());
+    setSnapOpen(false);
+    setSnapSelected(null);
+    // The snap channel's per-page record (#325). JSONL, so fetched as text; a
+    // volume without snap artifacts 404s into the SPA fallback, which fails
+    // the parse harmlessly (no rows -> empty map).
+    fetch(`/data/${volumeName}/artifacts/osm_snap/candidates.jsonl`)
+      .then((r) => (r.ok ? r.text() : ''))
+      .then((text) => {
+        if (!cancelled) setSnapRecords(parseSnapRecords(text));
+      })
+      .catch(() => {
+        if (!cancelled) setSnapRecords(new Map());
+      });
     setAdjacencyData(null);
     fetchAdjacency(volumeName)
       .then((data) => {
@@ -355,6 +385,27 @@ export function VolumeViewer() {
         missingPages.find((p) => p.stem === selectedStem) ??
         null);
   const selectedItemIndex = selectedPage?.itemIndex ?? null;
+  // The selected page's snap record and, when a pose row is highlighted, the
+  // P(road) overlay for it (image at the pose's own corner coordinates).
+  const snapRecord =
+    selectedStem !== null ? (snapRecords.get(selectedStem) ?? null) : null;
+  const snapOverlay = useMemo(() => {
+    if (!snapOpen || !snapRecord || snapSelected === null || !volumeName)
+      return null;
+    const pose =
+      snapSelected === -1
+        ? snapRecord.incumbent
+        : rankedCandidates(snapRecord)[snapSelected];
+    if (!pose?.world_affine) return null;
+    return {
+      url: `/data/${volumeName}/artifacts/edge_join/roadprob/${snapRecord.target}.png`,
+      corners: poseCorners(
+        pose.world_affine,
+        snapRecord.width,
+        snapRecord.height,
+      ),
+    };
+  }, [snapOpen, snapRecord, snapSelected, volumeName]);
   const selectedIsMissing =
     selectedPage !== null &&
     selectedItemIndex !== null &&
@@ -541,6 +592,7 @@ export function VolumeViewer() {
             it keeps its layout box, so nothing resizes either. */}
         <div className="volume-map-slot" aria-hidden={debugView !== null}>
           <VolumeMap
+            snapOverlay={snapOverlay}
             annotation={annotation}
             pages={pages}
             missingPages={missingPages}
@@ -567,6 +619,16 @@ export function VolumeViewer() {
             }
             onLoadResult={setLoadResult}
           />
+          {snapOpen && snapRecord && (
+            <div className="snap-panel-slot">
+              <SnapPanel
+                record={snapRecord}
+                selected={snapSelected}
+                onSelect={setSnapSelected}
+                onClose={() => setSnapOpen(false)}
+              />
+            </div>
+          )}
           {debugView && (
             <div className="volume-viewer-debug">
               <DebugView
@@ -579,6 +641,7 @@ export function VolumeViewer() {
         </div>
         <InfoPanel
           onOpenDebugView={(files, label) => setDebugView({ files, label })}
+          onOpenSnapView={snapRecord ? () => setSnapOpen(true) : undefined}
           runArtifacts={runArtifacts}
           pages={pages}
           missingCount={missingPages.length}

--- a/app/src/snap.ts
+++ b/app/src/snap.ts
@@ -1,0 +1,113 @@
+/**
+ * Snap-channel debug data: candidates.jsonl parsing and pose geometry (#325).
+ *
+ * The snap stage records everything it weighed per page in
+ * `data/<vol>/artifacts/osm_snap/candidates.jsonl` — search centers with
+ * provenance, rotation/scale priors, every candidate pose with its evidence
+ * components, and the incumbent's evaluation. This module reads that record;
+ * it deliberately re-implements NO scoring (the compare-output lesson): every
+ * number shown in the UI was computed by the pipeline itself.
+ */
+
+/** One candidate pose from the snap matcher, as recorded in candidates.jsonl. */
+export interface SnapCandidate {
+  world_affine: [number, number, number][];
+  center: [number, number];
+  center_dist_m?: number;
+  theta_deg?: number;
+  theta_source?: string;
+  scale_m_per_px?: number;
+  scale_source?: string;
+  scale_adjust?: number;
+  ncc?: number;
+  ncc_fine?: number;
+  chamfer_mean_m?: number;
+  inlier_frac?: number;
+  n_points?: number;
+  overlap_frac?: number;
+  region_containment?: number;
+  refine_shift_m?: number;
+  select_score?: number;
+  verification?: number;
+  name?: number;
+  plausible?: boolean;
+  gate_reasons?: string[];
+  /** Grid RMSE vs truth, present only when the volume has truth data. */
+  rmse_ft?: number;
+}
+
+/** The incumbent (published RANSAC pose) evaluated with the same evidence. */
+export interface SnapIncumbent {
+  world_affine: [number, number, number][];
+  verification?: number;
+  ncc_fine?: number;
+  inlier_frac?: number;
+  chamfer_mean_m?: number;
+  n_points?: number;
+  name?: number;
+  effective_gcps?: number;
+  rmse_ft?: number;
+}
+
+/** One page's full snap record. */
+export interface SnapRecord {
+  target: string;
+  status: string;
+  fit_state: string;
+  width: number;
+  height: number;
+  elapsed_s?: number;
+  margin?: number;
+  has_truth?: boolean;
+  search?: {
+    centers: [number, number][];
+    radius_m: number;
+    radius_source: string;
+    demoted_seed?: boolean;
+  };
+  priors?: {
+    rotation: { theta_deg: number; sigma_deg: number; source: string }[];
+    scale: { m_per_px: number; sigma_log: number; source: string }[];
+  };
+  incumbent?: SnapIncumbent;
+  candidates?: SnapCandidate[];
+}
+
+/** Parse candidates.jsonl text into a stem-keyed map (later rows win). */
+export function parseSnapRecords(jsonl: string): Map<string, SnapRecord> {
+  const records = new Map<string, SnapRecord>();
+  for (const line of jsonl.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const record = JSON.parse(trimmed) as SnapRecord;
+      if (record.target) records.set(record.target, record);
+    } catch {
+      // A truncated final line (interrupted run) is not an error worth surfacing.
+    }
+  }
+  return records;
+}
+
+/**
+ * The four page corners of a pose in lon/lat, TL/TR/BR/BL — the coordinate
+ * order maplibre image sources expect. `world_affine` maps page px → lon/lat.
+ */
+export function poseCorners(
+  affine: [number, number, number][],
+  width: number,
+  height: number,
+): [[number, number], [number, number], [number, number], [number, number]] {
+  const apply = (x: number, y: number): [number, number] => [
+    affine[0][0] * x + affine[0][1] * y + affine[0][2],
+    affine[1][0] * x + affine[1][1] * y + affine[1][2],
+  ];
+  return [apply(0, 0), apply(width, 0), apply(width, height), apply(0, height)];
+}
+
+/** Candidates sorted by select_score descending (unscored last, order kept). */
+export function rankedCandidates(record: SnapRecord): SnapCandidate[] {
+  return [...(record.candidates ?? [])].sort(
+    (a, b) => (b.select_score ?? -Infinity) - (a.select_score ?? -Infinity),
+  );
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -891,3 +891,87 @@ tr.relaxed {
 .detection-text-filter .filter-count {
   color: #666;
 }
+
+/* Snap-channel explorer (#325). Matches the app's light styling. */
+.snap-panel-slot {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  max-width: 720px;
+  max-height: 55%;
+  overflow: auto;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  padding: 8px 12px;
+  font-size: 13px;
+  z-index: 5;
+}
+.snap-panel-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+.snap-panel-header button {
+  margin-left: auto;
+}
+.snap-meta,
+.snap-search,
+.snap-note {
+  color: #6b7280;
+  font-size: 12px;
+  margin: 4px 0;
+}
+.snap-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+.snap-table th,
+.snap-table td {
+  padding: 2px 8px;
+  text-align: left;
+  border-bottom: 1px solid #e5e7eb;
+}
+.snap-table td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.snap-table tr.selected {
+  background: #dbeafe;
+}
+.snap-table tr.snap-best td:first-child {
+  font-weight: 600;
+}
+.snap-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 2px 0;
+}
+.snap-bar-label {
+  width: 90px;
+  color: #374151;
+  font-size: 12px;
+}
+.snap-bar-track {
+  flex: 1;
+  height: 8px;
+  background: #e5e7eb;
+  border-radius: 4px;
+  overflow: hidden;
+}
+.snap-bar-fill {
+  display: block;
+  height: 100%;
+  background: #059669;
+}
+.snap-bar-penalty {
+  background: #dc2626;
+}
+.snap-bar-value {
+  width: 52px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}


### PR DESCRIPTION
Phase 1 of #325. A **snap** button in the selected page's info panel opens the snap-channel explorer, styled to the app:

- **Search context**: centers with provenance, radius + source, rotation priors, demoted-seed flag (#315).
- **Pose table**: the incumbent plus every candidate the matcher weighed — losers included, which is the previously-invisible part — ranked by select_score, with θ + scale provenance, per-pose evidence columns, and per-pose truth grid-RMSE where the volume has truth (`rmse_ft` was already recorded per candidate).
- **Evidence bars** for the selected pose: inlier_frac, ncc_fine, chamfer (penalty), verification, select, plus `gate_reasons` chips.
- **Map overlay**: clicking a pose warps the cached P(road) PNG to that pose's corners as a maplibre image layer over the basemap — the alignment the matcher scored, seen directly. Click again to clear.

No client-side scoring: everything rendered comes from candidates.jsonl (per the no-duplication constraint discussed on the issue). The truth-pose synthetic candidate, rotation scan, and decision need/got table land with the phase-2 pipeline records.

Verified: type-check, prettier, 227 app tests, production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)