### PR TITLE
Snap searches from demoted poses without un-demoting them (#315)

### DIFF
--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -258,9 +258,18 @@ def load_page_units(volume: Path) -> list[PageUnit]:
         keymap_centers: list[tuple[float, float]] = []
         keymap_radius = 0.0
         keymap_regions = None
+        demoted_affine = None
         if georef is not None:
             if state == "fitted":
                 gen_affine = page_world_affine(georef)
+            else:
+                # #315: a declined pose (misscale/outlier/contradicted) still
+                # anchors snap's rescue search; nofit-style docs have no
+                # corners and stay None.
+                try:
+                    demoted_affine = page_world_affine(georef)
+                except (KeyError, TypeError, ValueError):
+                    demoted_affine = None
             inlier_int = sum(
                 1 for i in georef.get("intersections", []) if i.get("inlier")
             )
@@ -279,6 +288,7 @@ def load_page_units(volume: Path) -> list[PageUnit]:
             truth=truth,
             split_truth=stem in split_truth_parents,
             gen_affine=gen_affine,
+            demoted_affine=demoted_affine,
             inlier_intersections=inlier_int,
             inlier_streets=inlier_str,
             keymap_centers=keymap_centers,

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -103,6 +103,11 @@ class PageUnit:
     keymap_centers: list[tuple[float, float]]
     keymap_radius_m: float
     keymap_regions: list[list[list[float]]] | None = None
+    # A pose its channel produced and DECLINED (misscale/outlier/contradicted
+    # sidecar with corners). Never an incumbent; #315 uses it only to seed
+    # snap's search, because a demoted pose is measurably a good init (refine
+    # fixed richmond p353's 3.06x scale error from one).
+    demoted_affine: np.ndarray | None = None
     anchor_truth: bool = False
     anchor_free: bool = False
     rmse_ft: float | None = None  # generated-vs-truth RMSE

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -680,18 +680,28 @@ def build_page_context(
     ):
         if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in centers):
             centers = centers + [(lon, lat)]
+    seed_affine = None
     if unit.fit_state == "fitted" and unit.gen_affine is not None:
         # For arbitration the incumbent pose itself is the natural search
         # init — it also reaches fitted pages the keymap never placed.
+        seed_affine = unit.gen_affine
+    elif unit.demoted_affine is not None:
+        # #315: a demoted pose is denied publication, not usefulness. It
+        # anchors the rescue search exactly as an incumbent would — which
+        # also reaches demoted pages the keymap never placed (richmond p353:
+        # misscale, no keymap location, previously status no_keymap with no
+        # search at all; its own 3.06x-mis-scaled pose is a good init).
+        seed_affine = unit.demoted_affine
+    if seed_affine is not None:
         lon_c = (
-            unit.gen_affine[0, 0] * unit.width / 2
-            + unit.gen_affine[0, 1] * unit.height / 2
-            + unit.gen_affine[0, 2]
+            seed_affine[0, 0] * unit.width / 2
+            + seed_affine[0, 1] * unit.height / 2
+            + seed_affine[0, 2]
         )
         lat_c = (
-            unit.gen_affine[1, 0] * unit.width / 2
-            + unit.gen_affine[1, 1] * unit.height / 2
-            + unit.gen_affine[1, 2]
+            seed_affine[1, 0] * unit.width / 2
+            + seed_affine[1, 1] * unit.height / 2
+            + seed_affine[1, 2]
         )
         if all(haversine_m(lat_c, lon_c, b, a) > 50.0 for a, b in centers):
             centers = centers + [(lon_c, lat_c)]
@@ -893,20 +903,12 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
                     "radius_source": "local-challenge",
                 }
     if unit.fit_state in RESCUE_STATES and unit.demoted_affine is not None:
-        # #315: a demoted pose is denied publication, not usefulness. The
-        # rescue search from key-map/hint centers failed on every page whose
-        # demoted pose was a good init (richmond p353 unplaced vs 8.4 ft when
-        # seeded from its own 3.06x-mis-scaled fit), so the demoted pose's
-        # CENTER joins the search and its rotation becomes a prior. Position
-        # and angle only -- its scale is often the very reason it was demoted,
-        # and the matcher sweeps the volume rungs regardless. Candidates found
-        # from this seed face the same rescue bars, stamp gate, and reconciler
-        # entry as any other: the demotion itself stands.
+        # #315: the demoted pose's center joined the search in
+        # build_page_context; here its rotation — the pose's most trustworthy
+        # component (its scale is often the very reason for the demotion) —
+        # enters as a prior, and the record is marked so the debugger can show
+        # the seed's provenance.
         a = unit.demoted_affine
