### PR TITLE
Veto upside-down poses (#324): 0/1,332 truth pages read inverted

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -52,7 +52,7 @@ from mapsnap.streets import (
     is_number_only,
     normalize_street,
 )
-from mapsnap.utils import default_centerlines, image_stem
+from mapsnap.utils import default_centerlines, image_stem, pose_is_upside_down
 
 
 @dataclass
@@ -1569,6 +1569,15 @@ def ransac_hybrid(
         # p7's VAN BRUNT, ~3° off but ~115 ft beyond the truncated end). Seeds are the pair's
         # four source features; is_rotation_outlier identifies each by its own center, so an
         # ambiguous label's dropped canonical expansion (Detroit p94's KORTE) isn't faulted.
+        # A pose whose text reads upside-down is corpus-impossible (#324:
+        # 0 of 1,332 truth pages land in the 112-247 deg zone) -- it is the
+        # street/avenue grid alias reading the sheet 180 off (miami p18/p76).
+        # Vetoed outright, before the softer rotation-outlier check.
+        if pose_is_upside_down(A):
+            SPECIAL_CASE_COUNTS["upside_down_vetoed"] += 1
+            if debug:
+                print(f"  {i1} {i2} REJECTED upside-down pose")
+            continue
         seed_feats = (a.feat_a, a.feat_b, b.feat_a, b.feat_b)
         if any(
             is_rotation_outlier(f, block_index, A, dir_threshold) for f in seed_feats

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -60,7 +60,7 @@ from mapsnap.osm_snap import (
     snap_page,
 )
 from mapsnap.streets import Block, build_block_index
-from mapsnap.utils import default_centerlines, haversine_m
+from mapsnap.utils import default_centerlines, haversine_m, pose_is_upside_down
 
 # Pages the rescue channel may place: everything the iiif glob does not see.
 LOCAL_CHALLENGE_RADIUS_M = 150.0
@@ -925,6 +925,17 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
             }
         )
     candidates = snap_page(ctx, vctx.feature_index)
+    # #324: a candidate whose pose reads the page upside-down is
+    # corpus-impossible (0/1,332 truth pages in the zone); snap's rotation
+    # ladder has admitted 180-off aliases before (detroit p77 at 116 deg,
+    # 687 ft). Marked implausible the same way the stamp gate does, so it can
+    # never win rescue, challenge, or refinement.
+    for candidate in candidates:
+        if pose_is_upside_down(candidate.world_affine):
+            candidate.plausible = False
+            candidate.gate_reasons.append("upside-down")
+            candidate.verification = -math.inf
+
     if unit.fit_state in RESCUE_STATES:
         # A contradiction-demoted page may only be re-adopted at a pose that
         # satisfies the invariant that demoted it: its printed claim of a

--- a/mapsnap/utils.py
+++ b/mapsnap/utils.py
@@ -290,3 +290,31 @@ def list_pages(dir_path: Path) -> list[Path]:
         for p in images
         if "__" in p.stem or p.stem.split("__")[0] not in split_parents
     ]
+
+
+# The corpus-measured implausible-rotation zone (#324): the rotation of a
+# page's +x axis vs geographic east, over 1,332 truth pages across 18 volumes,
+# never lands between 112 and 247 degrees. Sheets rotate freely to +/-90 and
+# to arbitrary grid-aligned angles, but Sanborn never printed a sheet whose
+# text reads upside-down -- a pose in this zone means the fit aliased onto the
+# wrong grid axis (miami p18/p76: streets swapped for avenues, 180 off).
+UPSIDE_DOWN_DEG = (112.0, 247.0)
+
+
+def pose_text_theta_deg(affine) -> float:
+    """Rotation of a page-px -> lon/lat pose's +x axis vs geographic east, [0, 360)."""
+    import math
+
+    lat = float(affine[1][2])
+    kx = 111320.0 * math.cos(math.radians(lat))
+    ky = 110540.0
+    return (
+        math.degrees(math.atan2(float(affine[1][0]) * ky, float(affine[0][0]) * kx))
+        % 360.0
+    )
+
+
+def pose_is_upside_down(affine) -> bool:
+    """Whether a pose renders the page's text upside-down (see UPSIDE_DOWN_DEG)."""
+    theta = pose_text_theta_deg(affine)
+    return UPSIDE_DOWN_DEG[0] <= theta <= UPSIDE_DOWN_DEG[1]

--- a/mapsnap/utils_test.py
+++ b/mapsnap/utils_test.py
@@ -215,3 +215,27 @@ def test_label_letter_page_key():
     assert label_to_page_key("Los Angeles, Calif. | 1949 | Vol. 14 pb") == "pb"
     # A trailing non-page word must not become a page key.
     assert label_to_page_key("Los Angeles, Calif. | 1949 | key map") is None
+
+
+def test_pose_is_upside_down():
+    """The 112-247 deg zone flags; 0/90/270-deg poses do not (#324)."""
+    import math
+
+    from mapsnap.utils import pose_is_upside_down, pose_text_theta_deg
+
+    def pose(theta_deg: float, scale: float = 2e-6, lat: float = 40.0):
+        t = math.radians(theta_deg)
+        # Page +x rotated theta from east; lat row carries the y-flip like a
+        # real page->lon/lat affine (lat decreases with page y).
+        kx = 111320.0 * math.cos(math.radians(lat))
+        ky = 110540.0
+        return [
+            [scale * math.cos(t) / kx * 111320.0, 0.0, -96.0],
+            [scale * math.sin(t) / ky * 110540.0, -scale, lat],
+        ]
+
+    for theta in (0, 45, 90, 111, 248, 270, 315):
+        assert not pose_is_upside_down(pose(theta)), theta
+    for theta in (113, 150, 180, 210, 246):
+        assert pose_is_upside_down(pose(theta)), theta
+    assert abs(pose_text_theta_deg(pose(180)) - 180.0) < 1.0


### PR DESCRIPTION
Closes #324. Both sites from the issue, sharing one page-frame helper (`pose_is_upside_down`, zone 112–247° — deliberately a text-direction test, not a volume-median deviation, so the #256 multi-family trap doesn't apply):

- **RANSAC**: seed pairs whose model lands in the zone are vetoed outright, counted as `upside_down_vetoed` in the #327 census line.
- **Snap**: zone candidates are marked implausible exactly like stamp-inconsistent ones (verification −inf), so they can never win rescue/challenge/refine.

Pre-registered validation pages:

| page | before | after |
|---|---|---|
| fargo p63__2 (180°, 27,618 ft) | georef disaster | pose eliminated (3 seed vetoes fired) |
| fargo p70__1 (179°) | georef | fits **right-side-up** (θ≈0°), then misscale (correct gate; its demoted pose seeds snap per #315) |
| miami p76 (−179.9°, 4,162 ft) | fitted flip | re-fits at 297° — **grade pending tonight's run** |
| fargo p63__1 (180°) / detroit p77 (116° snap:1) | zone poses | killed at their sites on next fit |

Unit test pins the zone boundaries (111/248 pass, 113–246 flag). Tonight's corpus run is the full validation: expected effect is removal of the four zone poses plus miami p18/p76's aliases, with zero legitimate collateral (truth says the zone is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)