### PR TITLE
Instrument the RANSAC special cases (#229)

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -840,6 +840,16 @@ _CLUSTER_THRESHOLD_FT: float = 60.0
 # read as a street (New Orleans p153's "LIBERTY IRON WORKS" mis-read as S Liberty St, whose
 # diagonal box throws its crossing ~1200 px off the real street's) yields two genuinely different
 # image points for one world node, and only by keeping both can RANSAC pick the consistent one.
+# How often each RANSAC special case fires (#229): the legacy edge-case fixes
+# (#97/#98/#99/#106/#117) predate the snap channel, and whether each still
+# earns its complexity is an empirical question. Counted per process and
+# reported once per `mapsnap georef` invocation; with --num-workers the
+# workers' counts are not aggregated (the default is serial), so treat the
+# numbers as a floor, not an exact census.
+from collections import Counter as _Counter
+
+SPECIAL_CASE_COUNTS: "_Counter[str]" = _Counter()
+
 DUP_CROSSING_TOL_FRACTION: float = 0.05
 
 
@@ -868,6 +878,8 @@ def _dedupe_crossings_by_pixel(
                 break
         else:
             clusters.append([candidate])
+    if len(clusters) > 1:
+        SPECIAL_CASE_COUNTS["divergent_crossings_kept"] += len(clusters) - 1
     return [min(cluster, key=lambda g: g.pixel_dist) for cluster in clusters]
 
 
@@ -1170,6 +1182,7 @@ def find_intersection_gcps(
                     )
                     if straightened is not None:
                         geo = straightened
+                        SPECIAL_CASE_COUNTS["intersection_geo_straightened"] += 1
                 # Each (fa, fb) instance pair gives one candidate crossing for this world node.
                 # Crossings that coincide (genuine duplicate labels) later collapse to one GCP;
                 # divergent ones (a mislabel like p153's "LIBERTY IRON WORKS") are kept apart so
@@ -1533,6 +1546,7 @@ def ransac_hybrid(
         if any(
             is_rotation_outlier(f, block_index, A, dir_threshold) for f in seed_feats
         ):
+            SPECIAL_CASE_COUNTS["seed_rotation_vetoed"] += 1
             if debug:
                 print(f"  {i1} {i2} REJECTED ({len(inliers)}) seed rotation outlier")
             continue
@@ -2749,6 +2763,7 @@ def prepare_label_features(
             min_long_side=min_long_side,
             perp_tolerance_px=collinear_perp_tolerance_px,
         )
+        SPECIAL_CASE_COUNTS["collinear_discount_withheld"] += len(dominated)
         # Only surface drops that would otherwise have been admitted; a detection the
         # size/confidence gate would reject anyway is not informative, just log noise.
         loggable = [
@@ -2908,6 +2923,7 @@ def process_image(
     # an affine, so when every GCP collapses onto a single image point there is just one
     # control point: defer to the median-scale 1-GCP fit, which tries each world candidate.
     if len(_distinct_pixel_gcps(gcps)) == 1:
+        SPECIAL_CASE_COUNTS["jog_single_pixel_defer"] += 1
         ix = f"{gcps[0].feat_a.raw_text} x {gcps[0].feat_b.raw_text}"
         descr = (
             ix
@@ -3779,6 +3795,17 @@ def main() -> None:
     if scales and len(args.images) > 1 and ref_scale_px_per_ft is not None:
         print(
             f"\nReference scale: {ref_scale_px_per_ft:.4f} px/ft ({len(scales)} images)",
+            file=sys.stderr,
+        )
+        print(
+            "RANSAC special-cases: "
+            + (
+                ", ".join(
+                    f"{name}={count}"
+                    for name, count in sorted(SPECIAL_CASE_COUNTS.items())
+                )
+                or "none fired"
+            ),
             file=sys.stderr,
         )
 

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -82,6 +82,11 @@ class IntersectionGCP:
     pixel_dist: float  # distance between label centers
     feat_a: LabelFeature
     feat_b: LabelFeature
+    # Provenance for the #229 affected-the-fit accounting: whether #99 moved
+    # this GCP's geo, and whether #106 kept it as a divergent (non-primary)
+    # crossing the pre-#106 tiebreak would have discarded.
+    straightened: bool = False
+    divergent_kept: bool = False
 
 
 @dataclass
@@ -848,7 +853,16 @@ _CLUSTER_THRESHOLD_FT: float = 60.0
 # numbers as a floor, not an exact census.
 from collections import Counter as _Counter
 
-SPECIAL_CASE_COUNTS: "_Counter[str]" = _Counter()
+# The affected-the-fit keys are pre-seeded to zero so the summary line always
+# shows them: "seed_veto_changed_winner=0" against 74 vetoes is the
+# removability evidence itself, not a missing datum.
+SPECIAL_CASE_COUNTS: "_Counter[str]" = _Counter(
+    {
+        "seed_veto_changed_winner": 0,
+        "straightened_in_winning_seed": 0,
+        "divergent_kept_in_winning_seed": 0,
+    }
+)
 
 DUP_CROSSING_TOL_FRACTION: float = 0.05
 
@@ -878,9 +892,16 @@ def _dedupe_crossings_by_pixel(
                 break
         else:
             clusters.append([candidate])
-    if len(clusters) > 1:
-        SPECIAL_CASE_COUNTS["divergent_crossings_kept"] += len(clusters) - 1
-    return [min(cluster, key=lambda g: g.pixel_dist) for cluster in clusters]
+    representatives = [min(cluster, key=lambda g: g.pixel_dist) for cluster in clusters]
+    if len(representatives) > 1:
+        SPECIAL_CASE_COUNTS["divergent_crossings_kept"] += len(representatives) - 1
+        # The pre-#106 tiebreak kept only the globally closest-labels crossing;
+        # every other representative exists because of the fix.
+        primary = min(representatives, key=lambda g: g.pixel_dist)
+        for rep in representatives:
+            if rep is not primary:
+                rep.divergent_kept = True
+    return representatives
 
 
 def _cluster_geo_coords(
@@ -1176,12 +1197,14 @@ def find_intersection_gcps(
                 # If a street curves through the shared vertex, the vertex sits off the
                 # straight axis the map draws; use the straight-axis crossing instead so the
                 # geo matches the straight-line pixel crossing (no-op for straight junctions).
+                geo_was_straightened = False
                 if unique_intersection:
                     straightened = straight_intersection_geo(
                         geo, block_index.get(text_a, []), block_index.get(text_b, [])
                     )
                     if straightened is not None:
                         geo = straightened
+                        geo_was_straightened = True
                         SPECIAL_CASE_COUNTS["intersection_geo_straightened"] += 1
                 # Each (fa, fb) instance pair gives one candidate crossing for this world node.
                 # Crossings that coincide (genuine duplicate labels) later collapse to one GCP;
@@ -1206,6 +1229,7 @@ def find_intersection_gcps(
                                 pixel_dist=pixel_dist,
                                 feat_a=fa,
                                 feat_b=fb,
+                                straightened=geo_was_straightened,
                             )
                         )
                 gcps.extend(_dedupe_crossings_by_pixel(candidates, tol_px))
@@ -1451,6 +1475,9 @@ def ransac_hybrid(
     best_inliers: list[int] = []
     best_score = -float("inf")
     best_pair: tuple[int, int] | None = None
+    # #229: the best score among seed pairs the #98 rotation veto rejected. If
+    # it beats the eventual winner, the veto changed this page's outcome.
+    best_vetoed_score = -float("inf")
 
     print("Candidate intersections:")
     for a in gcps:
@@ -1547,6 +1574,9 @@ def ransac_hybrid(
             is_rotation_outlier(f, block_index, A, dir_threshold) for f in seed_feats
         ):
             SPECIAL_CASE_COUNTS["seed_rotation_vetoed"] += 1
+            best_vetoed_score = max(
+                best_vetoed_score, float(len(inliers)) * pos_threshold - err
+            )
             if debug:
                 print(f"  {i1} {i2} REJECTED ({len(inliers)}) seed rotation outlier")
             continue
@@ -1584,6 +1614,14 @@ def ransac_hybrid(
                 file=sys.stderr,
             )
 
+    if best_vetoed_score > best_score:
+        SPECIAL_CASE_COUNTS["seed_veto_changed_winner"] += 1
+    if best_pair is not None:
+        for index in best_pair:
+            if gcps[index].straightened:
+                SPECIAL_CASE_COUNTS["straightened_in_winning_seed"] += 1
+            if gcps[index].divergent_kept:
+                SPECIAL_CASE_COUNTS["divergent_kept_in_winning_seed"] += 1
     return best_A, best_inliers, best_pair
 
 


### PR DESCRIPTION
Step 1 of #229: measure before removing. Each of the five legacy special cases increments a counter when it actually fires, reported as one greppable line per `mapsnap georef` invocation:

```
RANSAC special-cases: collinear_discount_withheld=36, divergent_crossings_kept=55, intersection_geo_straightened=1, seed_rotation_vetoed=13
```

Firing sites: #117 (`drop_collinear_dominated`, counts dominated labels), #106 (`_dedupe_crossings_by_pixel`, counts extra clusters kept), #99 (straightened geo actually applied, i.e. past the ≥120 ft guard), #98 (seed pairs vetoed), #97 (single-pixel jog defers). Counts are per-process — serial is the default; under `--num-workers` they're a floor.

A 12-page champaign smoke already shows the shape: collinear withholding and divergent-crossing retention fire constantly, the seed-rotation veto steadily, straightening rarely, the jog defer not at all. Tonight's full-corpus logs give the real census; the removal question then becomes per-case: frequent-and-cheap cases stay on firing rate alone, while rare ones (#99, #97) get targeted A/Bs — note the firing COUNT alone doesn't prove value (a case can fire often and matter never), so high-fire cases that look removable still need the A/B before deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)