-        lon_c = float(a[0, 0] * unit.width / 2 + a[0, 1] * unit.height / 2 + a[0, 2])
-        lat_c = float(a[1, 0] * unit.width / 2 + a[1, 1] * unit.height / 2 + a[1, 2])
-        if (lon_c, lat_c) not in ctx.search_centers:
-            ctx.search_centers = [*ctx.search_centers, (lon_c, lat_c)]
         theta = math.degrees(math.atan2(-a[1, 0], a[0, 0]))
         ctx.rotation_priors = [
             *ctx.rotation_priors,
@@ -914,7 +916,6 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
                 theta_deg=theta, sigma_deg=DEMOTED_SEED_SIGMA_DEG, source="demoted-pose"
             ),
         ]
-        record["search"]["centers"].append([round(lon_c, 7), round(lat_c, 7)])
         record["search"]["demoted_seed"] = True
         record["priors"]["rotation"].append(
             {

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -69,6 +69,11 @@ LOCAL_CHALLENGE_RADIUS_M = 150.0
 
 RESCUE_STATES = {"nofit", "misscale", "1gcp", "outlier", "none"}
 
+# Rotation-prior sigma for a demoted pose used as a search seed (#315). Wide
+# enough that the ladder still explores, tight enough that the demoted fit's
+# orientation -- its most trustworthy component -- ranks first.
+DEMOTED_SEED_SIGMA_DEG = 10.0
+
 
 def artifacts_dir(volume: Path) -> Path:
     return volume / "artifacts" / "osm_snap"
@@ -359,10 +364,16 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
         keymap_centers: list[tuple[float, float]] = []
         keymap_radius = 0.0
         keymap_regions = None
+        demoted_affine = None
         if georef is not None:
             if state == "fitted":
                 gen_affine = page_world_affine(georef)
                 effective_gcps = effective_gcp_count(georef)
+            else:
+                try:
+                    demoted_affine = page_world_affine(georef)
+                except (KeyError, TypeError, ValueError):
+                    demoted_affine = None  # nofit-style doc: no corners
             keymap = georef.get("keymap") or {}
             keymap_centers = [tuple(c) for c in keymap.get("centers", [])]
             keymap_radius = float(keymap.get("radius_m") or 0.0)
@@ -378,6 +389,7 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
                 truth=truth,
                 split_truth=False,
                 gen_affine=gen_affine,
+                demoted_affine=demoted_affine,
                 inlier_intersections=effective_gcps,
                 inlier_streets=0,
                 keymap_centers=keymap_centers,
@@ -880,6 +892,37 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
                     "radius_m": round(ctx.radius_m, 1),
                     "radius_source": "local-challenge",
                 }
+    if unit.fit_state in RESCUE_STATES and unit.demoted_affine is not None:
+        # #315: a demoted pose is denied publication, not usefulness. The
+        # rescue search from key-map/hint centers failed on every page whose
+        # demoted pose was a good init (richmond p353 unplaced vs 8.4 ft when
+        # seeded from its own 3.06x-mis-scaled fit), so the demoted pose's
+        # CENTER joins the search and its rotation becomes a prior. Position
+        # and angle only -- its scale is often the very reason it was demoted,
+        # and the matcher sweeps the volume rungs regardless. Candidates found
+        # from this seed face the same rescue bars, stamp gate, and reconciler
+        # entry as any other: the demotion itself stands.
+        a = unit.demoted_affine
+        lon_c = float(a[0, 0] * unit.width / 2 + a[0, 1] * unit.height / 2 + a[0, 2])
+        lat_c = float(a[1, 0] * unit.width / 2 + a[1, 1] * unit.height / 2 + a[1, 2])
+        if (lon_c, lat_c) not in ctx.search_centers:
+            ctx.search_centers = [*ctx.search_centers, (lon_c, lat_c)]
+        theta = math.degrees(math.atan2(-a[1, 0], a[0, 0]))
+        ctx.rotation_priors = [
+            *ctx.rotation_priors,
+            RotationPrior(
+                theta_deg=theta, sigma_deg=DEMOTED_SEED_SIGMA_DEG, source="demoted-pose"
+            ),
+        ]
+        record["search"]["centers"].append([round(lon_c, 7), round(lat_c, 7)])
+        record["search"]["demoted_seed"] = True
+        record["priors"]["rotation"].append(
+            {
+                "theta_deg": round(theta, 2),
+                "sigma_deg": DEMOTED_SEED_SIGMA_DEG,
+                "source": "demoted-pose",
+            }
+        )
     candidates = snap_page(ctx, vctx.feature_index)
     if unit.fit_state in RESCUE_STATES:
         # A contradiction-demoted page may only be re-adopted at a pose that

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -512,3 +512,35 @@ def test_refine_requires_informative_challenger_evidence():
     record = fitted_record(incumbent_ver=-0.249, challenger_ver=0.35, shift_m=15.0)
     record["incumbent"]["effective_gcps"] = 14
     assert refine_adoption(record) is not None
+
+
+def test_load_page_units_populates_demoted_affine(tmp_path):
+    """A declined pose (misscale) loads as demoted_affine; a fitted one as gen_affine.
+
+    Two near-identical loaders build PageUnits (this module's panel loader and
+    edge_join_experiment.load_page_units for base pages); the #315 fix was
+    silently a no-op TWICE because only one of them populated the field. This
+    pins the base loader.
+    """
+    import json as json_module
+
+    from PIL import Image
+
+    from mapsnap.osm_snap_experiment import load_page_units
+
+    corners = [[-96.0, 46.0], [-95.9, 46.0], [-95.9, 45.9], [-96.0, 45.9]]
+    for stem, doc in [
+        ("p1", {"width": 40, "height": 30, "status": "misscale", "corners": corners}),
+        ("p2", {"width": 40, "height": 30, "corners": corners}),
+        ("p3", {"width": 40, "height": 30, "status": "nofit"}),
+    ]:
+        Image.new("RGB", (40, 30)).save(tmp_path / f"{stem}.jpg")
+        (tmp_path / f"{stem}.georef.json").write_text(json_module.dumps(doc))
+    units = {u.stem: u for u in load_page_units(tmp_path)}
+    assert units["p1"].fit_state == "misscale"
+    assert units["p1"].demoted_affine is not None
+    assert units["p1"].gen_affine is None
+    assert units["p2"].fit_state == "fitted"
+    assert units["p2"].gen_affine is not None
+    assert units["p2"].demoted_affine is None
+    assert units["p3"].demoted_affine is None


### PR DESCRIPTION
Closes #315. A demoted pose (misscale/outlier/contradicted sidecar with corners) now anchors snap's search context exactly as an incumbent does — center joins the search, rotation enters as a prior — while the demotion stands: candidates found from the seed face the unchanged rescue bars, stamp gate, and reconciler entry. Position and angle only, never scale (the scale is often why it was demoted; the matcher sweeps the volume rungs regardless).

## Validation (4-volume A/B vs a shared current-main control)

| volume | ctl | fix | target page |
|---|---|---|---|
| richmond | 77.6 | **78.1** | **p353: unplaced → 5.1 ft** (from its own 3.06×-mis-scaled pose — better than the issue's arm-D 8.4 ft, and without un-demoting anything) |
| miami | 77.8 | 77.8 | p76 unchanged — no longer a #315 case: the current pipeline publishes it *fitted* at 4,162 ft, rot_err −179.9° → it's a #324 (180° veto) case now |
| detroit | 70.4 | 70.4 | p56 unchanged — fitted at 330 ft (a slide), not demoted |
| washington_dc | 85.6 | 85.6 | p175 already 17.2 ft in control |

Zero regressions; none of arm D's ~12 catches republish (they'd need to clear the rescue bars as ordinary candidates, which is exactly what they fail).

## The two no-op rounds, for the record

Round 1 seeded an *existing* search — but p353 is misscale **with no keymap location**, so no context existed to seed (`no_keymap`). Round 2 moved the anchor into `build_page_context` — but patched the *panel* loader; base pages load through `edge_join_experiment.load_page_units`, whose near-identical block never populated the field. A loader test now pins both behaviors so the twin-path trap is fenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)