### PR TITLE
README + gallery: 2026-08-14 corpus results

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,139 +34,147 @@ Test data comes from hand-geocoding by volunteers on OldInsuranceMaps.net:
   <tbody>
     <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn01778_006">Champaign, Ill. 1915</a></td>
-      <td align="right">29/33 (88%)</td>
-      <td align="right">92.7%</td>
-      <td align="right">0.2%</td>
-      <td align="right"><b>92.5%</b></td>
+      <td align="right">28/33 (85%)</td>
+      <td align="right">97.7%</td>
+      <td align="right">0.6%</td>
+      <td align="right"><b>97.1%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchampaign_ill_1915.iiif.json">view</a></td>
     </tr>
     <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn03376_029">New Orleans 1951 Vol 5</a></td>
-      <td align="right">104/109 (95%)</td>
-      <td align="right">93.1%</td>
-      <td align="right">0.9%</td>
-      <td align="right"><b>92.2%</b></td>
+      <td align="right">102/109 (94%)</td>
+      <td align="right">93.4%</td>
+      <td align="right">0.0%</td>
+      <td align="right"><b>93.4%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1951_vol_5.iiif.json">view</a></td>
     </tr>
     <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn05791_053">Brooklyn 1939 Vol 1</a></td>
-      <td align="right">54/62 (87%)</td>
-      <td align="right">87.9%</td>
-      <td align="right">0.0%</td>
-      <td align="right"><b>87.9%</b></td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fbrooklyn_ny_1939_vol_1.iiif.json">view</a></td>
-    </tr>
-    <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn01227_003">Washington DC 1916 Vol 2</a></td>
-      <td align="right">119/134 (89%)</td>
-      <td align="right">86.5%</td>
-      <td align="right">1.6%</td>
-      <td align="right"><b>84.9%</b></td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fwashington_dc_1916_vol_2.iiif.json">view</a></td>
-    </tr>
-    <tr>
-      <td><a href="https://oldinsurancemaps.net/loc/sanborn07905_031">Philadelphia 1950 Vol 3</a></td>
-      <td align="right">61/65 (94%)</td>
-      <td align="right">84.0%</td>
-      <td align="right">0.0%</td>
-      <td align="right"><b>84.0%</b></td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fphiladelphia_pa_1950_vol_3.iiif.json">view</a></td>
-    </tr>
-    <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn03376_006">New Orleans 1896 Vol 2</a></td>
-      <td align="right">86/91 (95%)</td>
-      <td align="right">83.5%</td>
-      <td align="right">0.1%</td>
-      <td align="right"><b>83.4%</b></td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1896_vol_2.iiif.json">view</a></td>
-    </tr>
-    <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn01790_085">Chicago 1950 Vol 1</a></td>
-      <td align="right">100/111 (90%)</td>
-      <td align="right">79.5%</td>
-      <td align="right">0.0%</td>
-      <td align="right"><b>79.5%</b></td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchicago_il_1950_vol_1.iiif.json">view</a></td>
-    </tr>
-    <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn00656_064">Los Angeles 1949 Vol 14</a></td>
-      <td align="right">117/129 (91%)</td>
-      <td align="right">79.8%</td>
-      <td align="right">0.6%</td>
-      <td align="right"><b>79.2%</b></td>
+      <td align="right">127/129 (98%)</td>
+      <td align="right">90.9%</td>
+      <td align="right">1.2%</td>
+      <td align="right"><b>89.8%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Flos_angeles_ca_1949_vol_14.iiif.json">view</a></td>
     </tr>
     <tr>
       <td><a href="https://oldinsurancemaps.net/loc/sanborn06656_014">Columbus 1951 Vol 3</a></td>
       <td align="right">98/105 (93%)</td>
-      <td align="right">78.8%</td>
-      <td align="right">0.3%</td>
-      <td align="right"><b>78.4%</b></td>
+      <td align="right">88.5%</td>
+      <td align="right">0.5%</td>
+      <td align="right"><b>88.0%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fcolumbus_oh_1951_vol_3.iiif.json">view</a></td>
     </tr>
     <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn05791_053">Brooklyn 1939 Vol 1</a></td>
+      <td align="right">54/62 (87%)</td>
+      <td align="right">88.2%</td>
+      <td align="right">0.4%</td>
+      <td align="right"><b>87.7%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fbrooklyn_ny_1939_vol_1.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/loc/sanborn07905_031">Philadelphia 1950 Vol 3</a></td>
+      <td align="right">62/65 (95%)</td>
+      <td align="right">86.5%</td>
+      <td align="right">0.6%</td>
+      <td align="right"><b>85.9%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fphiladelphia_pa_1950_vol_3.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn01227_003">Washington DC 1916 Vol 2</a></td>
+      <td align="right">120/134 (90%)</td>
+      <td align="right">86.0%</td>
+      <td align="right">0.9%</td>
+      <td align="right"><b>85.1%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fwashington_dc_1916_vol_2.iiif.json">view</a></td>
+    </tr>
+    <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn04720_021">Kansas City 1951 Vol 4</a></td>
-      <td align="right">128/142 (90%)</td>
-      <td align="right">79.6%</td>
-      <td align="right">2.5%</td>
-      <td align="right"><b>77.1%</b></td>
+      <td align="right">131/142 (92%)</td>
+      <td align="right">81.8%</td>
+      <td align="right">0.2%</td>
+      <td align="right"><b>81.6%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fkansas_city_mo_1951_vol_4.iiif.json">view</a></td>
     </tr>
     <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn01790_085">Chicago 1950 Vol 1</a></td>
+      <td align="right">102/111 (92%)</td>
+      <td align="right">80.9%</td>
+      <td align="right">0.9%</td>
+      <td align="right"><b>80.0%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchicago_il_1950_vol_1.iiif.json">view</a></td>
+    </tr>
+    <tr>
       <td><a href="https://oldinsurancemaps.net/loc/sanborn01309_018">Miami 1950 Vol 1</a></td>
-      <td align="right">74/93 (80%)</td>
-      <td align="right">75.1%</td>
-      <td align="right">3.5%</td>
-      <td align="right"><b>71.6%</b></td>
+      <td align="right">82/93 (88%)</td>
+      <td align="right">80.3%</td>
+      <td align="right">1.8%</td>
+      <td align="right"><b>78.5%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fmiami_fl_1950_vol_1.iiif.json">view</a></td>
     </tr>
     <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn03985_041">Detroit 1929 Vol 11</a></td>
-      <td align="right">86/103 (83%)</td>
-      <td align="right">69.7%</td>
-      <td align="right">1.3%</td>
-      <td align="right"><b>68.5%</b></td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fdetroit_mich_1929_vol_11.iiif.json">view</a></td>
-    </tr>
-    <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn04023_023">Grand Rapids 1953 Vol 7</a></td>
-      <td align="right">64/83 (77%)</td>
-      <td align="right">71.2%</td>
-      <td align="right">3.0%</td>
-      <td align="right"><b>68.3%</b></td>
+      <td align="right">69/83 (83%)</td>
+      <td align="right">83.6%</td>
+      <td align="right">5.2%</td>
+      <td align="right"><b>78.5%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fgrand_rapids_mi_1953_vol7.iiif.json">view</a></td>
     </tr>
     <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn08356_019">Nashville 1957 Vol 1A</a></td>
-      <td align="right">60/71 (85%)</td>
-      <td align="right">66.3%</td>
-      <td align="right">0.6%</td>
-      <td align="right"><b>65.7%</b></td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnashville_tn_1957_vol1a.iiif.json">view</a></td>
-    </tr>
-    <tr>
-      <td><a href="https://oldinsurancemaps.net/loc/sanborn08131_010">Columbia, S.C. 1956 Vol 1</a></td>
-      <td align="right">77/87 (89%)</td>
-      <td align="right">67.4%</td>
-      <td align="right">3.9%</td>
-      <td align="right"><b>63.4%</b></td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fcolumbia_sc_1956_vol_1.iiif.json">view</a></td>
+      <td><a href="https://www.loc.gov/item/sanborn09064_008/">Richmond, Va. 1925 Vol 3</a></td>
+      <td align="right">87/92 (95%)</td>
+      <td align="right">78.7%</td>
+      <td align="right">0.2%</td>
+      <td align="right"><b>78.5%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Frichmond_va_1925_vol_3.iiif.json">view</a></td>
     </tr>
     <tr>
       <td><a href="https://oldinsurancemaps.net/loc/sanborn06536_012">Fargo, N.D. 1958</a></td>
-      <td align="right">81/115 (70%)</td>
-      <td align="right">58.6%</td>
-      <td align="right">6.5%</td>
-      <td align="right"><b>52.1%</b></td>
+      <td align="right">94/115 (82%)</td>
+      <td align="right">80.4%</td>
+      <td align="right">2.2%</td>
+      <td align="right"><b>78.3%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Ffargo_nd_1958.iiif.json">view</a></td>
     </tr>
     <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn03985_041">Detroit 1929 Vol 11</a></td>
+      <td align="right">84/103 (82%)</td>
+      <td align="right">77.5%</td>
+      <td align="right">1.1%</td>
+      <td align="right"><b>76.5%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fdetroit_mich_1929_vol_11.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn03376_006">New Orleans 1896 Vol 2</a></td>
+      <td align="right">87/91 (96%)</td>
+      <td align="right">79.9%</td>
+      <td align="right">3.5%</td>
+      <td align="right"><b>76.4%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1896_vol_2.iiif.json">view</a></td>
+    </tr>
+    <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn05511_036">Hudson County 1950 Vol 9</a></td>
-      <td align="right">71/95 (75%)</td>
-      <td align="right">50.6%</td>
-      <td align="right">0.0%</td>
-      <td align="right"><b>50.6%</b></td>
+      <td align="right">76/95 (80%)</td>
+      <td align="right">75.9%</td>
+      <td align="right">0.4%</td>
+      <td align="right"><b>75.5%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fhudson_co_nj_1950_vol_9.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/loc/sanborn08131_010">Columbia, S.C. 1956 Vol 1</a></td>
+      <td align="right">80/87 (92%)</td>
+      <td align="right">75.6%</td>
+      <td align="right">2.1%</td>
+      <td align="right"><b>73.5%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fcolumbia_sc_1956_vol_1.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn08356_019">Nashville 1957 Vol 1A</a></td>
+      <td align="right">64/71 (90%)</td>
+      <td align="right">71.4%</td>
+      <td align="right">0.2%</td>
+      <td align="right"><b>71.2%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnashville_tn_1957_vol1a.iiif.json">view</a></td>
     </tr>
   </tbody>
 </table>
@@ -175,7 +183,7 @@ Test data comes from hand-geocoding by volunteers on OldInsuranceMaps.net:
 
 Each **sheet** carries the same weight, split across its panels by the paper area each occupies, and discounted by the share of the sheet that is usable land (approximated by proximity to an OSM street). So a sheet counts for no more because it is physically large, but a sheet that is mostly harbour counts for less than a dense downtown one.
 
-> **Note:** the table above predates this weighting and is not comparable to it; it will be regenerated from the next full corpus run.
+Results are from the 2026-08-14 corpus run; the mean score across the 18 volumes is **82.0%**.
 
 You can view the fits on Allmaps or get the IIIF files from the `gallery` directory. For notes on poor fits, see [test data notes].
 

--- a/gallery/brooklyn_ny_1939_vol_1.iiif.json
+++ b/gallery/brooklyn_ny_1939_vol_1.iiif.json
@@ -7,2766 +7,6 @@
   "label": "Mosaic of main content, Brooklyn, N.Y. | 1939 | Vol. 1",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p14",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1571.4,0.0 5612.0,0.0 5612.0,8268.0 -0.0,8268.0 -0.0,414.7 1253.2,944.1 1567.1,958.5 1571.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01183642738108,
-                40.67300888270078
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00805212695447,
-                40.67199367140914
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01001028856263,
-                40.66773514714673
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01379458898924,
-                40.668750358438366
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p21",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5627
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5627.0,6302.4 5271.0,6437.0 5108.6,6013.5 4729.6,7097.0 4424.1,6309.2 2564.2,7042.9 1547.5,6993.2 1755.7,7352.9 173.3,7946.4 219.9,183.9 1148.8,196.8 1149.8,0.0 2729.3,0.0 2741.0,219.0 5627.0,259.1 5627.0,6302.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01065099859939,
-                40.68040562212427
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5627.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00798176565301,
-                40.682718584879005
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5627.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00353253299686,
-                40.6797238198133
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00620176594323,
-                40.67741085705856
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p25",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5622
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5045.9,1790.4 5154.9,7530.0 2360.4,7623.8 2308.6,6403.9 2801.5,5159.1 2978.7,4673.9 724.7,3821.4 1946.6,623.6 5045.9,1790.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00921556575516,
-                40.679518612811606
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5622.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00544038842823,
-                40.67840207612887
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5622.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00758958985925,
-                40.67416327010515
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01136476718617,
-                40.675279806787884
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p29",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/info.json",
-          "type": "ImageService2",
-          "height": 8267,
-          "width": 5490
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2621.3,0.0 3154.6,0.0 3504.9,156.0 5490.0,144.8 5490.0,3084.8 4983.0,3748.7 4982.3,4989.6 5336.4,4994.8 5338.5,8267.0 1445.8,8267.0 1445.3,7975.2 190.8,6838.6 184.4,129.3 2645.2,152.7 2621.3,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00662470534375,
-                40.67712313583052
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5490.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00525545395907,
-                40.679966463343085
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5490.0,
-                8267.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99964667445404,
-                40.67839097773776
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8267.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00101592583874,
-                40.675547650225205
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p31",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5589
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5343.3,154.7 5417.9,7744.4 0.0,7787.4 0.0,213.9 5343.3,154.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00415170903338,
-                40.68234241785946
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5589.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00272112622571,
-                40.685225885898305
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5589.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99713451558684,
-                40.683609415036926
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99856509839452,
-                40.68072594699807
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p33",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,7765.7 635.5,7772.8 1064.8,218.9 2099.7,230.7 2098.9,0.0 4182.8,0.0 4180.9,254.5 5612.0,270.8 5612.0,7765.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00180537161144,
-                40.68724645804901
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00040155808476,
-                40.690169344737086
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99476237542531,
-                40.688590022133084
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99616618895199,
-                40.685667135445
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p34",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4590.6,320.8 4600.2,0.0 5612.0,0.0 5612.0,8268.0 5499.9,8268.0 5539.4,7856.4 1646.6,7889.9 1569.2,315.4 4590.6,320.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00082811219386,
-                40.68937332310964
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99940042637887,
-                40.69225428895206
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99384194865164,
-                40.69064815968795
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99526963446662,
-                40.68776719384553
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p39",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"368.1,1191.6 5097.4,1130.7 5097.4,1130.9 5193.5,1129.8 5173.1,6611.0 3182.0,6403.8 477.4,6430.6 368.1,1191.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00094964006315,
-                40.67845717671079
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99949867097514,
-                40.68135719191214
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99390435706535,
-                40.679724601604775
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99535532615336,
-                40.67682458640343
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p4",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01600941972735,
-                40.68200140255679
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5599.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01344168188946,
-                40.684360373026166
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5599.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00888113792153,
-                40.681465154028096
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01144887575943,
-                40.67910618355872
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p40",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,6768.2 0.0,1272.9 5224.9,1227.0 5255.8,4134.7 4930.5,7334.8 2359.6,7034.5 2423.4,6420.7 1409.3,6276.1 1419.5,6931.4 0.0,6768.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99970278954943,
-                40.68116743752619
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99826194574078,
-                40.68406385729522
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99267433963392,
-                40.682442725828906
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99411518344257,
-                40.67954630605988
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p41",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4654.9,7668.6 772.7,7720.5 689.6,4504.4 290.2,1623.6 5010.0,966.4 5249.1,3875.2 4574.2,3968.4 4654.9,7668.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99866618558417,
-                40.68390408385502
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99675639763308,
-                40.686636997373625
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99148403008962,
-                40.684488321183814
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99339381804072,
-                40.68175540766521
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p42",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"209.0,7748.0 189.8,4042.1 867.1,3960.0 676.1,1043.7 4787.6,530.7 5138.1,3445.6 4078.5,3573.2 4097.4,7761.7 209.0,7748.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99723808462724,
-                40.68602344874389
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99539040645085,
-                40.68877645716126
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99007910039077,
-                40.68669772683648
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99192677856715,
-                40.683944718419106
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0045/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p45",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0045/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0045/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4811.2,6283.9 4767.0,6335.4 4762.5,8268.0 1428.2,8268.0 737.5,5001.9 2037.1,4714.2 1999.5,4540.3 -0.0,3243.7 -0.0,721.6 5215.6,691.2 5224.1,5802.2 4811.2,6283.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0045/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9974094189883,
-                40.67309184324161
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99401109933355,
-                40.671447385389186
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99718296064181,
-                40.667623204769484
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.00058128029656,
-                40.669267662621905
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p47",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,1292.6 5612.0,116.3 5612.0,7813.4 0.0,7761.5 0.0,1292.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99933644892133,
-                40.67354638983402
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9971566933212,
-                40.676208348619284
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99202200591114,
-                40.6737555565649
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99420176151126,
-                40.671093597779645
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p48",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4683.3,6921.5 4685.3,7301.7 825.4,7326.1 807.7,868.6 4662.4,844.2 4659.6,0.0 5612.0,0.0 5612.0,6912.2 4683.3,6921.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99202239469861,
-                40.67505683969486
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98860171462188,
-                40.67337937790905
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99183731556955,
-                40.66953013116823
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99525799564628,
-                40.67120759295404
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p49",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"372.7,2017.1 5322.9,1087.0 5178.8,7368.6 3920.0,7337.8 3922.5,7218.9 3940.3,6380.4 1219.7,6343.0 1193.2,8268.0 255.4,8268.0 372.7,2017.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99850287221479,
-                40.676578468916915
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99637241136806,
-                40.6792919244704
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99113816619474,
-                40.67689470487319
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99326862704147,
-                40.67418124931971
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p51",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4103.0,0.0 5126.4,0.0 5149.9,616.0 5612.0,604.7 5612.0,7361.5 4195.4,7396.6 371.2,7157.7 744.9,759.0 2747.5,686.7 2778.7,685.6 4205.6,646.7 4103.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99653541713415,
-                40.67867950615787
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99457144809442,
-                40.68139416750661
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98933470534031,
-                40.67918435886555
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99129867438006,
-                40.67646969751681
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p57",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/info.json",
-          "type": "ImageService2",
-          "height": 8267,
-          "width": 5630
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"948.0,8267.0 963.9,7324.4 113.4,7313.0 154.2,3428.6 0.0,3426.6 0.0,-0.0 2793.5,0.0 2786.2,983.4 5262.3,1011.1 5176.4,7379.6 5630.0,7386.9 5630.0,8267.0 948.0,8267.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99402427572225,
-                40.675329108819355
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5630.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99189504493748,
-                40.677958356910885
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5630.0,
-                8267.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98684134825864,
-                40.675570981175596
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8267.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98897057904342,
-                40.672941733084066
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p58",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5556
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"449.2,7323.4 0.0,7322.2 0.0,1017.4 2646.6,1018.6 5102.1,798.3 5426.8,4127.0 4145.6,4242.6 4433.0,7266.0 5556.0,7162.7 5556.0,8268.0 0.0,8268.0 460.9,8194.5 449.2,7323.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99203900603159,
-                40.677797893317795
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5556.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98987068103423,
-                40.680396236180634
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5556.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98480788590417,
-                40.67793186034168
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98697621090155,
-                40.67533351747884
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p61",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5629
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1871.2,8268.0 1875.6,7279.0 875.4,7276.9 872.7,864.7 4747.3,921.1 4758.9,7297.0 5629.0,7302.5 5629.0,8268.0 1871.2,8268.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98827702218155,
-                40.68291300281711
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5629.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98642013564809,
-                40.68569207468323
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5629.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98107403612475,
-                40.68360882721192
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9829309226582,
-                40.68082975534579
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/georef",
       "type": "Annotation",
       "@context": [
@@ -2777,15 +17,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2833,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.02288923373989,
-                40.67714940672102
+                -74.02281132806249,
+                40.67709571899987
               ]
             }
           },
@@ -2854,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.02016774077099,
-                40.67945539806248
+                -74.02015045578837,
+                40.679390672270905
               ]
             }
           },
@@ -2875,8 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01568025625365,
-                40.67640689379288
+                -74.01568272508587,
+                40.676411224549355
               ]
             }
           },
@@ -2896,29 +136,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01840174922253,
-                40.67410090245143
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5491.0,
-                7724.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.016028,
-                40.676563
+                -74.01834359735999,
+                40.67411627127832
               ]
             }
           }
@@ -2936,15 +155,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2963,197 +182,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5418.0,8268.0 5420.6,7347.1 4421.7,7348.8 4411.2,7664.0 0.0,7664.9 0.0,-0.0 5599.0,0.0 5599.0,8268.0 5418.0,8268.0\" /></svg>"
+          "value": "<svg><polygon points=\"5418.9,8268.0 5421.4,7343.9 4421.7,7345.9 4411.2,7664.0 0.0,7664.4 0.0,-0.0 5599.0,0.0 5599.0,8268.0 5418.9,8268.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4411.2,
-                7664.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9994446,
-                40.6916676
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                555.9,
-                7664.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0004427,
-                40.6896644
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p11",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"207.0,468.1 5599.0,462.1 5599.0,8268.0 -0.0,8268.0 -0.0,381.8 206.6,381.4 207.0,468.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2459.6,
-                460.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.015425,
-                40.675199
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5351.0,
-                460.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.013855,
-                40.674128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p13",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5612,0 5612,8268 0,8268\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -3178,8 +211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01380778451566,
-                40.67443382481102
+                -74.00583753531365,
+                40.69087973764018
               ]
             }
           },
@@ -3187,7 +220,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5612.0,
+                5599.0,
                 0.0
               ],
               "creator": {
@@ -3199,8 +232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01075704825011,
-                40.67236869579175
+                -74.00438801249209,
+                40.69378894925844
               ]
             }
           },
@@ -3208,7 +241,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5612.0,
+                5599.0,
                 8268.0
               ],
               "creator": {
@@ -3220,8 +253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01476721881627,
-                40.66895869389645
+                -73.99872326909802,
+                40.69216622394498
               ]
             }
           },
@@ -3241,8 +274,83 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01781795508181,
-                40.67102382291573
+                -74.00017279191958,
+                40.68925701232672
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p11",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5599
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,381.8 5599.0,462.1 5599.0,8268.0 -0.0,8268.0 -0.0,381.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01653585809588,
+                40.676299408567026
               ]
             }
           },
@@ -3250,20 +358,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                320.0,
-                456.0
+                5599.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.013855,
-                40.674128
+                -74.01349574744583,
+                40.67422554964586
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01753303130317,
+                40.67082143485483
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.02057314195322,
+                40.672895293775994
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p14",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 5612.0,0.0 5612.0,8268.0 -0.0,8268.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0118314323098,
+                40.67300344157412
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00805063045759,
+                40.67198170440687
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01002137943992,
+                40.66772711740386
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01380218129214,
+                40.668748854571106
               ]
             }
           }
@@ -3281,15 +569,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3308,34 +596,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"339.7,6829.2 319.0,1618.7 5384.5,1611.6 5370.2,5386.8 5523.3,5644.6 5535.6,6829.9 339.7,6829.2\" /></svg>"
+          "value": "<svg><polygon points=\"5523.3,5644.6 5535.6,6829.9 339.7,6829.2 319.0,1618.7 5384.5,1611.6 5370.2,5386.8 5523.3,5644.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5372.0,
-                2928.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01206,
-                40.675781
+                -74.01353904385479,
+                40.678942706923415
               ]
             }
           },
@@ -3343,20 +634,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                328.0,
-                4224.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.015401,
-                40.677098
+                -74.01051771128192,
+                40.67688865741938
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01450792464111,
+                40.673512840139324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01752925721398,
+                40.675566889643356
               ]
             }
           }
@@ -3374,15 +707,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3408,27 +741,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5095.1,
-                4888.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0156533,
-                40.6791877
+                -74.02077111878101,
+                40.678893926719226
               ]
             }
           },
@@ -3436,20 +772,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5095.1,
-                7668.0
+                5599.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0141485,
-                40.678165
+                -74.01805466933392,
+                40.68119278327726
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01357924257137,
+                40.678151170471516
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01629569201846,
+                40.67585231391348
               ]
             }
           }
@@ -3467,15 +845,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3494,34 +872,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5211.5,7334.0 197.3,7342.1 188.0,4776.6 -0.0,4777.8 -0.0,0.0 1241.6,-0.0 1240.0,916.0 5612.0,916.3 5612.0,4303.3 5213.6,4302.0 5211.5,7334.0\" /></svg>"
+          "value": "<svg><polygon points=\"5214.1,7339.9 195.7,7347.4 186.7,4779.7 -0.0,4780.9 -0.0,-0.0 1241.7,-0.0 1240.0,916.0 5612.0,916.8 5612.0,4306.7 5216.5,4305.3 5214.1,7339.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1240.0,
-                916.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0104477,
-                40.6804294
+                -74.01067520587536,
+                40.681265024705716
               ]
             }
           },
@@ -3529,20 +910,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5184.0,
-                916.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.008302,
-                40.67897
+                -74.00762582442383,
+                40.67919149415828
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01165395157082,
+                40.67578439610168
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01470333302235,
+                40.67785792664912
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p21",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5627
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5274.9,6440.0 5112.6,6016.0 4733.9,7096.9 4429.5,6310.9 2565.8,7045.0 2179.0,7025.7 1804.2,7170.9 1742.8,7004.1 1548.4,6994.8 1756.6,7354.8 172.9,7948.1 223.1,180.0 1151.8,193.3 1152.9,0.0 2734.5,0.0 2746.0,216.3 5627.0,257.7 5627.0,6307.0 5274.9,6440.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01065019226695,
+                40.68040285099689
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5627.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00798430086246,
+                40.68271507448344
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5627.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00353649026817,
+                40.67972405848464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00620238167267,
+                40.67741183499809
               ]
             }
           }
@@ -3560,15 +1121,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3587,34 +1148,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"53.2,5748.8 863.0,3570.2 1241.4,3639.3 1288.1,3495.3 -0.0,3077.4 -0.0,-0.0 1975.3,0.0 1992.4,432.0 5152.4,412.0 5185.3,4308.0 5621.0,4303.3 5621.0,7891.1 53.2,5748.8\" /></svg>"
+          "value": "<svg><polygon points=\"5036.8,7671.1 50.8,5755.3 863.0,3570.2 1070.7,3632.5 1241.5,3639.3 1288.2,3495.4 -0.0,3077.5 -0.0,-0.0 1975.3,0.0 1992.4,432.0 5152.4,412.0 5196.1,5592.7 5063.3,5594.7 5036.8,7671.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5184.9,
-                4308.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0039713,
-                40.6823752
+                -74.00640798618423,
+                40.6856109725419
               ]
             }
           },
@@ -3622,20 +1186,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1992.4,
-                432.0
+                5621.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0051587,
-                40.6850009
+                -74.00257160184128,
+                40.68452070897075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5621.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00468671896877,
+                40.680240672261334
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00852310331172,
+                40.681330935832484
               ]
             }
           }
@@ -3653,15 +1259,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "11"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3680,34 +1286,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1821.7,5295.9 948.2,5655.9 844.0,5365.9 857.6,4029.1 -0.0,4387.0 -0.0,708.7 891.3,710.1 893.9,461.9 2068.2,449.8 2323.7,298.0 4760.1,299.7 4762.1,4108.0 3821.2,4493.2 4824.3,7094.8 3705.5,7556.9 3535.9,7127.2 2709.7,7450.6 1821.7,5295.9\" /></svg>"
+          "value": "<svg><polygon points=\"2068.2,449.8 2323.7,298.0 4760.1,299.7 4762.1,4108.0 3821.2,4493.2 4824.3,7094.8 3705.5,7556.9 3535.9,7127.2 2694.9,7456.5 1232.1,3883.4 857.5,4038.7 857.5,4038.7 -0.0,4394.2 -0.0,708.7 891.3,710.1 893.9,461.9 2068.2,449.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3468.0,
-                3076.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.011181,
-                40.674223
+                -74.01454134724736,
+                40.673930343985056
               ]
             }
           },
@@ -3715,20 +1324,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3468.0,
-                304.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.012687,
-                40.675247
+                -74.01180786458863,
+                40.676242714794085
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00731594251071,
+                40.6731884463958
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01004942516944,
+                40.67087607558677
               ]
             }
           }
@@ -3746,15 +1397,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3780,27 +1431,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3832.0,
-                392.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.010793,
-                40.676834
+                -74.0128630592104,
+                40.67541636636283
               ]
             }
           },
@@ -3808,20 +1462,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1248.0,
-                3172.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.010554,
-                40.674758
+                -74.01014121801443,
+                40.67770247697352
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00570023203089,
+                40.674661268225314
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00842207322687,
+                40.672375157614624
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p25",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5622
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5046.8,1792.2 5154.6,7532.7 2359.7,7626.0 2308.1,6405.9 2801.4,5161.0 2978.6,4675.8 721.4,3821.5 1943.7,623.3 5046.8,1792.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00921570211482,
+                40.67951900278084
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5622.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00544080950085,
+                40.678403209213904
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5622.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0075885805216,
+                40.67416472286868
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01136347313556,
+                40.67528051643562
               ]
             }
           }
@@ -3839,15 +1673,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3873,27 +1707,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1688.0,
-                676.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0044835,
-                40.6692758
+                -74.0054776870818,
+                40.66997328919196
               ]
             }
           },
@@ -3901,20 +1738,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3296.0,
-                676.0
+                5464.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0033677,
-                40.6689515
+                -74.00168146591115,
+                40.668869942243
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5464.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00388268106204,
+                40.66451301140092
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00767890223268,
+                40.66561635834988
               ]
             }
           }
@@ -3932,15 +1811,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3959,34 +1838,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,6059.9 0.0,1645.9 615.6,1632.3 586.5,0.0 1475.0,0.0 1476.4,462.5 5497.0,394.6 5497.0,7856.8 2688.5,7920.0 2688.5,6049.6 0.0,6059.9\" /></svg>"
+          "value": "<svg><polygon points=\"2688.5,7295.6 2688.5,6052.0 0.0,6063.0 0.0,1653.7 596.0,1641.8 570.5,0.0 1475.0,0.0 1476.4,462.5 5255.8,396.9 5263.9,7273.5 2688.5,7295.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2688.5,
-                440.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.008337,
-                40.6732973
+                -74.0093232645194,
+                40.67199099089378
               ]
             }
           },
@@ -3994,20 +1876,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2688.5,
-                7920.0
+                5497.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0032316,
-                40.6718496
+                -74.0079207481465,
+                40.67483604585727
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5497.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00227750654223,
+                40.67323583414605
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00368002291512,
+                40.67039077918256
               ]
             }
           }
@@ -4025,15 +1949,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4052,34 +1976,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"478.6,284.8 5229.8,178.3 5270.3,6865.5 5612.0,7294.9 5612.0,7875.5 5355.1,7755.3 4616.2,7714.5 499.7,7813.5 478.6,284.8\" /></svg>"
+          "value": "<svg><polygon points=\"230.1,221.9 5244.8,173.8 5258.4,6885.9 5612.0,7328.9 5612.0,7908.0 5339.9,7779.3 4598.4,7735.3 229.7,7822.9 230.1,221.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5264.0,
-                5072.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0031933,
-                40.6762708
+                -74.00791770584215,
+                40.67455940613674
               ]
             }
           },
@@ -4087,20 +2014,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3992.0,
-                2744.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0050803,
-                40.6760699
+                -74.00651581807284,
+                40.67741368825718
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00097108452135,
+                40.67584731567083
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00237297229066,
+                40.672993033550384
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p29",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/info.json",
+          "type": "ImageService2",
+          "height": 8267,
+          "width": 5490
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2620.1,0.0 3152.5,0.0 3503.4,156.4 5490.0,145.3 5490.0,3081.2 5027.1,3687.7 5019.3,4989.0 5333.9,4993.6 5335.8,8267.0 1444.4,8267.0 1443.9,7972.7 190.0,6836.4 184.1,129.4 2644.0,152.9 2620.1,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0066247195838,
+                40.677123277167404
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5490.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00525528065803,
+                40.67996768744897
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5490.0,
+                8267.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99964436527083,
+                40.67839198605547
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8267.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00101380419659,
+                40.675547575773905
               ]
             }
           }
@@ -4118,15 +2225,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4145,34 +2252,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"470.7,7732.1 471.9,4936.0 978.7,4936.0 980.9,20.0 5599.0,0.0 5599.0,7536.8 3062.2,7534.7 3063.3,7733.6 470.7,7732.1\" /></svg>"
+          "value": "<svg><polygon points=\"470.7,7732.1 471.9,4936.0 978.7,4936.0 980.9,20.0 5599.0,0.0 5599.0,7538.0 3062.2,7536.2 3063.3,7733.6 470.7,7732.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3047.5,
-                4936.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0144115,
-                40.6802395
+                -74.01853835240084,
+                40.68079952196115
               ]
             }
           },
@@ -4180,20 +2290,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                471.9,
-                4936.0
+                5599.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0156533,
-                40.6791877
+                -74.01583878718345,
+                40.68308604370028
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01138733749391,
+                40.680063360925054
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0140869027113,
+                40.677776839185924
               ]
             }
           }
@@ -4211,15 +2363,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4238,34 +2390,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"350.3,7713.2 351.0,5013.2 0.0,5017.3 0.0,3785.9 502.1,3128.6 500.9,1055.9 1233.6,197.5 1232.1,641.5 5021.9,653.8 4957.4,7687.8 350.3,7713.2\" /></svg>"
+          "value": "<svg><polygon points=\"5612.0,7736.4 5167.1,7739.1 5074.5,7739.7 328.9,7768.3 315.0,5026.9 0.0,5030.1 0.0,3720.6 502.1,3054.2 447.2,1006.4 1283.1,0.0 3862.4,0.0 3865.3,166.0 5612.0,154.6 5612.0,7736.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3476.0,
-                4992.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.001122,
-                40.680569
+                -74.00538317870797,
+                40.67974443935658
               ]
             }
           },
@@ -4273,20 +2428,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3892.0,
-                228.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0042923,
-                40.681708
+                -74.00396223797156,
+                40.682641917922176
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99837270657122,
+                40.68104314638505
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99979364730763,
+                40.67814566781946
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p31",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5589
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5344.0,157.3 5417.5,7745.3 630.7,7782.5 602.9,209.3 5344.0,157.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00415352676912,
+                40.682341790609286
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5589.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00272312237162,
+                40.68522607160689
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5589.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99713493665581,
+                40.68360980233807
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99856534105331,
+                40.68072552134046
               ]
             }
           }
@@ -4304,15 +2639,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4338,27 +2673,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1308.2,
-                4012.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9998606,
-                40.685029
+                -74.00292834815038,
+                40.68510909174151
               ]
             }
           },
@@ -4366,20 +2704,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1308.2,
-                7884.0
+                5481.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9972144,
-                40.6842975
+                -74.00156308478344,
+                40.68794904359878
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5481.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99591257300659,
+                40.68638704928058
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99727783637353,
+                40.683547097423315
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p33",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1063.9,221.2 2098.4,232.2 2097.5,0.0 4180.6,0.0 4178.8,254.3 4735.7,260.2 4754.8,7761.4 639.3,7772.3 1063.9,221.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00180723463652,
+                40.687247325145236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00040057575032,
+                40.69017070645431
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99476043880887,
+                40.688588182755204
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99616709769506,
+                40.68566480144613
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p34",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"777.3,7897.3 686.4,316.0 4590.0,323.7 4599.8,0.0 5612.0,0.0 5612.0,8268.0 5497.7,8268.0 5537.2,7857.2 777.3,7897.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00082978273765,
+                40.689373282176334
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99940235714021,
+                40.69225529759834
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99384185437518,
+                40.69064946107583
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99526927997262,
+                40.687767445653826
               ]
             }
           }
@@ -4397,15 +3053,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4424,34 +3080,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,1868.0 5612.0,8268.0 0.0,8268.0 0.0,-0.0 5317.9,0.0 5310.8,1868.1 5612.0,1868.0\" /></svg>"
+          "value": "<svg><polygon points=\"5612.0,1866.3 5612.0,4796.7 5354.5,4796.9 5388.0,6616.0 5612.0,6615.4 5612.0,8268.0 0.0,8268.0 -0.0,-0.0 5319.7,0.0 5312.1,1866.4 5612.0,1866.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5388.0,
-                6616.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9999634,
-                40.6709791
+                -74.005850287224,
+                40.669451035696675
               ]
             }
           },
@@ -4459,20 +3118,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2912.0,
-                6616.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0005895,
-                40.6696941
+                -74.00443273985155,
+                40.672362810864534
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99877670739808,
+                40.67077883289211
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00019425477053,
+                40.66786705772425
               ]
             }
           }
@@ -4490,15 +3191,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4517,34 +3218,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,508.6 5612.0,680.5 5153.5,677.3 5215.1,3217.7 4938.6,3507.8 5612.0,3516.6 5134.4,4008.9 5137.0,5813.1 4549.4,5815.9 4261.2,7148.8 1842.6,6627.2 174.7,8268.0 0.0,8268.0 0.0,6967.7 413.9,6969.7 445.0,612.8 5612.0,508.6\" /></svg>"
+          "value": "<svg><polygon points=\"431.4,3525.1 444.5,619.7 147.1,618.6 152.4,0.0 2703.7,0.0 2699.5,574.1 5612.0,515.2 5612.0,686.8 5147.6,683.5 5209.4,3220.3 4933.4,3510.1 5612.0,3512.4 5128.9,4010.4 5131.7,5812.0 4542.2,5814.8 4273.3,7061.5 1921.2,6547.8 172.8,8268.0 0.0,8268.0 0.0,6964.9 416.0,6966.8 423.3,5328.3 201.2,5327.9 176.1,3524.2 431.4,3525.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1436.0,
-                5328.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9996512,
-                40.6716259
+                -74.00369616369301,
+                40.671890549115176
               ]
             }
           },
@@ -4552,20 +3256,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3896.0,
-                596.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0023003,
-                40.6738155
+                -74.00228382468379,
+                40.67483206118704
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9965697927817,
+                40.67325396838077
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99798213179092,
+                40.670312456308906
               ]
             }
           }
@@ -4583,15 +3329,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4610,34 +3356,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2105.8,1330.6 3402.8,1371.6 3656.0,1491.2 3658.1,917.9 4405.5,1514.4 5612.0,1433.1 5612.0,6665.1 875.7,6684.1 858.9,4862.7 1344.7,4354.1 657.2,4358.4 934.1,4063.3 851.8,1499.1 1314.8,1498.7 1313.7,1356.4 2105.8,1340.2 2105.8,1330.6\" /></svg>"
+          "value": "<svg><polygon points=\"851.8,1499.1 1321.4,1498.8 1320.0,1325.3 3402.8,1371.6 3670.5,1498.1 3670.3,928.4 4583.9,1684.3 4603.6,6674.5 875.7,6684.1 858.9,4862.7 1344.7,4354.1 657.2,4358.4 934.1,4063.3 851.8,1499.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3312.0,
-                6680.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9977713,
-                40.6747317
+                -74.00316664793728,
+                40.67430682905204
               ]
             }
           },
@@ -4645,20 +3394,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4592.0,
-                4352.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.999033,
-                40.6758417
+                -74.00174016118456,
+                40.67720794971257
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99610448951955,
+                40.675614077633476
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99753097627227,
+                40.67271295697295
               ]
             }
           }
@@ -4676,15 +3467,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4703,34 +3494,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4594.9,2021.5 4611.1,6724.3 1690.2,6730.6 1723.8,2020.5 4594.9,2021.5\" /></svg>"
+          "value": "<svg><polygon points=\"694.1,2022.8 4594.9,2023.9 4611.1,6724.3 679.0,6732.8 694.1,2022.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1932.0,
-                4404.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9987227,
-                40.6764868
+                -74.00220476031842,
+                40.67631857533353
               ]
             }
           },
@@ -4738,20 +3532,1028 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                684.0,
-                4404.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.999033,
-                40.6758417
+                -74.00080940486976,
+                40.679219457705344
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99517407565476,
+                40.67766040323039
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99656943110342,
+                40.67475952085858
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p39",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"370.8,1191.0 5100.1,1125.8 5180.8,6606.1 3189.5,6400.7 484.9,6430.0 370.8,1191.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00094990070521,
+                40.6784562719506
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99949550342926,
+                40.681355257426524
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99390317592547,
+                40.67971880981682
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99535757320142,
+                40.676819824340896
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p4",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5599
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01601132658732,
+                40.681995629985
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01344728624474,
+                40.68435452137627
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00888692080667,
+                40.68146345517954
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01145096114925,
+                40.67910456378827
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p40",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,1276.2 5612.0,1223.9 5612.0,7407.2 2363.1,7030.7 2426.5,6418.2 1413.5,6274.0 1423.9,6928.1 0.0,6765.0 0.0,1276.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99970675102247,
+                40.68116659317188
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99826297816232,
+                40.68406570124366
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99267018593672,
+                40.682441274224054
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99411395879687,
+                40.679542166152274
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p41",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1451.5,7704.3 679.3,1557.7 5017.2,961.6 5251.2,3872.7 4575.7,3964.7 4649.8,7667.3 1451.5,7704.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99865902259704,
+                40.68389752999197
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99675682061233,
+                40.68663137804022
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99148265041815,
+                40.684491236613766
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99338485240285,
+                40.681757388565515
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p42",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"210.4,7749.7 189.0,4043.8 866.3,3961.4 673.5,1045.2 4784.7,529.8 5137.0,3444.4 4077.4,3572.7 4098.7,7761.2 210.4,7749.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99723821616055,
+                40.686025468105974
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99538843212711,
+                40.68877765052266
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99007871964822,
+                40.68669655100341
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99192850368166,
+                40.68394436858672
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p44",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 429.7,-0.0 3932.3,1273.5 3811.4,-0.0 5612.0,-0.0 5612.0,8268.0 -0.0,8268.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99649616977781,
+                40.66867180604661
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99337955931648,
+                40.666850390278924
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99689252504905,
+                40.66334300630131
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00000913551038,
+                40.665164422069
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0045/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p45",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0045/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0045/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3172.6 -0.0,754.3 5202.6,740.3 5224.6,5769.5 5612.0,6015.7 5612.0,6120.1 5394.6,6100.0 5209.0,8268.0 1526.3,8268.0 821.1,4968.4 2099.9,4689.1 2062.8,4519.5 -0.0,3172.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0045/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99744512889825,
+                40.67313653242267
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99397296558014,
+                40.67146974936219
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99721061558016,
+                40.66758989936222
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00068277889827,
+                40.6692566824227
               ]
             }
           }
@@ -4769,15 +4571,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4796,34 +4598,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6287.5 450.0,5761.3 430.3,366.1 4281.3,380.4 4280.7,0.0 5612.0,0.0 5612.0,8268.0 -0.0,8268.0 -0.0,6287.5 -0.0,6287.5\" /></svg>"
+          "value": "<svg><polygon points=\"4272.6,6716.4 4279.8,7659.1 1249.7,6246.2 467.6,5744.0 470.8,374.9 4303.1,405.4 4304.2,0.0 5612.0,0.0 5612.0,6559.2 4274.4,6429.3 4272.6,6716.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4280.0,
-                5536.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9940294,
-                40.6678529
+                -73.99453248124023,
+                40.671714164113354
               ]
             }
           },
@@ -4831,20 +4636,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4280.0,
-                1672.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.992527,
-                40.669655
+                -73.99105580185967,
+                40.67006219632055
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99426445101747,
+                40.66617703017043
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99774113039803,
+                40.667828997963234
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p47",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,1293.6 5612.0,120.0 5612.0,7814.3 0.0,7759.9 0.0,1293.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99933826918792,
+                40.67354504815265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99715943039132,
+                40.67620861842415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99202165008123,
+                40.673756850607454
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99420048887782,
+                40.67109328033595
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p48",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4687.0,7270.5 866.7,7290.1 824.7,1985.6 -0.0,1994.8 -0.0,1047.4 817.2,1033.2 816.0,880.0 4631.2,860.3 4623.8,0.0 5612.0,0.0 5612.0,6854.2 4682.8,6866.4 4687.0,7270.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99202316698177,
+                40.67506831349301
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9885645085911,
+                40.673376686814166
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9918503932733,
+                40.66951190048415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99530905166397,
+                40.671203527162994
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p49",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"376.1,2016.0 5325.8,1087.6 5179.8,7366.1 3921.6,7334.9 3924.1,7216.1 3942.7,6352.7 1216.4,6318.9 1192.2,8268.0 259.8,8268.0 376.1,2016.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99850473115805,
+                40.67657555352703
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99637432127106,
+                40.67929081757478
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99113658754246,
+                40.67689365530751
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99326699742944,
+                40.67417839125976
               ]
             }
           }
@@ -4862,15 +5123,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4889,34 +5150,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5325.6,7856.1 -0.0,7588.6 -0.0,-0.0 5599.0,0.0 5599.0,8268.0 5441.2,8268.0 5325.6,7856.1\" /></svg>"
+          "value": "<svg><polygon points=\"5325.6,7856.0 -0.0,7588.7 0.0,-0.0 5599.0,0.0 5599.0,8268.0 5441.2,8268.0 5325.6,7856.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2815.5,
-                6624.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0085336,
-                40.6829405
+                -74.01338406340243,
+                40.68395876715373
               ]
             }
           },
@@ -4924,20 +5188,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2815.5,
-                7728.0
+                5599.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0079286,
-                40.6825753
+                -74.01094568350642,
+                40.68628177445389
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00642295294578,
+                40.68355168982463
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00886133284179,
+                40.68122868252448
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p51",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"747.1,758.1 2748.5,685.7 2773.8,684.9 4205.8,645.8 4103.3,0.0 5126.0,0.0 5149.5,615.1 4973.1,621.0 5025.3,4005.9 5270.4,3995.3 5382.4,7363.1 4195.7,7391.7 373.8,7153.1 747.1,758.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99653604814714,
+                40.67867813792115
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99457082906797,
+                40.68139433519853
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98933112245936,
+                40.6791831204484
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99129634153853,
+                40.67646692317102
               ]
             }
           }
@@ -4955,15 +5399,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4982,34 +5426,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4673.6,659.6 4695.7,7368.6 1057.2,7380.9 1264.3,666.8 4673.6,659.6\" /></svg>"
+          "value": "<svg><polygon points=\"819.9,4030.4 574.9,4034.9 626.7,668.1 5612.0,657.5 5612.0,7359.5 828.3,7381.7 819.9,4030.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3408.0,
-                4024.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9912964,
-                40.6814334
+                -73.9950434994133,
+                40.68078075614647
               ]
             }
           },
@@ -5017,20 +5464,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2112.0,
-                7376.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.989559,
-                40.679946
+                -73.99316516299663,
+                40.68353737747197
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98780978008692,
+                40.6814387972622
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98968811650359,
+                40.6786821759367
               ]
             }
           }
@@ -5048,15 +5537,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5075,34 +5564,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4780.0,7464.0 885.1,7472.2 916.4,714.1 4814.1,736.0 4780.0,7464.0\" /></svg>"
+          "value": "<svg><polygon points=\"1808.1,7470.2 1861.7,719.4 4814.1,736.0 4780.0,7464.0 1808.1,7470.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2192.0,
-                7464.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9882767,
-                40.6818589
+                -73.99381288536831,
+                40.68263748543883
               ]
             }
           },
@@ -5110,20 +5602,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4780.0,
-                7464.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.98743,
-                40.683126
+                -73.9919768419371,
+                40.685385153599576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98663870671581,
+                40.683333881505575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98847475014702,
+                40.68058621334483
               ]
             }
           }
@@ -5141,15 +5675,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5168,34 +5702,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"686.9,668.2 4591.2,679.3 4579.7,7402.0 689.7,7367.2 689.3,6478.9 639.0,6478.7 686.9,668.2\" /></svg>"
+          "value": "<svg><polygon points=\"4613.4,681.1 4554.0,7380.0 677.9,7317.6 722.8,642.2 4613.4,681.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3272.0,
-                7380.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.986564,
-                40.684389
+                -73.99241854085955,
+                40.68461497772268
               ]
             }
           },
@@ -5203,20 +5740,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1984.0,
-                668.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.991332,
-                40.685448
+                -73.99057405174341,
+                40.687386526381935
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98518933939808,
+                40.685325888365014
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98703382851421,
+                40.68255433970576
               ]
             }
           }
@@ -5234,15 +5813,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5268,27 +5847,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2784.0,
-                5616.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.991509,
-                40.687959
+                -73.99607790098662,
+                40.68795934205568
               ]
             }
           },
@@ -5296,20 +5878,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3484.0,
-                424.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9946743,
-                40.6895809
+                -73.99426174304894,
+                40.690737651991036
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9888636402174,
+                40.688708760770176
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99067979815509,
+                40.68593045083482
               ]
             }
           }
@@ -5327,15 +5951,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5354,34 +5978,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"768.0,7400.0 796.1,710.6 4977.0,738.4 4968.2,0.0 5612.0,0.0 5606.8,7406.3 768.0,7400.0\" /></svg>"
+          "value": "<svg><polygon points=\"768.0,7400.0 796.1,710.6 4977.0,738.4 4968.2,0.0 5612.0,0.0 5612.0,7406.3 768.0,7400.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3348.0,
-                4064.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.987429,
-                40.687138
+                -73.99118556006933,
+                40.68650981980096
               ]
             }
           },
@@ -5389,20 +6016,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                768.0,
-                7400.0
+                5612.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9861154,
-                40.6850247
+                -73.9893212694148,
+                40.689278768435884
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98394144647752,
+                40.687196071150545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98580573713204,
+                40.68442712251562
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p57",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/info.json",
+          "type": "ImageService2",
+          "height": 8267,
+          "width": 5630
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"962.3,8267.0 978.6,7327.1 107.9,7314.0 155.1,3440.6 0.0,3438.2 0.0,-0.0 2792.8,0.0 2783.7,1006.5 5240.6,1038.1 5154.8,7388.7 5630.0,7397.2 5630.0,8267.0 962.3,8267.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99403995560492,
+                40.67533201219269
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5630.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99191045668385,
+                40.67797133601486
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5630.0,
+                8267.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9868373910836,
+                40.67558366071124
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8267.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98896689000466,
+                40.67294433688907
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p58",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5556
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,8184.2 482.8,8177.6 471.2,7315.5 0.0,7313.5 0.0,1017.7 2654.9,1023.2 5107.2,807.3 5426.0,4131.7 4146.5,4245.1 4428.5,7264.6 5556.0,7162.7 5556.0,8268.0 0.0,8268.0 0.0,8184.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99204547115094,
+                40.677791967255054
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5556.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98987960100067,
+                40.68039674481055
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5556.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98480426663261,
+                40.67793515968195
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98697013678289,
+                40.675330382126454
               ]
             }
           }
@@ -5420,15 +6365,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5447,34 +6392,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"782.8,4235.0 2069.7,4236.3 2068.0,904.0 5516.0,896.1 5516.0,8268.0 1807.0,8268.0 1953.4,7260.1 776.8,7261.1 782.8,4235.0\" /></svg>"
+          "value": "<svg><polygon points=\"782.8,4235.0 2069.7,4236.3 2068.0,904.0 5516.0,896.1 5516.0,8268.0 1814.6,8268.0 1953.4,7260.1 776.8,7261.1 782.8,4235.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3360.0,
-                7264.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.984998,
-                40.678977
+                -73.99083450154907,
+                40.67915554268384
               ]
             }
           },
@@ -5482,20 +6430,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2068.0,
-                904.0
+                5516.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.989559,
-                40.679946
+                -73.98899850047363,
+                40.68187259261229
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5516.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98362825547842,
+                40.679785561745746
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98546425655387,
+                40.677068511817296
               ]
             }
           }
@@ -5513,15 +6503,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5547,27 +6537,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2531.5,
-                7656.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0054824,
-                40.6843278
+                -74.01140336093422,
+                40.68444451791083
               ]
             }
           },
@@ -5575,20 +6568,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5099.1,
-                7656.0
+                5599.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0048438,
-                40.6856737
+                -74.01001077526442,
+                40.687379502334515
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00429648867589,
+                40.68582034268563
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0056890743457,
+                40.68288535826195
               ]
             }
           }
@@ -5606,15 +6641,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5640,27 +6675,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3215.4,
-                4231.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.985672,
-                40.681642
+                -73.98951945184719,
+                40.68113822513071
               ]
             }
           },
@@ -5668,20 +6706,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1955.6,
-                7239.1
+                5503.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.984139,
-                40.680246
+                -73.98765597026541,
+                40.683858331930196
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5503.0,
+                8267.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98226782468124,
+                40.681735498957714
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8267.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98413130626302,
+                40.67901539215823
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p61",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5629
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1890.4,8268.0 1892.6,7273.8 893.4,7279.6 876.3,899.7 4747.4,925.0 4773.2,7268.8 5629.0,7267.4 5629.0,8268.0 1890.4,8268.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98830783921487,
+                40.68292355649303
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5629.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98642018704093,
+                40.68569386084086
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5629.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9810533574357,
+                40.68359093282069
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98294100960963,
+                40.680820628472866
               ]
             }
           }
@@ -5699,15 +6917,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5726,34 +6944,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"675.9,7341.5 666.2,940.4 5549.0,935.4 5549.0,8268.0 1552.8,8268.0 1553.1,7342.2 675.9,7341.5\" /></svg>"
+          "value": "<svg><polygon points=\"682.2,7302.9 672.6,934.7 5549.0,929.6 5549.0,8268.0 1538.9,8268.0 1541.3,7303.6 682.2,7302.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1964.4,
-                4300.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.983522,
-                40.684816
+                -73.98694413764773,
+                40.684930185980186
               ]
             }
           },
@@ -5761,20 +6982,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3264.6,
-                4300.0
+                5549.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.983092,
-                40.685451
+                -73.98509954990118,
+                40.68765414025341
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5549.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.97974623393006,
+                40.68556962880063
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9815908216766,
+                40.68284567452741
               ]
             }
           }
@@ -5792,15 +7055,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5826,27 +7089,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5235.1,
-                5688.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0044976,
-                40.6863169
+                -74.00603853919905,
+                40.687245702316496
               ]
             }
           },
@@ -5854,20 +7120,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5235.1,
-                6968.0
+                5599.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0048438,
-                40.6856737
+                -74.00418479179268,
+                40.68673486557919
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00517246293776,
+                40.684644870831406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00702621034414,
+                40.68515570756871
               ]
             }
           }
@@ -5885,15 +7193,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5912,34 +7220,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4242.1,7596.4 1044.2,7591.2 1030.5,7153.8 -0.0,7145.6 -0.0,-0.0 4235.0,0.0 4242.1,7596.4\" /></svg>"
+          "value": "<svg><polygon points=\"4242.1,7596.4 1044.2,7591.2 1030.5,7153.8 -0.0,7145.6 -0.0,-0.0 4234.9,0.0 4242.1,7596.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4231.2,
-                3696.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0020408,
-                40.6864013
+                -74.00398760100249,
+                40.68909043228258
               ]
             }
           },
@@ -5947,20 +7258,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1031.8,
-                6284.0
+                5599.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0048438,
-                40.6856737
+                -74.00020011083825,
+                40.688040077287724
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00224497950184,
+                40.68379928422346
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00603246966608,
+                40.68484963921832
               ]
             }
           }
@@ -5978,15 +7331,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:10:13Z",
-      "modified": "2026-08-07T14:10:13Z",
+      "created": "2026-08-15T00:28:13Z",
+      "modified": "2026-08-15T00:28:13Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6012,27 +7365,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4527.2,
-                7760.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0004427,
-                40.6896644
+                -74.00728552594524,
+                40.68878566575863
               ]
             }
           },
@@ -6040,20 +7396,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1051.8,
-                7760.0
+                5599.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0013897,
-                40.6877592
+                -74.00575986426513,
+                40.69185503284723
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99978344328129,
+                40.69014702142662
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0013091049614,
+                40.68707765433802
               ]
             }
           }

--- a/gallery/champaign_ill_1915.iiif.json
+++ b/gallery/champaign_ill_1915.iiif.json
@@ -24,8 +24,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"121.2,573.0 5981.9,588.0 5957.3,6880.4 908.3,6874.3 276.0,7650.0 -0.0,7650.0 121.2,573.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7650.0 120.8,570.3 5981.8,589.1 5954.2,6882.9 904.0,6873.6 270.4,7650.0 -0.0,7650.0\" /></svg>"
         }
       },
       "body": {
@@ -73,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23717577791308,
-                40.11857464765783
+                -88.23717571954084,
+                40.11857328602701
               ]
             }
           },
@@ -94,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23325765557708,
-                40.11859772696669
+                -88.23325854437522,
+                40.118598286955056
               ]
             }
           },
@@ -115,8 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23322211026372,
-                40.11501870680545
+                -88.23322003950373,
+                40.11502013198932
               ]
             }
           },
@@ -136,8 +136,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23714023259973,
-                40.11499562749659
+                -88.23713721466936,
+                40.11499513106127
               ]
             }
           }
@@ -162,8 +162,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -182,7 +182,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6344.1,7629.9 142.5,7650.0 100.0,-0.0 6450.0,-0.0 5911.2,86.2 5912.6,248.7 6313.5,247.2 6344.1,7629.9\" /></svg>"
+          "value": "<svg><polygon points=\"6349.2,7618.6 148.4,7650.0 93.1,-0.0 3070.9,-0.0 3070.9,-0.0 6450.0,-0.0 5903.8,76.4 5905.5,238.8 6306.3,236.7 6349.2,7618.6\" /></svg>"
         }
       },
       "body": {
@@ -211,8 +211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2288235835531,
-                40.11839045697794
+                -88.22882355458553,
+                40.11838718718772
               ]
             }
           },
@@ -232,8 +232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2288215778791,
-                40.11532855481421
+                -88.2288281811557,
+                40.11532495049612
               ]
             }
           },
@@ -253,8 +253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23353733367053,
-                40.11532672272741
+                -88.23354445242573,
+                40.1153291766454
               ]
             }
           },
@@ -274,8 +274,438 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23353933934452,
-                40.118388624891146
+                -88.23353982585556,
+                40.11839141333701
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0012/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p12",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0012/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0012/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6450.0,7266.7 595.5,7167.5 586.8,641.0 5967.2,658.2 5967.4,6345.3 6450.0,6500.0 6450.0,7266.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0012/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2471883533897,
+                40.11598760100227
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24321128830798,
+                40.11600245152233
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24318825584548,
+                40.11239492370049
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24716532092721,
+                40.11238007318043
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p13 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7650.0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"57.8,79.4 1672.9,50.3 1671.5,329.4 3462.1,0.0 6450.0,71.6 6450.0,7270.3 5339.4,7650.0 2499.6,7650.0 57.8,79.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24354160411866,
+                40.11680613270729
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23974637012189,
+                40.11589126709505
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2411653161658,
+                40.11244875336688
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24496055016257,
+                40.113363618979115
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0014/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p14",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0014/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0014/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6450.0,7293.8 652.9,7245.4 2965.7,463.2 4350.6,932.3 4348.5,1466.5 5844.1,1427.7 6450.0,972.3 6450.0,7293.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0014/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24140401640169,
+                40.11600632686536
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23745780537868,
+                40.11605511788802
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23738213333893,
+                40.11247555096215
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24132834436193,
+                40.112426759939495
               ]
             }
           }
@@ -300,8 +730,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +750,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6273.8,6703.6 -0.0,6773.7 -0.0,6269.6 1212.9,6264.8 1221.7,5994.3 428.6,5353.9 414.7,273.0 5203.0,264.2 6224.2,405.5 6273.8,6703.6\" /></svg>"
+          "value": "<svg><polygon points=\"6267.9,6701.3 -0.0,6764.2 -0.0,6260.8 1211.5,6258.4 1219.9,5993.0 428.7,5350.8 427.8,272.0 5214.0,275.4 6234.5,419.2 6267.9,6701.3\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +779,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23336112153646,
-                40.11557027174073
+                -88.23336233055356,
+                40.11557673924251
               ]
             }
           },
@@ -370,8 +800,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23334673268809,
-                40.112571713270775
+                -88.23333800973276,
+                40.11257697639325
               ]
             }
           },
@@ -391,8 +821,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2379647382767,
-                40.112558569202555
+                -88.23795787180923,
+                40.11255475957609
               ]
             }
           },
@@ -412,8 +842,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23797912712507,
-                40.11555712767251
+                -88.23798219263003,
+                40.115554522425356
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0016/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p16",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0016/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0016/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6003.7,168.8 6031.9,7620.7 5036.8,7478.6 367.8,7462.3 399.2,162.6 -0.0,160.7 -0.0,0.0 6450.0,-0.0 6450.0,169.2 6003.7,168.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0016/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.22887486288836,
+                40.11558429437112
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.22883876740971,
+                40.11250926595949
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23360795642425,
+                40.112476524117824
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2336440519029,
+                40.11555155252945
               ]
             }
           }
@@ -438,8 +1006,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +1026,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"805.2,7555.4 815.2,96.6 1258.8,93.7 1259.2,-0.0 5732.0,-0.0 5855.1,62.7 5839.4,7553.2 805.2,7555.4\" /></svg>"
+          "value": "<svg><polygon points=\"5837.6,7552.8 804.0,7553.7 816.1,95.9 5855.3,63.3 5837.6,7552.8\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +1055,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.22889342475328,
-                40.11311297045757
+                -88.22889404433515,
+                40.113113440521055
               ]
             }
           },
@@ -508,8 +1076,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.22883715623357,
-                40.11001917074556
+                -88.22883668846531,
+                40.11001925301682
               ]
             }
           },
@@ -529,8 +1097,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23360166651737,
-                40.109967768141956
+                -88.2336017959565,
+                40.109966857093546
               ]
             }
           },
@@ -550,8 +1118,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2336579350371,
-                40.11306156785397
+                -88.23365915182634,
+                40.11306104459778
               ]
             }
           }
@@ -576,8 +1144,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +1164,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"687.2,94.7 5882.9,125.8 5882.1,0.0 6450.0,0.0 6450.0,7650.0 663.8,7650.0 687.2,94.7\" /></svg>"
+          "value": "<svg><polygon points=\"686.5,93.8 5881.9,124.9 5881.2,0.0 6450.0,0.0 6450.0,7650.0 663.0,7650.0 686.5,93.8\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +1193,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2324659043214,
-                40.11032261872298
+                -88.23246549032154,
+                40.110322206041005
               ]
             }
           },
@@ -646,8 +1214,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.22853710000925,
-                40.11036700452275
+                -88.22853648199116,
+                40.11036662915556
               ]
             }
           },
@@ -667,8 +1235,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2284687480668,
-                40.106777791065916
+                -88.22846807258577,
+                40.106777229315064
               ]
             }
           },
@@ -688,8 +1256,762 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23239755237896,
-                40.10673340526615
+                -88.23239708091616,
+                40.10673280620051
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0019/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p19",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0019/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0019/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"435.6,172.3 4982.7,203.9 4973.6,2808.4 6211.3,2807.1 6187.1,6663.5 6450.0,6631.9 6450.0,7650.0 -0.0,7650.0 -0.0,818.8 428.8,824.0 435.6,172.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0019/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23963592224617,
+                40.112782667377424
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23181786811209,
+                40.11288926812044
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23165254641869,
+                40.10579716958616
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23947060055276,
+                40.105690568843144
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p20 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7650.0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6450.0,794.2 6020.7,793.4 6092.0,7632.2 -0.0,7650.0 -0.0,116.5 3076.1,128.5 3076.4,0.0 3741.5,0.0 4152.0,132.7 6450.0,141.7 6450.0,794.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24691547699763,
+                40.112717146226444
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23910551876136,
+                40.11276134958036
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23903696615439,
+                40.10567658114702
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24684692439065,
+                40.10563237779311
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p20 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3475.1"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3372.1"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2974.9"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "4277.9"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3475.1,7650.0 3475.1,3502.1 6174.9,3503.5 6216.8,7650.0 3475.1,7650.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3475.1,
+                3372.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25021735252224,
+                40.11273905514908
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                3372.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24657739705566,
+                40.11273151895685
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24659156832368,
+                40.108727823730085
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3475.1,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25023152379026,
+                40.10873535992231
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p21 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7650.0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3241.9,7650.0 -0.0,7650.0 -0.0,-0.0 5929.1,0.0 5923.6,299.6 6450.0,303.4 6450.0,1329.0 6031.2,1322.5 6034.5,7438.6 4034.5,7412.0 4034.7,7277.2 3242.6,7275.7 3241.9,7650.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2615672245225,
+                40.11943064194892
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25380585045832,
+                40.11947482480822
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25373731625282,
+                40.11243550410747
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.261498690317,
+                40.11239132124816
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p21 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "2621.9"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "4258.5"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5028.1"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"142.4,7336.7 -0.0,7335.8 0.0,2621.9 4258.5,2621.9 4258.5,7379.9 4056.0,7379.1 4055.2,7494.5 2976.3,7494.5 2975.7,7650.0 2179.9,7650.0 2181.3,7496.0 143.6,7501.5 142.4,7336.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                2621.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24378734062331,
+                40.130528215426196
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4258.5,
+                2621.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23861062739591,
+                40.130561423587466
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4258.5,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23855932127347,
+                40.125884965537594
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24373603450087,
+                40.125851757376324
               ]
             }
           }
@@ -714,8 +2036,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +2056,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6358.3,7353.8 136.1,7327.3 93.5,1215.8 479.0,1219.3 469.8,194.7 6338.1,186.5 6344.1,1214.4 6244.2,1214.3 6067.3,1214.3 6066.2,3390.3 6343.5,3390.0 6358.3,7353.8\" /></svg>"
+          "value": "<svg><polygon points=\"136.4,7327.3 94.1,1215.3 515.7,1219.0 509.1,194.1 6450.0,184.8 6450.0,4011.5 6346.8,4011.6 6359.2,7354.1 136.4,7327.3\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +2085,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.25441137844643,
-                40.11937445950966
+                -88.25441207072697,
+                40.11937389124388
               ]
             }
           },
@@ -784,8 +2106,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.24669946935029,
-                40.119380872460475
+                -88.24670085185541,
+                40.11938055040663
               ]
             }
           },
@@ -805,8 +2127,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.24668959266037,
-                40.11233630888404
+                -88.24669059597042,
+                40.11233661737346
               ]
             }
           },
@@ -826,8 +2148,1776 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.25440150175652,
-                40.11232989593322
+                -88.25440181484198,
+                40.11232995821071
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p23 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3239.6"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 785.5,0.0 785.6,133.5 6082.7,184.6 6057.8,3239.6 -0.0,3239.6 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25760011863616,
+                40.11275797878201
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24977333553879,
+                40.112790665573606
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                3239.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24975185847792,
+                40.10978306120129
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3239.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2575786415753,
+                40.10975037440969
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p23 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "2295.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5355.0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,2295.0 6176.7,2295.0 6197.9,3666.7 6197.9,3666.7 6252.3,7360.4 -0.0,7443.8 0.0,2295.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                2295.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25436747380333,
+                40.12398582086723
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                2295.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24652456702175,
+                40.123919627199676
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24659646464872,
+                40.11893755496152
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2544393714303,
+                40.119003748629076
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0024/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p24",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0024/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0024/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1772.7,7650.0 1773.6,7584.5 -0.0,7560.3 -0.0,0.0 6450.0,-0.0 6450.0,264.5 6376.2,235.3 6292.4,7113.9 5724.8,7103.4 5704.6,7650.0 1772.7,7650.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0024/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.22864328860202,
+                40.12423533943329
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.22850422509804,
+                40.1182787210577
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23774357858173,
+                40.11815259144473
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23788264208571,
+                40.124109209820325
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p2 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7650.0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 6061.1,0.0 6060.2,7329.0 679.7,7317.1 674.0,4734.9 -0.0,4725.9 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24727601606793,
+                40.12613785405885
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24332815297792,
+                40.12614466655117
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2433175856168,
+                40.12256413701583
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2472654487068,
+                40.122557324523505
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p3 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7650.0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5961.2,6885.9 410.8,6850.4 432.7,179.6 4410.1,152.7 4408.6,453.4 5961.9,447.1 5961.2,6885.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24383293233426,
+                40.126075649001514
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23981598327998,
+                40.126088910254616
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23979541441135,
+                40.12244543197991
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24381236346562,
+                40.12243217072681
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__3/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p3 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "4847.5"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "1041.9"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1602.5"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "1072.7"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__3/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6450.0,2114.6 4847.5,2114.6 4847.5,1041.9 6450.0,1041.9 6450.0,2114.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__3/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4847.5,
+                1041.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.26511767563571,
+                40.11740719569534
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                1041.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.26412787309886,
+                40.11740707298687
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                2114.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.26412798032767,
+                40.116901140662485
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4847.5,
+                2114.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.26511778286452,
+                40.116901263370956
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p4 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3727.2"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7650.0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1336.0,7650.0 -0.0,7650.0 -0.0,232.8 2093.8,224.1 2094.3,0.0 3727.2,0.0 3727.2,7650.0 1516.7,7650.0 1520.2,7095.5 1336.0,7650.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24012014984677,
+                40.12613117289529
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3727.2,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23778542191684,
+                40.12613866639653
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3727.2,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2377652956011,
+                40.122472322536865
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24010002353103,
+                40.12246482903563
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004__3/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p4 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3726.8"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "2151.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2723.2"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2405.8"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004__3/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3726.8,4556.8 4141.9,2289.4 3726.8,2151.0 6450.0,2151.0 6450.0,4556.8 3726.8,4556.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004__3/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3726.8,
+                2151.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25017425853163,
+                40.12294501736342
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                2151.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25041073709949,
+                40.12356119764335
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                4556.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24970336514006,
+                40.12372216970275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3726.8,
+                4556.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24946688657221,
+                40.123105989422825
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0005/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p5",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0005/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0005/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"642.6,7442.2 615.6,0.0 5963.8,0.0 5974.6,5935.7 6090.4,5938.7 5950.2,6380.4 5947.7,7370.9 642.6,7442.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0005/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24722893144134,
+                40.12271381733172
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24325727124027,
+                40.12271398329788
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24325701383958,
+                40.11911128736389
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24722867404066,
+                40.11911112139774
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0006/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p6",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0006/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0006/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6450.0,-0.0 6275.3,7280.6 -0.0,7308.3 -0.0,1579.2 744.6,1574.6 735.9,187.5 158.7,-0.0 6450.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0006/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23914905125723,
+                40.12280685448773
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23915709727186,
+                40.1198310307522
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24377289879858,
+                40.119838328462116
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24376485278395,
+                40.12281415219764
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0007/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p7",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0007/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0007/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5882.1,61.1 5966.1,7650.0 756.1,7650.0 760.5,121.5 5882.1,61.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0007/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24716615326386,
+                40.11926661755609
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2432188361979,
+                40.11927174715164
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24321088010252,
+                40.115691352854846
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24715819716849,
+                40.115686223259296
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0008/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p8",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0008/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0008/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1968.3,7488.5 -0.0,1526.0 -0.0,1049.9 3319.2,0.0 6450.0,0.0 6450.0,1348.5 4753.0,1851.8 5600.6,4709.7 6007.7,4817.9 6017.7,6115.9 6398.3,7399.0 5400.4,7401.9 4624.9,7650.0 3592.4,7650.0 3593.4,7455.8 1968.3,7488.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0008/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24328277982455,
+                40.12038849219966
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23951372229789,
+                40.11947306156796
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24093340597892,
+                40.116053957519156
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24470246350559,
+                40.116969388150856
               ]
             }
           }
@@ -852,8 +3942,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
+      "created": "2026-08-15T00:34:32Z",
+      "modified": "2026-08-15T00:34:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +3962,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3609.3,7555.9 3597.3,7023.4 2194.7,6592.5 1862.7,7650.0 1553.6,7650.0 1907.1,6495.1 -0.0,5899.1 -0.0,4551.2 388.0,3190.7 -0.0,3034.2 -0.0,-0.0 6206.0,0.0 6202.5,7089.1 5703.2,7096.1 5898.3,6766.0 5109.4,7477.5 3609.3,7555.9\" /></svg>"
+          "value": "<svg><polygon points=\"5070.8,7521.1 3659.6,7588.0 3642.6,7046.5 2222.2,6620.7 1911.4,7650.0 1599.6,7650.0 1930.9,6524.3 -0.0,5935.3 -0.0,4519.8 366.8,3176.9 -0.0,3029.3 -0.0,-0.0 6215.9,0.0 6278.6,7092.3 5729.7,7065.6 5070.8,7521.1\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +3991,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2408808401785,
-                40.11891665908206
+                -88.24084903081123,
+                40.11888628528437
               ]
             }
           },
@@ -922,8 +4012,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23695035295286,
-                40.11888535819397
+                -88.23695781970405,
+                40.118829219664384
               ]
             }
           },
@@ -943,8 +4033,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23699856085122,
-                40.1152950597475
+                -88.23704632958855,
+                40.11529971906625
               ]
             }
           },
@@ -964,2115 +4054,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.24092904807686,
-                40.11532636063559
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0012/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p12",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0012/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0012/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6450.0,7266.7 595.5,7167.5 586.8,626.0 5967.2,649.3 5967.4,6345.4 6450.0,6500.1 6450.0,7266.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0012/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3277.0,
-                3436.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2451574,
-                40.1143744
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                584.2,
-                3436.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2468178,
-                40.1143682
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p13 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "13"
-        },
-        {
-          "label": "intersections",
-          "value": "31"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6450.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7650.0"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"57.8,79.4 1672.9,50.4 1671.5,258.2 2648.6,261.5 3462.1,0.0 6450.0,71.4 6450.0,7270.2 5339.1,7650.0 2499.7,7650.0 57.8,79.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1680.5,
-                1408.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.242814,
-                40.115934
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2920.9,
-                172.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.241855,
-                40.116314
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0014/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p14",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0014/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0014/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"623.5,7259.1 624.7,7255.7 358.6,7252.6 2274.1,1475.5 2584.1,1483.3 2943.8,423.6 4339.7,894.2 4338.3,1432.4 5844.8,1391.1 6450.0,937.0 6450.0,7299.8 623.5,7259.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0014/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3265.0,
-                3456.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.239363,
-                40.114406
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2504.8,
-                1740.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2398409,
-                40.1151976
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0016/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p16",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "18"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0016/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0016/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6003.7,168.8 6031.9,7620.7 5036.8,7478.6 367.8,7462.3 399.2,162.6 -0.0,160.7 -0.0,0.0 6450.0,-0.0 6450.0,169.2 6003.7,168.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0016/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2376.7,
-                2520.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.230433,
-                40.1144404
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2376.7,
-                7474.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.233521,
-                40.1144192
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0019/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p19",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0019/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0019/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7650.0 -0.0,828.7 -0.0,176.2 4949.5,184.0 4954.1,2801.9 6198.2,2794.2 6194.0,6637.3 6450.0,6636.7 6450.0,7650.0 -0.0,7650.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0019/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6197.9,
-                5317.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2320085,
-                40.1079555
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4949.5,
-                184.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.233592,
-                40.112676
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p20 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6450.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7650.0"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"96.2,4032.9 108.4,120.3 3084.5,141.8 3085.2,0.0 3708.0,0.0 4166.2,149.6 6075.9,163.4 6093.2,7595.0 6450.0,7594.1 6450.0,7650.0 -0.0,7650.0 -0.0,4030.6 96.2,4032.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1464.5,
-                4045.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.245106,
-                40.108981
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2828.9,
-                2768.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.243467,
-                40.110178
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p20 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "3475.1"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "3372.1"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "2974.9"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "4277.9"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3475.1,7650.0 3475.1,3502.1 6268.8,3503.5 6307.0,7381.7 6211.6,7380.7 6215.1,7650.0 3475.1,7650.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4922.6,
-                4519.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2484501,
-                40.1116615
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3603.0,
-                6150.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.25007,
-                40.1101382
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p21 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6450.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7650.0"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3114.6,7650.0 -0.0,7650.0 -0.0,-0.0 5972.3,0.0 5965.7,314.8 6450.0,319.5 6450.0,1337.3 6069.9,1330.4 6057.7,7401.3 4072.6,7369.8 4073.1,7246.0 3253.2,7245.4 3253.1,7356.6 3115.8,7357.0 3114.6,7650.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6065.9,
-                3460.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.254277,
-                40.11628
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6065.9,
-                2388.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.25429,
-                40.117274
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p21 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "22"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "2621.9"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "4258.5"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "5028.1"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"143.6,7501.5 142.4,7336.7 -0.0,7335.8 -0.0,7032.3 140.1,7033.8 135.1,5878.8 -0.0,5878.8 0.0,2621.9 4258.5,2621.9 4258.5,7379.9 4056.0,7379.1 4055.2,7494.5 143.6,7501.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2181.3,
-                4849.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.241113,
-                40.128473
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2181.3,
-                7494.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.241086,
-                40.126012
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p23 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6450.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "3239.6"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 816.1,0.0 815.7,123.1 6093.2,194.0 6056.8,3239.6 -0.0,3239.6 -0.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1412.4,
-                1151.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2559076,
-                40.1116846
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6189.9,
-                2855.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.25007,
-                40.1101382
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p23 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "31"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "2295.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6450.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "5355.0"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7443.8 0.0,2295.0 6177.2,2295.0 6252.3,7360.4 -0.0,7443.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3493.1,
-                5278.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2501601,
-                40.1211743
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6197.9,
-                3666.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2468495,
-                40.122646
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0024/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p24",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "14"
-        },
-        {
-          "label": "intersections",
-          "value": "24"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0024/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0024/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1797.8,7650.0 1798.6,7577.1 -0.0,7557.0 -0.0,0.0 6450.0,-0.0 6450.0,300.8 6347.8,299.3 6282.1,7098.7 5659.4,7088.8 5645.0,7650.0 1797.8,7650.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0024/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4457.4,
-                5705.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.235438,
-                40.120023
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1204.4,
-                1568.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.230464,
-                40.123111
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p2 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "1480.1"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "2105.8"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1210.1,1137.5 1210.1,1436.9 -0.0,1429.5 -0.0,-0.0 1343.1,-0.0 1348.1,1139.0 1210.1,1137.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2452473397441,
-                40.127489522754544
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1480.1,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24342081155675,
-                40.12750117825744
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1480.1,
-                2105.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2433991464121,
-                40.125515248686895
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                2105.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24522567459945,
-                40.125503593184
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1348.1,
-                1136.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.243563,
-                40.125991
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1348.1,
-                1136.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.243572,
-                40.126426
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p2 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6450.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7650.0"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"675.0,4734.9 -0.0,4725.9 -0.0,-0.0 6061.1,0.0 6060.2,7328.9 679.7,7317.1 675.0,4734.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                672.2,
-                3312.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24686,
-                40.124588
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3345.0,
-                7466.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2452183,
-                40.122647
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p3 [3]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5983.4,6934.4 406.1,6869.5 440.7,158.8 6267.4,131.8 6253.5,2416.9 5992.5,2417.6 5983.4,6934.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                424.1,
-                4385.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.243557,
-                40.123988
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2436.8,
-                148.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.242326,
-                40.126002
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p4 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "3727.2"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7650.0"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1336.0,7650.0 -0.0,7650.0 -0.0,2491.9 258.3,2490.7 267.5,231.0 2093.8,224.1 2094.3,0.0 3727.2,0.0 3727.2,7650.0 1507.6,7650.0 1512.7,7117.9 1336.0,7650.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2093.8,
-                2504.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.238802,
-                40.124935
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2093.8,
-                224.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.238808,
-                40.126028
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0005/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p5",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "18"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0005/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0005/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"642.4,7442.1 615.6,0.0 5964.1,0.0 5974.7,5935.8 6076.4,5938.6 5950.4,6333.4 5947.8,7371.0 642.4,7442.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0005/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3289.0,
-                5361.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2452035,
-                40.120189
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                616.2,
-                144.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2468495,
-                40.122646
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0006/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p6",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0006/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0006/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6290.2,7278.2 -0.0,7326.9 -0.0,1577.5 720.8,1570.6 707.4,178.7 151.0,-0.0 6450.0,-0.0 6290.2,7278.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0006/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3713.2,
-                5529.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24249,
-                40.121099
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3713.2,
-                1116.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.239837,
-                40.121088
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0007/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p7",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0007/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0007/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"539.4,7650.0 543.8,6437.8 -0.0,6438.7 -0.0,2142.1 542.7,2142.1 529.9,112.6 5886.6,43.3 5979.7,7650.0 539.4,7650.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0007/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3249.0,
-                4233.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2451734,
-                40.117288
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                544.2,
-                4233.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2468229,
-                40.1172873
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0008/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p8",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "29"
-        }
-      ],
-      "created": "2026-08-07T13:49:54Z",
-      "modified": "2026-08-07T13:49:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0008/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0008/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1980.4,7476.6 -0.0,1503.1 -0.0,1077.3 3393.4,0.0 6450.0,0.0 6450.0,1272.8 4674.5,1818.9 5563.2,4706.9 5975.8,4743.1 6007.6,6150.8 6402.4,7433.7 5397.6,7385.4 4574.6,7650.0 3596.4,7650.0 3597.1,7441.9 1980.4,7476.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0008/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3597.1,
-                4705.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.242054,
-                40.117775
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3597.1,
-                7441.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2425666,
-                40.1165462
+                -88.24093754069574,
+                40.115356784686234
               ]
             }
           }

--- a/gallery/chicago_il_1950_vol_1.iiif.json
+++ b/gallery/chicago_il_1950_vol_1.iiif.json
@@ -7,6 +7,1954 @@
   "label": "Mosaic of main content, Chicago, Ill. | 1950 | Vol. 1",
   "items": [
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0100W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p100W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0100W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0100W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5882
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2642.3,1003.2 5882.0,1008.8 5882.0,7323.0 2594.4,7323.0 2642.3,1003.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0100W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64325603273544,
+                41.872530530577855
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5882.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64316643273544,
+                41.870012980577876
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5882.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64737752867354,
+                41.869929874459615
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64746712867354,
+                41.872447424459594
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0101W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p101W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0101W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0101W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5844
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4130.9,1244.3 4196.0,6231.1 1785.5,6239.8 1736.0,1251.8 4130.9,1244.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0101W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64488199258466,
+                41.87252661084342
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5844.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64132500931967,
+                41.87256681412231
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5844.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6412573472518,
+                41.869247301787716
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64481433051678,
+                41.86920709850883
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0102W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p102W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0102W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0102W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5882
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1752.1,6222.2 1712.6,1287.8 2492.4,1291.2 2456.1,6222.5 1752.1,6222.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0102W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64342528269003,
+                41.872565094608
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5882.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63980846766626,
+                41.872619566930354
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5882.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63971735197777,
+                41.86926488733432
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64333416700154,
+                41.86921041501196
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0103W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p103W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0103W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0103W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5844
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4116.0,1227.8 4163.2,7256.3 1698.1,7323.0 1684.0,6207.2 -0.0,6218.9 -0.0,1254.0 4116.0,1227.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0103W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64188649921302,
+                41.87256735904658
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5844.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63831557538666,
+                41.87260157160975
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5844.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63825799550382,
+                41.86926905994464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64182891933018,
+                41.86923484738147
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0104W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p104W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0104W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0104W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5901
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1435.4,0.0 5901.0,0.0 5901.0,7323.0 1441.7,7323.0 1435.4,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0104W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6402509630634,
+                41.87258500833729
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5901.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63667152682473,
+                41.87263953340149
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5901.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63658063231397,
+                41.86933076928056
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64016006855263,
+                41.86927624421636
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0107W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p107W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0107W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0107W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5849
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3479.2,1059.6 3328.4,7323.0 -0.0,7323.0 -0.0,6997.4 2212.8,7029.4 2299.5,1041.6 3479.2,1059.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0107W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6431734146165,
+                41.871057968809986
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5849.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64302815694103,
+                41.86841979305969
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5849.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64746510157319,
+                41.868284323802925
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64761035924866,
+                41.870922499553224
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0108W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p108W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0108W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0108W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5877
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5877.0,7323.0 -0.0,7323.0 -0.0,1035.1 5085.5,1000.0 5090.8,1717.0 5266.0,1714.1 5877.0,1703.6 5877.0,7323.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0108W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64309714628303,
+                41.86947702944121
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5877.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6430364746142,
+                41.86680630909084
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5877.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64750661417013,
+                41.866749993794784
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64756728583895,
+                41.86942071414515
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0109W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p109W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0109W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0109W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5861
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"961.5,7323.0 956.9,6657.8 1686.5,6659.9 1704.3,947.9 4149.9,968.5 4132.4,7323.0 961.5,7323.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0109W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64477519590584,
+                41.87011317280579
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5861.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6412601042751,
+                41.8701843387212
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5861.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64114066400423,
+                41.866912745118405
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64465575563496,
+                41.86684157920299
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0010N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p10N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0010N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0010N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5809
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4111.8,735.4 4137.5,6529.2 1684.3,6531.1 1684.4,742.2 4111.8,735.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0010N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63226533696016,
+                41.89695332571653
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5809.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.628765454517,
+                41.89699870919339
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5809.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62868857731608,
+                41.89371324215053
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63218845975925,
+                41.89366785867367
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0110W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p110W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0110W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0110W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5877
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4116.8,7323.0 -0.0,7323.0 -0.0,7194.0 1724.8,7181.4 1696.3,963.9 4080.7,963.9 4116.8,7323.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0110W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64332216706114,
+                41.87015571270638
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5877.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63971917343699,
+                41.87020895163253
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5877.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63963006371081,
+                41.866864685979436
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64323305733497,
+                41.86681144705329
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0111W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p111W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0111W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0111W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5861
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"407.3,2165.4 5861.0,2152.1 5861.0,7323.0 401.2,7323.0 407.3,2165.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0111W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64107903347865,
+                41.87023757940655
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5861.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63745353912296,
+                41.87030967414951
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5861.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63733253990783,
+                41.86693532733602
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64095803426352,
+                41.86686323259306
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0011N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p11N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0011N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0011N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5806
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4181.5,763.3 4123.4,6591.3 1511.9,6558.9 1563.3,734.1 906.4,727.2 914.8,0.0 5806.0,0.0 5806.0,774.1 4181.5,763.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0011N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63073086981497,
+                41.89696159601064
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5806.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62725052013559,
+                41.897041048874286
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5806.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62711591978727,
+                41.893774195010465
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63059626946665,
+                41.89369474214682
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0012N__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p12N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5809.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7323.0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0012N__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0012N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5809
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4063.6,731.1 4036.7,6523.1 1791.6,6518.4 1806.8,730.8 4063.6,731.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0012N__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62931093323958,
+                41.8969877435453
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5809.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62580543452202,
+                41.897048609518244
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5809.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62570232191237,
+                41.89375815373924
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62920782062993,
+                41.8936972877663
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0013N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p13N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0013N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0013N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5806
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"826.2,6472.7 875.1,689.7 229.2,685.6 226.7,0.0 5806.0,4.2 5806.0,6497.6 5191.1,6493.0 5189.0,7302.5 4894.3,7298.9 4901.5,6486.2 826.2,6472.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0013N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6273851250309,
+                41.897001398681084
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5806.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62389920903864,
+                41.89707265625339
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5806.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6237793383715,
+                41.893777481341345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62726525436376,
+                41.89370622376904
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0014N/georef",
       "type": "Annotation",
       "@context": [
@@ -24,8 +1972,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +1992,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"463.3,742.7 519.7,0.0 4724.0,0.0 4792.9,6485.2 420.4,6521.9 431.0,7323.0 135.8,7323.0 147.0,974.7 180.3,749.0 463.3,742.7\" /></svg>"
+          "value": "<svg><polygon points=\"4780.7,6491.5 1024.3,6509.5 944.7,8.2 4735.4,0.0 4780.7,6491.5\" /></svg>"
         }
       },
       "body": {
@@ -73,8 +2021,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62445859850105,
-                41.89707286647876
+                -87.62446555864122,
+                41.897068060922884
               ]
             }
           },
@@ -94,8 +2042,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62097636506903,
-                41.89710257427952
+                -87.62098326458106,
+                41.8971073069061
               ]
             }
           },
@@ -115,8 +2063,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62092639007187,
-                41.89381088327099
+                -87.6209172442817,
+                41.89381555858691
               ]
             }
           },
@@ -136,8 +2084,300 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6244086235039,
-                41.893781175470224
+                -87.62439953834186,
+                41.89377631260369
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0015N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p15N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0015N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0015N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5806
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 5806.0,0.0 5806.0,6515.8 -0.0,6540.0 -0.0,770.7 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0015N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62162717763039,
+                41.897111077388104
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5806.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61813355282418,
+                41.89716791176815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5806.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61803727102641,
+                41.89388857019512
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62153089583262,
+                41.89383173581507
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p16N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5798.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7323.0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5798
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,6369.5 1041.4,6455.9 1576.0,0.0 5798.0,0.0 5798.0,5735.0 5182.8,5700.1 5598.7,6843.8 1536.8,6495.9 1489.4,7323.0 -0.0,7323.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61904557697103,
+                41.89699253253875
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5798.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61567909321438,
+                41.897255330849944
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5798.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61523327973931,
+                41.894090965748326
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61859976349596,
+                41.893828167437135
               ]
             }
           }
@@ -162,8 +2402,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -182,7 +2422,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2551.6,955.3 4288.4,936.3 4342.6,6122.1 667.2,5661.7 587.4,1763.6 2569.1,1768.6 2551.6,955.3\" /></svg>"
+          "value": "<svg><polygon points=\"643.6,5836.3 660.2,987.0 886.7,984.1 899.5,1800.3 2231.7,1779.5 2551.4,962.8 4287.1,941.5 4777.1,7323.0 309.8,7323.0 252.0,6836.8 643.6,5836.3\" /></svg>"
         }
       },
       "body": {
@@ -211,8 +2451,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64299555419213,
-                41.89432592389173
+                -87.64299566561156,
+                41.894331044050666
               ]
             }
           },
@@ -232,8 +2472,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63951258955389,
-                41.89434073362772
+                -87.63951051708473,
+                41.894342444694715
               ]
             }
           },
@@ -253,8 +2493,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6394876774322,
-                41.89104820832493
+                -87.63949133954229,
+                41.89104785617473
               ]
             }
           },
@@ -274,8 +2514,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64297064207044,
-                41.89103339858893
+                -87.64297648806912,
+                41.89103645553068
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0018N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p18N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0018N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0018N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5798
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5560.5,6348.8 419.5,6371.9 353.9,5526.3 -0.0,4887.1 -0.0,965.4 5529.6,957.4 5560.5,6348.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0018N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64042910301265,
+                41.89434858931977
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5798.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63693757029787,
+                41.89439019082168
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5798.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63686699907443,
+                41.8911081939471
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6403585317892,
+                41.891066592445185
               ]
             }
           }
@@ -300,8 +2678,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +2698,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4097.2,6359.5 1710.7,6336.9 1713.4,963.0 4113.8,974.3 4097.2,6359.5\" /></svg>"
+          "value": "<svg><polygon points=\"4098.0,6362.0 1712.5,6340.8 1712.1,969.3 4111.5,979.2 4098.0,6362.0\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +2727,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63813042687698,
-                41.8943748957784
+                -87.63812992628746,
+                41.894378365649736
               ]
             }
           },
@@ -370,8 +2748,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63465580922596,
-                41.894433246718016
+                -87.63465370586738,
+                41.89443527863561
               ]
             }
           },
@@ -391,8 +2769,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63455743697442,
-                41.89114134152142
+                -87.63455775782268,
+                41.89114185495142
               ]
             }
           },
@@ -412,8 +2790,560 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63803205462546,
-                41.8910829905818
+                -87.63803397824276,
+                41.891084941965545
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0020N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p20N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0020N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0020N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5798
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4270.9,7323.0 1725.6,7323.0 1703.4,915.9 4227.6,916.7 4270.9,7323.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0020N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63668259510305,
+                41.89437463306395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5798.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63320084841557,
+                41.89441885406766
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5798.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63312583387815,
+                41.891146042393665
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63660758056564,
+                41.89110182138995
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p21N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5794
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1660.6,6269.7 1660.6,948.3 4193.6,963.5 4183.2,2736.0 3926.7,2735.8 3870.1,6279.2 1660.6,6269.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63516382482419,
+                41.894410136314995
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63162208945063,
+                41.894474971406424
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63151201426267,
+                41.89114299546659
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63505374963623,
+                41.89107816037516
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0022N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p22N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0022N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0022N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5798
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1586.8,5327.5 1618.2,2779.1 1876.1,2777.4 1873.7,994.8 4182.6,995.9 4180.6,5329.3 1586.8,5327.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0022N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63373577410202,
+                41.89445399829072
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5798.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6302102628733,
+                41.89449970139917
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5798.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63013273404451,
+                41.891185756354105
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63365824527322,
+                41.89114005324566
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0023N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p23N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0023N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0023N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5794
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4101.4,965.8 4121.7,6354.7 1644.6,6365.1 1643.3,969.5 4101.4,965.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0023N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63217980679045,
+                41.8944579676204
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62869600332802,
+                41.894501277624364
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62862247285393,
+                41.89122380132639
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63210627631636,
+                41.89118049132242
               ]
             }
           }
@@ -438,8 +3368,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +3388,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1604.1,6286.2 1575.7,915.2 4189.3,907.8 4218.8,6276.2 1604.1,6286.2\" /></svg>"
+          "value": "<svg><polygon points=\"1578.6,920.2 4190.2,917.4 4215.0,7323.0 1600.8,7323.0 1578.6,920.2\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +3417,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63065661710057,
-                41.89445646009629
+                -87.63065996048834,
+                41.89445771137243
               ]
             }
           },
@@ -508,8 +3438,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62718234663949,
-                41.894496378435605
+                -87.62718332837184,
+                41.89450221931281
               ]
             }
           },
@@ -529,8 +3459,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62711510541465,
-                41.89120755046282
+                -87.627108356104,
+                41.89121115574021
               ]
             }
           },
@@ -550,8 +3480,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63058937587573,
-                41.89116763212351
+                -87.6305849882205,
+                41.89116664779983
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0025N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p25N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0025N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0025N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5794
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5053.9,6273.9 613.4,6298.3 595.1,936.5 5026.6,917.2 5053.9,6273.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0025N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6285072346345,
+                41.894494084335335
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62500763837204,
+                41.89453909773114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6249312162501,
+                41.891246750101345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62843081251256,
+                41.89120173670554
               ]
             }
           }
@@ -576,8 +3644,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +3664,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"701.5,4428.3 688.8,877.9 2562.2,867.4 2561.7,1078.5 2560.3,1734.0 2855.2,1757.8 2851.7,872.3 5190.0,875.8 5194.4,4422.1 2846.5,4430.8 2853.6,4222.2 2339.5,4430.3 701.5,4428.3\" /></svg>"
+          "value": "<svg><polygon points=\"672.7,4419.0 683.9,851.9 2553.0,853.3 2545.7,1669.1 2839.5,1672.7 2841.8,860.0 5174.6,878.6 5155.0,4441.5 2812.6,4435.2 2821.1,4225.7 2306.8,4431.4 672.7,4419.0\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +3693,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6258863796507,
-                41.89450969640195
+                -87.62588737613194,
+                41.89449417751849
               ]
             }
           },
@@ -646,8 +3714,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62239969802705,
-                41.894563799116
+                -87.62239311351152,
+                41.894565060211725
               ]
             }
           },
@@ -667,8 +3735,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62230862639267,
-                41.891265499699614
+                -87.62227295413659,
+                41.89128274748851
               ]
             }
           },
@@ -688,8 +3756,162 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62579530801631,
-                41.89121139698556
+                -87.62576721675701,
+                41.891211864795274
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0027N__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p27N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5794.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7322.0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0027N__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0027N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5794
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"915.4,7322.0 897.6,6355.3 -0.0,6359.2 -0.0,4489.1 882.1,4514.5 856.3,964.3 4931.7,911.6 4953.2,4542.8 1787.8,4535.1 1814.1,7322.0 915.4,7322.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0027N__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62328035582473,
+                41.894589659648524
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6197966591012,
+                41.89462722958323
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61973287415901,
+                41.89134984301235
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62321657088255,
+                41.891312273077645
               ]
             }
           }
@@ -714,8 +3936,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +3956,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1142.5,6279.7 265.3,6280.5 263.7,951.4 4007.7,953.8 4007.8,0.0 4455.3,0.0 4600.8,4557.3 3393.2,4552.1 3382.0,7323.0 1145.3,7323.0 1142.5,6279.7\" /></svg>"
+          "value": "<svg><polygon points=\"263.8,4546.8 267.7,955.9 2999.6,956.3 3076.0,1868.4 4510.9,1750.3 4583.7,4557.8 3397.3,4553.3 3387.4,7323.0 2990.4,7323.0 2981.1,4543.7 263.8,4546.8\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +3985,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62047902117733,
-                41.89464133475886
+                -87.62048129906034,
+                41.89464360226303
               ]
             }
           },
@@ -784,8 +4006,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.61697726338974,
-                41.89469945326196
+                -87.61697774916297,
+                41.89470049010646
               ]
             }
           },
@@ -805,8 +4027,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.61687943172728,
-                41.891386899363866
+                -87.61688198908658,
+                41.89138624092828
               ]
             }
           },
@@ -826,8 +4048,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62038118951487,
-                41.89132878086077
+                -87.62038553898395,
+                41.89132935308485
               ]
             }
           }
@@ -852,8 +4074,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +4094,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4259.5,4653.9 -0.0,4521.9 -0.0,949.3 3890.8,1065.6 3431.0,0.0 5753.0,0.0 5753.0,7323.0 4177.3,7323.0 4259.5,4653.9\" /></svg>"
+          "value": "<svg><polygon points=\"4279.6,4651.4 -0.0,4524.1 -0.0,952.1 3906.4,1063.9 3445.7,0.0 5753.0,0.0 5753.0,7323.0 4200.7,7323.0 4279.6,4651.4\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +4123,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.61777631848665,
-                41.894688277242345
+                -87.61778538504258,
+                41.894689525451184
               ]
             }
           },
@@ -922,8 +4144,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.61427724428114,
-                41.894816493801876
+                -87.61428566281018,
+                41.89481443405595
               ]
             }
           },
@@ -943,8 +4165,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.61405946428852,
-                41.89147655730408
+                -87.61407350161063,
+                41.891473877044355
               ]
             }
           },
@@ -964,8 +4186,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.61755853849402,
-                41.89134834074455
+                -87.61757322384304,
+                41.89134896843959
               ]
             }
           }
@@ -990,8 +4212,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1010,7 +4232,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1737.3,6534.7 1733.2,6306.2 -0.0,6345.5 0.0,0.0 3774.5,0.0 4075.6,987.4 4167.7,7323.0 2163.2,7323.0 2145.0,6528.9 1737.3,6534.7\" /></svg>"
+          "value": "<svg><polygon points=\"2466.8,6515.6 -0.0,6422.5 0.0,0.0 2348.5,0.0 2466.8,6515.6\" /></svg>"
         }
       },
       "body": {
@@ -1039,8 +4261,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64393387961776,
-                41.89678823196648
+                -87.64393278869615,
+                41.896788883606284
               ]
             }
           },
@@ -1060,8 +4282,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64046725113641,
-                41.89679642116035
+                -87.64046231735183,
+                41.89679380044346
               ]
             }
           },
@@ -1081,8 +4303,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64045356005063,
-                41.893539653184824
+                -87.64045409714677,
+                41.893533422885874
               ]
             }
           },
@@ -1102,8 +4324,438 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.643920188532,
-                41.89353146399095
+                -87.64392456849109,
+                41.893528506048696
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0030N__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p30N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5803.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7323.0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0030N__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0030N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5803
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5803.0,6352.7 2591.2,6375.7 2531.3,4764.2 -0.0,4856.6 0.0,-0.0 5803.0,-0.0 5803.0,6352.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0030N__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6112965968757,
+                41.892601001381045
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5803.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6112598985505,
+                41.890068522264926
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5803.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61555282016823,
+                41.8900340491107
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61558951849344,
+                41.89256652822682
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0031N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p31N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0031N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0031N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5753
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4762.7,7209.3 4762.8,7323.0 2696.6,7323.0 2698.7,6432.3 -0.0,6516.2 -0.0,1077.6 5162.4,1024.0 5206.2,6429.4 3430.3,6432.5 3476.5,7201.7 4762.7,7209.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0031N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64012159902136,
+                41.89197714230881
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5753.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63667138635385,
+                41.89200308260336
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5753.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63662701713173,
+                41.8887327052236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64007722979923,
+                41.888706764929054
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0032N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p32N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0032N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0032N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5803
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1667.7,1063.9 4081.4,1042.5 4167.3,4659.4 1300.6,7323.0 -0.0,7323.0 -0.0,6544.3 1667.7,1063.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0032N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63801115283317,
+                41.892009713045866
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5803.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63456940920166,
+                41.89202042114924
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5803.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63455125761804,
+                41.88878732652261
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63799300124955,
+                41.888776618419236
               ]
             }
           }
@@ -1128,8 +4780,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1148,7 +4800,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1703.5,3842.2 1653.4,0.0 4192.4,0.0 4216.1,2787.6 5825.0,2776.0 5825.0,4576.2 4228.7,4583.1 4225.5,3817.3 1703.5,3842.2\" /></svg>"
+          "value": "<svg><polygon points=\"1697.9,3826.4 1670.0,2043.7 4208.6,2035.3 4213.2,2790.3 5825.0,2779.4 5825.0,4581.1 4225.0,4587.3 4222.1,3833.3 1697.9,3826.4\" /></svg>"
         }
       },
       "body": {
@@ -1177,8 +4829,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63659665636945,
-                41.89202821062543
+                -87.63659364365849,
+                41.8920275255911
               ]
             }
           },
@@ -1198,8 +4850,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63308643030594,
-                41.892062780200696
+                -87.63308630883311,
+                41.892063325698054
               ]
             }
           },
@@ -1219,8 +4871,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63302844108432,
-                41.888753482865994
+                -87.63302625543875,
+                41.888756754104236
               ]
             }
           },
@@ -1240,8 +4892,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63653866714783,
-                41.88871891329073
+                -87.63653359026412,
+                41.88872095399728
               ]
             }
           }
@@ -1266,8 +4918,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1286,7 +4938,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3465.7,4487.3 3516.0,2682.5 1839.0,2708.3 1813.4,974.1 4059.6,940.1 4111.5,4478.1 3465.7,4487.3\" /></svg>"
+          "value": "<svg><polygon points=\"3469.1,4487.2 3515.4,2681.7 1837.8,2708.9 1810.8,974.0 4057.8,938.1 4112.7,4477.5 3469.1,4487.2\" /></svg>"
         }
       },
       "body": {
@@ -1315,8 +4967,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63514808673196,
-                41.892010852437586
+                -87.63514559598732,
+                41.89201132186661
               ]
             }
           },
@@ -1336,8 +4988,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63164473201049,
-                41.89202398794957
+                -87.63164360349501,
+                41.89202226030384
               ]
             }
           },
@@ -1357,8 +5009,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6316226976696,
-                41.8887211672936
+                -87.63162525466664,
+                41.88872072390223
               ]
             }
           },
@@ -1378,8 +5030,698 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63512605239106,
-                41.888708031781626
+                -87.63512724715896,
+                41.888709785465004
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0035N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p35N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0035N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0035N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5831
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1417.2,4555.9 1415.5,0.0 4043.1,0.0 4043.9,2795.6 5831.0,2803.3 5831.0,4608.9 1417.2,4555.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0035N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63355575320176,
+                41.892045128028926
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5831.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6300678611656,
+                41.89208851872039
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5831.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6299946619451,
+                41.88882778909901
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63348255398127,
+                41.888784398407545
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0036N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p36N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0036N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0036N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5825
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1760.8,978.5 4244.7,971.9 4248.2,2763.9 3725.0,4767.7 1758.6,2749.3 1760.8,978.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0036N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.632193487197,
+                41.89204362775459
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5825.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62870081531024,
+                41.89209111543048
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5825.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62862059423999,
+                41.88882144341263
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63211326612675,
+                41.88877395573674
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0037N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p37N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0037N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0037N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5831
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1462.8,2932.0 4098.7,2964.6 4092.7,3706.3 1455.7,3688.3 1462.8,2932.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0037N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63054615263155,
+                41.892457278353945
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5831.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62707984473316,
+                41.89253355343847
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5831.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62695117001816,
+                41.889293006921704
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63041747791655,
+                41.88921673183718
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0038N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p38N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0038N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0038N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5825
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4215.8,3649.3 1944.6,3650.0 1948.3,1839.7 4227.5,1844.3 4215.8,3649.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0038N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62924690166999,
+                41.8924557150334
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5825.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6258075061246,
+                41.89251580638564
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5825.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62570600722229,
+                41.88929557784557
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62914540276768,
+                41.889235486493334
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0039N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p39N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0039N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0039N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5866
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1821.1,1706.4 3192.8,1707.9 3224.9,3499.7 1806.7,3494.0 1821.1,1706.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0039N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62783673162758,
+                41.892425596418576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62433856982608,
+                41.892490881018695
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62422909661178,
+                41.88924018012583
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62772725841329,
+                41.88917489552571
               ]
             }
           }
@@ -1404,8 +5746,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1424,7 +5766,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1683.4,1065.4 1403.3,84.2 5879.0,0.0 5879.0,759.1 4257.2,757.8 4124.8,1044.3 4126.8,6524.6 1658.4,6515.6 1683.4,1065.4\" /></svg>"
+          "value": "<svg><polygon points=\"5879.0,0.0 5879.0,752.6 4257.0,752.6 4124.9,1039.1 4131.4,6517.7 1663.8,6510.7 1331.6,7322.0 -0.0,7322.0 0.0,0.0 5879.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +5795,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64253873910751,
-                41.89681824215971
+                -87.64253906477585,
+                41.89681757821723
               ]
             }
           },
@@ -1474,8 +5816,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6390093259649,
-                41.896873405795596
+                -87.63900849333068,
+                41.89687059499653
               ]
             }
           },
@@ -1495,8 +5837,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63891771538992,
-                41.8935797570404
+                -87.63892044805309,
+                41.89357586531324
               ]
             }
           },
@@ -1516,8 +5858,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64244712853254,
-                41.89352459340451
+                -87.64245101949825,
+                41.89352284853394
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0040N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p40N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0040N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0040N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5820
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"708.9,118.1 4261.3,58.2 4252.2,1899.3 2816.1,1898.5 2828.5,3620.8 2607.9,3621.1 2592.4,1898.3 708.0,1898.4 708.9,118.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0040N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6258440520623,
+                41.89256911194674
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5820.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62229016812654,
+                41.89262051139748
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5820.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62220327817984,
+                41.889291288372476
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6257571621156,
+                41.889239888921736
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0041N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p41N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0041N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0041N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5866
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,0.0 5866.0,0.0 5866.0,7323.0 0.0,7323.0 -0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0041N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63716059168397,
+                41.880083567987874
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63718465570587,
+                41.8807413642413
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6360889197717,
+                41.880763899495086
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6360648557498,
+                41.88010610324166
               ]
             }
           }
@@ -1542,8 +6160,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1562,7 +6180,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"48.1,7323.0 -0.0,2535.3 418.1,2553.4 420.4,748.0 2849.1,760.4 2847.2,0.0 5382.5,0.0 5280.7,7323.0 48.1,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"130.0,7323.0 115.9,6428.7 -0.0,6430.6 -0.0,2579.4 439.7,2592.1 420.6,793.0 2824.0,775.9 2812.8,0.0 5321.7,0.0 5308.4,7323.0 130.0,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -1591,8 +6209,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6372461954406,
-                41.89027250941568
+                -87.63724394910724,
+                41.89029632414608
               ]
             }
           },
@@ -1612,8 +6230,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63375786032289,
-                41.890332777578365
+                -87.63371814608512,
+                41.89032506205913
               ]
             }
           },
@@ -1633,8 +6251,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63365669588082,
-                41.887041769386634
+                -87.63366956709727,
+                41.887022009288565
               ]
             }
           },
@@ -1654,8 +6272,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63714503099854,
-                41.88698150122395
+                -87.6371953701194,
+                41.886993271375516
               ]
             }
           }
@@ -1680,8 +6298,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1700,7 +6318,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,6714.1 1918.0,6618.8 1695.2,177.3 4226.1,0.0 4382.0,3315.0 4261.3,4429.6 4354.4,6749.6 5143.2,6730.5 5153.5,6943.6 4449.3,6961.5 4331.2,6811.6 4248.7,7031.4 2586.6,7140.8 2596.5,7323.0 -0.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,6725.6 1925.7,6650.4 1691.9,183.3 4218.2,0.0 4379.1,3311.7 4260.4,4424.6 4357.0,6740.7 5144.5,6720.3 5161.2,7056.0 -0.0,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -1729,8 +6347,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63504193896757,
-                41.890083822835855
+                -87.63504129054755,
+                41.890087918673224
               ]
             }
           },
@@ -1750,8 +6368,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6314684290398,
-                41.89001248111111
+                -87.63146205590618,
+                41.890012267485126
               ]
             }
           },
@@ -1771,8 +6389,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63158728219172,
-                41.88666639863036
+                -87.63158808849346,
+                41.88666082462629
               ]
             }
           },
@@ -1792,8 +6410,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63516079211949,
-                41.88673774035511
+                -87.63516732313482,
+                41.88673647581439
               ]
             }
           }
@@ -1818,8 +6436,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,7 +6456,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6887.7 1982.4,54.5 5828.0,92.1 5828.0,291.3 4133.3,6936.5 2516.4,7323.0 2516.4,7323.0 -0.0,7323.0 -0.0,6887.7\" /></svg>"
+          "value": "<svg><polygon points=\"64.9,6682.9 2025.8,109.6 5828.0,152.8 5828.0,319.7 5828.0,344.1 5828.0,7323.0 -0.0,7323.0 64.9,6682.9\" /></svg>"
         }
       },
       "body": {
@@ -1867,8 +6485,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63370061612522,
-                41.890003458088295
+                -87.63378679811055,
+                41.8900279336632
               ]
             }
           },
@@ -1888,8 +6506,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63007375322286,
-                41.89007864096241
+                -87.62999312245698,
+                41.890110782682804
               ]
             }
           },
@@ -1909,8 +6527,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.629947727374,
-                41.88666161705789
+                -87.62985328015476,
+                41.886561287501486
               ]
             }
           },
@@ -1930,8 +6548,1526 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63357459027635,
-                41.886586434183776
+                -87.63364695580833,
+                41.88647843848188
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0045N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p45N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0045N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0045N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5866
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6866.3 -0.0,6738.3 -0.0,6527.5 1665.2,0.0 4110.8,0.0 5866.0,7002.9 5866.0,7323.0 1645.0,7323.0 -0.0,6866.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0045N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63210307226578,
+                41.889910333580026
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6285263216079,
+                41.889967237527394
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62843085248959,
+                41.88664158480938
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63200760314747,
+                41.886584680862015
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0046N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p46N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0046N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0046N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"326.9,7094.9 376.1,6873.7 1565.4,6884.5 1552.0,1539.8 4248.0,1539.8 4130.4,3160.4 4284.5,3114.1 4336.1,3264.4 4339.9,5407.3 5828.0,5410.9 5828.0,7323.0 326.9,7094.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0046N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63049755126106,
+                41.889900535065564
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62709910956964,
+                41.88993728432373
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62703707367558,
+                41.886757900655745
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.630435515367,
+                41.88672115139758
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0047N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p47N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0047N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0047N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5866
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"514.0,3643.9 515.4,2068.9 -0.0,2070.2 -0.0,78.0 5365.9,60.0 5397.3,3237.1 5260.1,3561.1 514.0,3643.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0047N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62993129936179,
+                41.8908763905502
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62638887761601,
+                41.890926005557866
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62630563556536,
+                41.887632341462094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62984805731114,
+                41.887582726454426
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p48N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5828.0,7323.0 701.1,7323.0 692.5,5266.4 642.6,5122.3 494.9,5167.1 604.0,3611.5 2733.4,3503.8 2867.7,3180.8 2815.4,22.1 5000.8,0.7 5016.6,2942.7 5828.0,2761.8 5828.0,7323.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62840104959494,
+                41.89088934601658
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62485979463109,
+                41.89092134786776
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62480577224608,
+                41.88760838835217
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62834702720993,
+                41.88757638650099
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0049N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p49N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0049N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0049N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5847
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1466.1,7322.0 1544.2,4788.5 737.3,4942.5 811.4,2034.3 -0.0,2018.6 -0.0,279.2 2713.7,338.8 2688.8,2050.8 2907.8,2055.6 2935.7,344.3 5239.3,399.8 5229.7,1345.7 5847.0,1363.3 5847.0,7322.0 1466.1,7322.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0049N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62591458530368,
+                41.89183051587073
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5847.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62232249164886,
+                41.89194552655265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5847.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62212910952009,
+                41.88859836305041
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6257212031749,
+                41.888483352368496
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0004N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p4N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0004N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0004N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5845
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4038.0,692.4 4116.7,6564.8 1689.0,6574.9 1644.8,1000.7 1776.5,708.3 4038.0,692.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0004N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64103411989682,
+                41.896820253807334
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5845.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63756269823561,
+                41.89685428035458
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5845.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63750541907855,
+                41.893615325533894
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64097684073975,
+                41.893581298986646
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0051N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p51N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0051N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0051N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5847
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7322.0 -0.0,115.8 5847.0,161.1 5847.0,7322.0 -0.0,7322.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0051N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6221692,
+                41.8926235
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5847.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6186245,
+                41.8926891
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5847.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61851419999999,
+                41.889386099999996
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6220589,
+                41.8893205
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0052N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p52N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0052N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0052N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5811
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,-0.0 5811.0,0.0 5811.0,7323.0 -0.0,7323.0 0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0052N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6183706164362,
+                41.89261617003581
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5811.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61504723604435,
+                41.89266059464897
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5811.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61497203425864,
+                41.88954299018469
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61829541465049,
+                41.88949856557152
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0056W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p56W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0056W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0056W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5813
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,0.0 4019.3,2.0 3947.7,3703.2 4401.0,3703.6 4376.8,6083.2 1404.6,6061.4 2895.7,7323.0 -0.0,7323.0 -0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0056W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64854420432725,
+                41.89389231235417
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.645052633548,
+                41.893945016501334
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64496341478255,
+                41.890669687799694
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6484549855618,
+                41.89061698365253
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0057W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p57W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0057W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0057W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5865
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"452.1,3683.5 -0.0,3691.8 -0.0,0.0 5865.0,93.7 5865.0,5909.7 473.8,6056.5 452.1,3683.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0057W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64613001885145,
+                41.89392787398788
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5865.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64259683565815,
+                41.89393033785339
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5865.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64259270178174,
+                41.89064534511949
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64612588497504,
+                41.890642881253974
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0058W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p58W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0058W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0058W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5813
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"404.2,1245.3 5615.0,1207.8 5574.0,3552.3 5728.0,3547.8 5664.0,5894.1 127.0,6004.9 140.1,7323.0 -0.0,7323.0 -0.0,2469.2 1861.3,2442.3 404.2,1245.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0058W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6478827573348,
+                41.8917699705592
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6442654388686,
+                41.891785628316796
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64423893379454,
+                41.8883922463421
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64785625226074,
+                41.88837658858451
               ]
             }
           }
@@ -1956,8 +8092,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2005,8 +8141,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64774614501133,
-                41.89175770145844
+                -87.64774872689944,
+                41.8917587163453
               ]
             }
           },
@@ -2026,8 +8162,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64418965768951,
-                41.89179900584041
+                -87.64419402238087,
+                41.89179933689922
               ]
             }
           },
@@ -2047,8 +8183,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64412084401617,
-                41.88846895089276
+                -87.64412634797456,
+                41.88847095124834
               ]
             }
           },
@@ -2068,8 +8204,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64767733133799,
-                41.888427646510785
+                -87.64768105249313,
+                41.88843033069442
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0005N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p5N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0005N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0005N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5879
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1070.8,679.9 1066.2,0.0 5879.0,0.0 5879.0,666.4 4072.8,665.7 4141.4,6418.6 1755.5,6428.2 1678.8,675.6 1070.8,679.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0005N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63965467749783,
+                41.89683252558076
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5879.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63608704268552,
+                41.89686764503469
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5879.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63602830760695,
+                41.89356168116128
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63959594241926,
+                41.893526561707354
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0060W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p60W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0060W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0060W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5813
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1704.3,1259.8 4256.3,1167.3 4296.0,1686.8 5813.0,1689.1 5813.0,6023.6 1753.6,6006.4 1818.6,3629.9 1662.6,3634.5 1704.3,1259.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0060W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6454359348414,
+                41.89179716148451
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64186461643666,
+                41.8918128625424
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64183803810666,
+                41.88846262765128
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6454093565114,
+                41.88844692659339
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0062W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p62W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0062W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0062W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"942.0,1119.5 261.5,1071.3 263.4,0.0 3159.2,0.0 3161.9,1115.8 5828.0,1026.5 5828.0,4888.9 3376.5,4935.4 3447.1,7323.0 1037.7,7323.0 942.0,1119.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0062W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6420066558187,
+                41.889560281813345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63846897339604,
+                41.88958064547551
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6384345977677,
+                41.88627099853896
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64197228019036,
+                41.886250634876795
               ]
             }
           }
@@ -2094,8 +8644,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2114,7 +8664,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5648.0,653.9 5674.1,5561.3 375.5,5514.6 372.3,5195.7 358.5,4340.7 -0.0,4334.5 -0.0,718.8 5648.0,653.9\" /></svg>"
+          "value": "<svg><polygon points=\"5649.5,653.9 5667.4,5564.9 365.1,5509.2 362.4,5190.1 350.0,4336.1 -0.0,4330.3 -0.0,709.4 5649.5,653.9\" /></svg>"
         }
       },
       "body": {
@@ -2143,8 +8693,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64778974594637,
-                41.889316565863076
+                -87.64778882137595,
+                41.889312041768626
               ]
             }
           },
@@ -2164,8 +8714,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64420265711833,
-                41.8893546608776
+                -87.64420434323547,
+                41.889354642552796
               ]
             }
           },
@@ -2185,8 +8735,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6441393569517,
-                41.8860045127534
+                -87.6441335561057,
+                41.88600693267045
               ]
             }
           },
@@ -2206,8 +8756,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64772644577974,
-                41.88596641773888
+                -87.64771803424618,
+                41.88596433188628
               ]
             }
           }
@@ -2232,8 +8782,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2252,7 +8802,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"511.3,5610.9 483.7,683.9 5266.0,742.4 5323.5,5679.0 511.3,5610.9\" /></svg>"
+          "value": "<svg><polygon points=\"509.3,5598.5 499.8,674.4 5279.1,750.5 5318.4,5684.3 509.3,5598.5\" /></svg>"
         }
       },
       "body": {
@@ -2281,8 +8831,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64463653568954,
-                41.889362619965304
+                -87.64464796168231,
+                41.88935750769862
               ]
             }
           },
@@ -2302,8 +8852,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64109430657507,
-                41.88939948213816
+                -87.64110383713216,
+                41.88940419532668
               ]
             }
           },
@@ -2323,8 +8873,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64103251665554,
-                41.886062164567115
+                -87.64102557737907,
+                41.8860650916958
               ]
             }
           },
@@ -2344,8 +8894,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64457474577002,
-                41.88602530239426
+                -87.64456970192921,
+                41.88601840406774
               ]
             }
           }
@@ -2370,8 +8920,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2390,7 +8940,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"94.6,7322.0 -0.0,7322.0 -0.0,-0.0 1357.8,0.0 1395.1,1168.5 5877.0,1130.1 5867.3,6076.1 5273.6,6088.1 5118.0,6355.8 1532.4,6351.4 1536.6,6547.0 74.8,6582.3 94.6,7322.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 1370.8,0.0 1405.1,1166.3 4411.3,1148.2 4857.1,3552.1 5877.0,3536.4 5877.0,6564.3 5309.2,6572.8 5112.9,6360.2 1529.3,6346.8 1533.0,6542.3 72.0,6573.8 90.1,7322.0 -0.0,7322.0 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -2419,8 +8969,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.648365744507,
-                41.8873348034347
+                -87.6483741561753,
+                41.88733250651184
               ]
             }
           },
@@ -2440,8 +8990,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64476324273924,
-                41.887326135508
+                -87.64476966602962,
+                41.887330648615155
               ]
             }
           },
@@ -2461,8 +9011,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64477764525799,
-                41.88396148800969
+                -87.64477275308755,
+                41.88396414402108
               ]
             }
           },
@@ -2482,8 +9032,1112 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64838014702575,
-                41.88397015593639
+                -87.64837724323323,
+                41.88396600191776
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0066W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p66W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0066W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0066W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4001.3,1184.9 4113.6,6564.7 3719.9,6304.0 3120.2,6308.7 3145.6,3668.2 2087.3,3674.3 1648.8,1176.6 4001.3,1184.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0066W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64665001765933,
+                41.8873182080799
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64320480132051,
+                41.88734126968005
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6431661457192,
+                41.88409525045266
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64661136205802,
+                41.88407218885251
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0067W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p67W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0067W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0067W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5877
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4137.3,985.7 4173.6,6205.7 1814.6,6228.1 1676.1,983.7 4137.3,985.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0067W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6452969626866,
+                41.887253472481795
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5877.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64173259882949,
+                41.8872625432183
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5877.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64171752701915,
+                41.883933512901415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64528189087626,
+                41.88392444216491
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0068W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p68W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0068W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0068W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1744.0,6267.2 1676.0,987.9 2193.4,988.2 2409.2,6261.6 1744.0,6267.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0068W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64379601232946,
+                41.88725771915009
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64027746671022,
+                41.88725095085342
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64028889166921,
+                41.88395905939201
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64380743728846,
+                41.883965827688684
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0069W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p69W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0069W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0069W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5877
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4117.6,1963.6 4096.7,5881.6 -0.0,5741.3 -0.0,621.9 1798.0,696.7 1769.3,1891.8 4117.6,1963.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0069W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64248816736445,
+                41.887098916327524
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5877.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63883209970396,
+                41.88720323825727
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5877.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63865753774432,
+                41.88381246448207
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64231360540481,
+                41.88370814255232
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0006N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p6N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0006N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0006N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5839
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1782.4,6597.8 1709.6,745.0 3547.9,744.9 3547.6,66.9 4204.4,49.9 4197.2,6585.5 1782.4,6597.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0006N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63820280990916,
+                41.896877307745406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5839.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63472130615385,
+                41.89691027593233
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5839.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63466576099576,
+                41.89366025093232
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63814726475107,
+                41.8936272827454
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0070W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p70W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0070W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0070W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5813
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5813.0,7323.0 5421.3,7323.0 5425.5,6348.1 1340.7,6270.2 1291.0,0.0 5813.0,0.0 5813.0,7323.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0070W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64073408393405,
+                41.887325637552934
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63713108092202,
+                41.887397201021244
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63700994843902,
+                41.88401701309605
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64061295145105,
+                41.88394544962774
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0071W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p71W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0071W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0071W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5867
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7322.0 -0.0,772.1 1478.1,775.6 1479.2,576.4 2845.5,610.2 2717.3,6419.6 400.0,6408.1 394.6,7322.0 -0.0,7322.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0071W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64834376597875,
+                41.88465828137276
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64478713086773,
+                41.884720377571554
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64468309197886,
+                41.88141705812712
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64823972708989,
+                41.881354961928324
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0072W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p72W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0072W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0072W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5813
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,705.8 2274.3,723.3 2473.8,940.2 3049.3,932.8 3105.0,3438.9 2407.2,3450.2 2491.6,6481.7 -0.0,6513.5 -0.0,705.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0072W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64661074095116,
+                41.884731750910156
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64311125584221,
+                41.88473537405948
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64310516629263,
+                41.88142900999028
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64660465140157,
+                41.88142538684095
               ]
             }
           }
@@ -2508,8 +10162,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2528,7 +10182,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4046.3,6603.7 1664.0,6605.7 1691.9,826.3 4068.0,860.3 4046.3,6603.7\" /></svg>"
+          "value": "<svg><polygon points=\"697.0,3550.6 728.7,554.7 1316.9,562.0 1697.8,825.6 4071.3,864.4 4037.7,6601.5 -0.0,6576.2 -0.0,3542.4 697.0,3550.6\" /></svg>"
         }
       },
       "body": {
@@ -2557,8 +10211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64521539960478,
-                41.88477660720329
+                -87.64522103828132,
+                41.88477496895275
               ]
             }
           },
@@ -2578,8 +10232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64168419364898,
-                41.88484847823423
+                -87.64168621626979,
+                41.88485239622775
               ]
             }
           },
@@ -2599,8 +10253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64156461548295,
-                41.88154579450994
+                -87.64155739366225,
+                41.881546331198585
               ]
             }
           },
@@ -2620,8 +10274,974 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64509582143874,
-                41.881473923479
+                -87.64509221567378,
+                41.88146890392358
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0074W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p74W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0074W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0074W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5813
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4195.7,841.0 4217.6,6519.9 1822.3,6515.1 1822.3,799.9 4195.7,841.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0074W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64387346718698,
+                41.88478186591681
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64033499725953,
+                41.88484295666554
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5813.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64023159509014,
+                41.88152319606371
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64377006501759,
+                41.88146210531498
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0075W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p75W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0075W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0075W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5867
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1720.7,6341.5 1752.2,772.4 5867.0,885.8 5867.0,6419.4 1720.7,6341.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0075W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64241146066632,
+                41.884775178891466
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63876793948764,
+                41.88486393139062
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63861923227572,
+                41.881480075884866
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6422627534544,
+                41.881391323385714
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0076W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p76W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0076W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0076W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3918.8,6464.0 3423.0,6458.3 3364.1,749.2 5828.0,783.5 5828.0,7322.0 3921.5,7322.0 3918.8,6464.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0076W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64078513176112,
+                41.884756459152285
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63727687652303,
+                41.8848149724324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63717816283008,
+                41.881534387370166
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64068641806817,
+                41.88147587409005
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0077W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p77W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0077W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0077W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5873
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4322.2,946.5 4304.4,7302.6 1484.9,7322.0 1496.3,928.3 4322.2,946.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0077W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64355524897954,
+                41.88250511961217
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5873.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64349222850014,
+                41.8798348342092
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5873.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64796316023897,
+                41.87977634289041
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64802618071838,
+                41.88244662829338
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0078W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p78W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0078W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0078W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4162.0,7316.8 1341.1,7322.0 1350.6,945.6 4152.0,898.2 4162.0,7316.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0078W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64352459413077,
+                41.881151633215694
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64346683331581,
+                41.87850965324039
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64792368615173,
+                41.87845563783802
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64798144696668,
+                41.881097617813325
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0079W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p79W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0079W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0079W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5873
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4116.2,6483.0 1738.5,6525.6 1659.7,899.0 4011.0,851.7 4116.2,6483.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0079W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64512265611967,
+                41.882219500017456
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5873.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64154083423163,
+                41.88224108464571
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5873.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6415046976431,
+                41.878916392196366
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64508651953113,
+                41.87889480756811
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0007N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p7N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0007N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0007N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5835
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1730.0,0.0 5052.1,0.0 5050.3,705.8 4187.3,707.9 4187.4,6496.8 1664.8,6484.4 1730.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0007N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63673494676144,
+                41.8968621278301
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5835.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63322911747755,
+                41.896918648967805
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5835.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63313382515452,
+                41.893643659934895
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6366396544384,
+                41.89358713879719
               ]
             }
           }
@@ -2646,8 +11266,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2666,7 +11286,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4119.0,6513.0 1692.0,6501.0 1660.4,795.0 4099.5,795.9 4119.0,6513.0\" /></svg>"
+          "value": "<svg><polygon points=\"4101.9,804.6 4114.1,6516.8 1689.2,6501.7 1665.0,800.6 4101.9,804.6\" /></svg>"
         }
       },
       "body": {
@@ -2695,8 +11315,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64367494023075,
-                41.88218781919121
+                -87.64367921610666,
+                41.88218960178045
               ]
             }
           },
@@ -2716,8 +11336,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64019094654076,
-                41.882243712019296
+                -87.64019229042431,
+                41.882248925572966
               ]
             }
           },
@@ -2737,8 +11357,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64009731826737,
-                41.878962687273614
+                -87.64009291480755,
+                41.87896513964561
               ]
             }
           },
@@ -2758,8 +11378,836 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64358131195736,
-                41.87890679444553
+                -87.6435798404899,
+                41.878905815853095
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0081W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p81W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0081W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0081W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5853
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,7322 0,0 5853,0 5853,7322 0,7322\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0081W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6421824916928,
+                41.88160663348444
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5853.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63867905313809,
+                41.88161076688353
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5853.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63867215757891,
+                41.8783249308922
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64217559613361,
+                41.8783207974931
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0082W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p82W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0082W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0082W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1136.0,1150.3 5828.0,1206.0 5828.0,6820.8 1131.4,6768.4 1136.0,1150.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0082W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64192794141086,
+                41.88238180260688
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6383578025222,
+                41.88244951613141
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6382435715915,
+                41.87911095070103
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64181371048016,
+                41.879043237176504
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0083W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p83W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0083W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0083W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5853
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1455.5,7322.0 1464.6,878.0 4299.9,855.2 4276.9,7268.7 1455.5,7322.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0083W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64351498777778,
+                41.8799316099119
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5853.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6434467004653,
+                41.8772892963608
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5853.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64788574979265,
+                41.877225697706095
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64795403710512,
+                41.879868011257194
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0084W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p84W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0084W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0084W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5868
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1586.1,7323.0 1590.9,898.4 4376.4,881.9 4408.4,7323.0 1586.1,7323.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0084W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64345536146097,
+                41.878706482071344
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64339710239098,
+                41.876062446023724
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64782931947865,
+                41.87600830501332
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64788757854863,
+                41.87865234106094
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0085W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p85W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0085W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0085W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5853
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4188.7,876.2 4158.6,7322.0 1781.0,7322.0 1817.5,867.6 4188.7,876.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0085W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64515712178151,
+                41.87963318730157
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5853.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6415786626872,
+                41.87971221218551
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5853.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6414459030855,
+                41.87637942555678
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64502436217981,
+                41.87630040067284
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p86W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5868
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1830.7,6506.0 1732.0,848.5 5868.0,814.2 5868.0,6472.8 1830.7,6506.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64362752424579,
+                41.87966762297577
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64009388724095,
+                41.87968954911882
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6400573897869,
+                41.87638251962537
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64359102679174,
+                41.87636059348232
               ]
             }
           }
@@ -2784,8 +12232,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2804,7 +12252,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4249.2,5268.0 4083.8,7322.0 1720.4,7322.0 1716.7,0.0 4160.0,0.0 4249.2,5268.0\" /></svg>"
+          "value": "<svg><polygon points=\"4067.2,922.4 4183.8,5249.1 4044.7,6479.7 3327.2,6477.9 3365.4,923.6 4067.2,922.4\" /></svg>"
         }
       },
       "body": {
@@ -2833,8 +12281,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64217725926675,
-                41.87967799400526
+                -87.64217798216248,
+                41.879723365310994
               ]
             }
           },
@@ -2854,8 +12302,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63864634660806,
-                41.879736371245464
+                -87.63856135834325,
+                41.879764026552685
               ]
             }
           },
@@ -2875,8 +12323,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63854896148631,
-                41.87642466772014
+                -87.63849304850257,
+                41.87639569968291
               ]
             }
           },
@@ -2896,8 +12344,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.642079874145,
-                41.876366290479936
+                -87.6421096723218,
+                41.87635503844122
               ]
             }
           }
@@ -2922,8 +12370,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2942,7 +12390,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5868.0,6407.4 1538.3,6492.1 1662.5,5241.7 1480.0,854.1 3181.2,842.6 3799.2,829.1 3778.1,0.0 5868.0,0.0 5868.0,6407.4\" /></svg>"
+          "value": "<svg><polygon points=\"5868.0,6417.7 1543.2,6485.4 1672.2,5235.4 1506.8,846.7 5868.0,802.6 5868.0,6417.7\" /></svg>"
         }
       },
       "body": {
@@ -2971,8 +12419,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64055156265961,
-                41.879714099504085
+                -87.64056967917423,
+                41.879708044661115
               ]
             }
           },
@@ -2992,8 +12440,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63700317809811,
-                41.879716148715
+                -87.63702166034204,
+                41.87972046247215
               ]
             }
           },
@@ -3013,8 +12461,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63699976705222,
-                41.87639532180483
+                -87.6370009900939,
+                41.876399975857716
               ]
             }
           },
@@ -3034,8 +12482,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64054815161371,
-                41.876393272593916
+                -87.64054900892609,
+                41.87638755804668
               ]
             }
           }
@@ -3060,8 +12508,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3080,7 +12528,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5822.0,935.6 5822.0,7323.0 1104.3,7323.0 1175.9,895.4 5822.0,935.6\" /></svg>"
+          "value": "<svg><polygon points=\"1096.4,7323.0 1172.8,891.9 5822.0,935.5 5822.0,6223.6 5389.7,6319.7 5822.0,6409.9 5822.0,7323.0 1096.4,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -3109,8 +12557,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64342688089798,
-                41.87727480258876
+                -87.64343059573922,
+                41.87727246411775
               ]
             }
           },
@@ -3130,8 +12578,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64331286535584,
-                41.874632551360286
+                -87.64331424971415,
+                41.87463599818203
               ]
             }
           },
@@ -3151,8 +12599,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64774415062408,
-                41.87452503801016
+                -87.64773582593509,
+                41.87452628709011
               ]
             }
           },
@@ -3172,8 +12620,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64785816616622,
-                41.87716728923863
+                -87.64785217196015,
+                41.877162753025836
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0008N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p8N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0008N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0008N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5839
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4262.3,6567.2 1661.7,6559.1 1661.7,717.9 4042.0,714.9 4022.1,2967.8 4307.7,2967.9 4262.3,6567.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0008N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63520862804418,
+                41.89688831674733
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5839.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63173182111767,
+                41.8969444226606
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5839.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6316372936271,
+                41.89369876987046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63511410055361,
+                41.89364266395719
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0090W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p90W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0090W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0090W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5868
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2041.7,6230.3 2467.1,6126.9 2354.6,956.7 3597.8,959.1 3643.8,7202.0 5868.0,7185.6 5868.0,7323.0 2490.6,7206.0 2471.1,6309.8 2041.7,6230.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0090W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64331957534141,
+                41.87570538566065
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64327787641757,
+                41.87301721286322
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64778383677996,
+                41.872978459346164
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6478255357038,
+                41.8756666321436
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0091W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p91W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0091W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0091W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5867
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1710.2,1992.2 4082.2,1954.6 4091.1,3142.9 5867.0,3126.0 5867.0,4293.3 4106.4,4302.3 4110.7,5264.8 1726.8,5271.1 1710.2,1992.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0091W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64500063300179,
+                41.87722283984145
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64140425346342,
+                41.87725974463196
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64134238410902,
+                41.87391787780689
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64493876364739,
+                41.873880973016384
               ]
             }
           }
@@ -3198,8 +13060,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3218,7 +13080,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1677.3,0.0 4085.1,0.0 4149.1,6270.7 1757.8,6292.0 1677.3,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1746.1,3143.1 1728.6,1095.9 4106.8,1080.1 4131.8,3120.3 4136.5,4304.0 4141.4,6327.1 1773.8,6340.6 1746.1,3143.1\" /></svg>"
         }
       },
       "body": {
@@ -3247,8 +13109,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6435128841734,
-                41.87719298638659
+                -87.6435465294177,
+                41.8772200881503
               ]
             }
           },
@@ -3268,8 +13130,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64000056082419,
-                41.87721787128572
+                -87.63999910201218,
+                41.877253850579
               ]
             }
           },
@@ -3289,8 +13151,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6399591118026,
-                41.87392840954203
+                -87.63994246370746,
+                41.87395512871378
               ]
             }
           },
@@ -3310,8 +13172,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6434714351518,
-                41.8739035246429
+                -87.64348989111298,
+                41.87392136628508
               ]
             }
           }
@@ -3336,8 +13198,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3356,7 +13218,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1759.4,6291.6 1781.9,4243.3 -0.0,4227.1 -0.0,3032.1 1793.2,3044.7 1794.5,1819.1 4197.8,1829.2 4113.5,5642.1 4244.0,6326.1 1759.4,6291.6\" /></svg>"
+          "value": "<svg><polygon points=\"1766.2,6287.6 1788.9,4241.3 1189.0,4235.8 1204.0,3039.6 1800.3,3043.9 1802.8,979.9 4221.0,1013.7 4118.0,5639.1 4248.4,6322.4 1766.2,6287.6\" /></svg>"
         }
       },
       "body": {
@@ -3385,8 +13247,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64213480109737,
-                41.87717153540002
+                -87.64214036791795,
+                41.877172266277334
               ]
             }
           },
@@ -3406,8 +13268,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63865471798445,
-                41.87724011156228
+                -87.63865692116698,
+                41.87724126934945
               ]
             }
           },
@@ -3427,8 +13289,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6385405729523,
-                41.873983077959494
+                -87.63854206554332,
+                41.87398108769479
               ]
             }
           },
@@ -3448,8 +13310,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64202065606521,
-                41.87391450179723
+                -87.64202551229428,
+                41.873912084622674
               ]
             }
           }
@@ -3474,8 +13336,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3494,7 +13356,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2933.4,6331.4 433.4,6317.3 301.3,5636.6 314.3,1176.3 390.1,1026.1 4786.8,1039.5 4810.3,0.0 5866.0,0.0 5866.0,7323.0 2939.9,7323.0 2933.4,6331.4\" /></svg>"
+          "value": "<svg><polygon points=\"433.1,6313.7 298.5,5222.7 388.4,1028.3 4774.8,1040.4 4794.0,0.0 5866.0,0.0 5866.0,7323.0 2936.4,7323.0 2928.5,6327.1 433.1,6313.7\" /></svg>"
         }
       },
       "body": {
@@ -3523,8 +13385,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6398648487928,
-                41.87722485495134
+                -87.63986400698646,
+                41.877226403772546
               ]
             }
           },
@@ -3544,8 +13406,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6363720993175,
-                41.877286105181945
+                -87.63636742413611,
+                41.87728702010117
               ]
             }
           },
@@ -3565,8 +13427,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63627007869616,
-                41.87401498916145
+                -87.63626645918497,
+                41.87401231979496
               ]
             }
           },
@@ -3586,8 +13448,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63976282817147,
-                41.87395373893085
+                -87.63976304203531,
+                41.87395170346633
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0095W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p95W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0095W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0095W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5867
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1779.3,6307.7 1745.2,0.0 4147.0,0.0 4175.3,6303.1 1779.3,6307.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0095W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64495930951965,
+                41.874815240691596
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64138995680729,
+                41.87485887730707
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64131681362124,
+                41.87154158981327
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6448861663336,
+                41.871497953197796
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0096W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p96W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0096W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0096W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5866
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4108.7,1077.4 4181.4,6303.1 1802.5,6303.7 1772.6,1083.9 4108.7,1077.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0096W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64352164699213,
+                41.8748562696063
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63992643940409,
+                41.87489831108834
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63985592185577,
+                41.871554717127175
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6434511294438,
+                41.871512675645135
               ]
             }
           }
@@ -3612,8 +13750,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3632,7 +13770,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3537.2,6291.8 1027.7,6269.9 1028.2,1072.4 5867.0,1144.1 5867.0,5082.0 3543.9,5059.7 3537.2,6291.8\" /></svg>"
+          "value": "<svg><polygon points=\"3536.3,6286.6 1030.0,6261.9 1036.2,1071.0 5867.0,1147.9 5867.0,5080.9 3544.3,5056.1 3536.3,6286.6\" /></svg>"
         }
       },
       "body": {
@@ -3661,8 +13799,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64164205338507,
-                41.87487185925713
+                -87.64164846307082,
+                41.87487116799609
               ]
             }
           },
@@ -3682,8 +13820,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63805098651845,
-                41.87495241421485
+                -87.63805298219751,
+                41.874954817348566
               ]
             }
           },
@@ -3703,8 +13841,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63791690780218,
-                41.87159138425554
+                -87.63791375305365,
+                41.87158965613543
               ]
             }
           },
@@ -3724,8 +13862,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6415079746688,
-                41.87151082929782
+                -87.64150923392697,
+                41.87150600678295
               ]
             }
           }
@@ -3733,25 +13871,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0100W/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0099W/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p100W",
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p99W",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3760,3571 +13898,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0100W/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0099W/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0100W/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0099W/info.json",
           "type": "ImageService2",
           "height": 7323,
-          "width": 5882
+          "width": 5867
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5882.0,1008.8 5882.0,7323.0 -0.0,7323.0 -0.0,998.7 5882.0,1008.8\" /></svg>"
+          "value": "<svg><polygon points=\"5867.0,7323.0 -0.0,7323.0 -0.0,1024.6 5867.0,985.5 5867.0,7323.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0100W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1280.4,
-                1003.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6438138,
-                41.8719711
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2961.0,
-                1003.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6437882,
-                41.8712518
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0101W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p101W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0101W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0101W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5844
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4196.0,6231.1 1785.5,6239.8 1727.2,42.6 4123.1,0.0 4196.0,6231.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0101W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4196.0,
-                6231.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6422705,
-                41.8697309
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1736.0,
-                1251.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6438138,
-                41.8719711
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0102W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p102W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0102W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0102W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5882
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1752.1,6222.2 1720.7,2303.7 4093.0,2314.5 4129.4,6223.2 1752.1,6222.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0102W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1712.6,
-                1287.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6423562,
-                41.871991
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4129.4,
-                6223.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6408087,
-                41.8697525
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0103W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p103W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0103W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0103W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5844
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1601.3,1249.1 4116.0,1227.8 4153.9,6219.8 1684.0,6207.2 1601.3,1249.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0103W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4116.0,
-                1227.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6393618,
-                41.8720327
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1684.0,
-                6207.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6408087,
-                41.8697525
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0104W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p104W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0104W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0104W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5901
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1435.4,0.0 5901.0,0.0 5901.0,7323.0 1441.7,7323.0 1435.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0104W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1440.2,
-                1251.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6393618,
-                41.8720327
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1440.2,
-                6279.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6392994,
-                41.8697612
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0107W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p107W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0107W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0107W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5849
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3479.2,1059.6 3328.5,7323.0 -0.0,7323.0 -0.0,6997.4 2212.8,7029.4 2299.5,1041.3 3479.2,1059.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0107W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2944.5,
-                1051.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6437376,
-                41.8697104
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2944.5,
-                6379.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6469654,
-                41.8696118
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0108W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p108W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0108W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0108W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5877
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5877.0,7323.0 -0.0,7323.0 -0.0,1035.1 5085.5,1000.0 5090.8,1717.0 5714.6,1706.4 5683.4,-0.0 5877.0,-0.0 5877.0,7323.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0108W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4972.8,
-                3431.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6451405,
-                41.8671908
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4972.8,
-                999.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6436561,
-                41.8672095
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0109W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p109W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0109W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0109W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5861
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"905.8,7323.0 906.6,6684.8 1640.4,6692.9 1704.3,947.9 4163.9,988.3 4095.5,7323.0 905.8,7323.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0109W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4144.7,
-                2639.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6422473,
-                41.8689973
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1704.3,
-                947.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6437376,
-                41.8697104
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0010N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p10N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0010N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0010N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5809
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4111.8,735.4 4137.5,6529.2 1684.3,6531.1 1684.4,742.2 4111.8,735.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0010N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1684.3,
-                4759.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6312006,
-                41.8948312
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1684.3,
-                6531.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.631182,
-                41.8940363
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0110W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p110W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0110W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0110W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5877
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1696.3,963.9 4125.2,978.0 4124.2,7283.3 1688.2,7241.6 1696.3,963.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0110W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1696.3,
-                4431.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6422169,
-                41.8681766
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1696.3,
-                963.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6422705,
-                41.8697309
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0111W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p111W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0111W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0111W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5861
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"408.1,999.9 2922.2,1048.4 2916.7,2103.5 5861.0,2123.0 5861.0,7323.0 398.3,7323.0 408.1,999.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0111W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                408.1,
-                4483.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6407521,
-                41.8681955
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                408.1,
-                999.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6408087,
-                41.8697525
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0011N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p11N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0011N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0011N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5806
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4181.5,763.3 4123.4,6591.3 1511.9,6558.9 1563.3,734.1 906.4,727.2 914.8,0.0 5806.0,0.0 5806.0,774.1 4181.5,763.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0011N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4162.6,
-                2995.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6281806,
-                41.8956822
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1535.5,
-                4779.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6297226,
-                41.8948505
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0012N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p12N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0012N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0012N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5809
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4063.6,731.1 4036.7,6523.1 1791.6,6518.4 1806.8,730.8 4063.6,731.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0012N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1804.3,
-                2947.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6281806,
-                41.8956822
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4036.7,
-                6523.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6267831,
-                41.894099
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0013N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p13N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0013N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0013N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5806
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4850.3,6462.6 835.7,6475.1 848.9,737.9 212.6,738.0 205.4,0.0 5295.8,7.3 5233.2,742.6 4954.9,746.2 4920.1,969.4 4850.3,6462.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0013N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                835.7,
-                2931.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6268284,
-                41.8957065
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                835.7,
-                6475.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6267831,
-                41.894099
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0015N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p15N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0015N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0015N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5806
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5806.0,0.0 5806.0,6515.8 -0.0,6540.2 -0.0,770.7 -0.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0015N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2051.3,
-                2955.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.620354,
-                41.8958076
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2051.3,
-                6515.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6203072,
-                41.8942136
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p16N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5798.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7323.0"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5798
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1584.5,5504.1 1123.4,5466.1 1576.0,0.0 5798.0,0.0 5798.0,5733.3 5182.4,5699.2 5598.7,6843.8 1553.4,6497.5 1584.5,5504.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1507.5,
-                6495.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.617775,
-                41.8942551
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3334.8,
-                703.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6170654,
-                41.8968396
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0018N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p18N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0018N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0018N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5798
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5560.5,6348.8 -0.0,6434.7 -0.0,965.4 5529.6,957.4 5560.5,6348.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0018N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5546.1,
-                2767.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6370626,
-                41.893148
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                811.7,
-                6355.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6398784,
-                41.8915062
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0020N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p20N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0020N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0020N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5798
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4260.3,5267.2 1712.6,5257.5 1703.4,915.9 4227.6,916.7 4260.3,5267.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0020N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1703.4,
-                2731.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6356317,
-                41.8931668
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1703.4,
-                915.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6356503,
-                41.8939783
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p21N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5794
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3870.1,6279.2 1660.6,6269.7 1660.6,948.3 4193.6,963.5 4183.2,2736.0 3926.7,2735.8 3870.1,6279.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1660.6,
-                948.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6341345,
-                41.8939972
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1660.6,
-                6269.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6340545,
-                41.8915756
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0022N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p22N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0022N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0022N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5798
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1613.6,2780.9 1872.0,2779.0 1870.0,1773.2 4181.5,1767.6 4182.9,7323.0 1586.5,7323.0 1587.5,7322.6 1593.0,5333.9 1584.0,5333.9 1613.6,2780.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0022N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4182.6,
-                2771.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6311632,
-                41.8932327
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4182.6,
-                6339.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.631127,
-                41.8916211
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0023N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p23N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0023N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0023N/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5794
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4101.4,965.8 4121.7,6354.7 1644.6,6365.1 1643.3,969.5 4101.4,965.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0023N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1644.6,
-                2764.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6311632,
-                41.8932327
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1644.6,
-                4537.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6311454,
-                41.8924393
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0025N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p25N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0025N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0025N/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5794
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5053.9,6273.9 613.4,6298.3 595.1,936.5 5026.6,917.2 5053.9,6273.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0025N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2845.0,
-                4489.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.626742,
-                41.8924976
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2845.0,
-                2716.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6267605,
-                41.8932946
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0027N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p27N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0027N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0027N/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5794
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4933.1,909.7 4977.7,6297.7 900.1,6357.2 856.3,964.3 4933.1,909.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0027N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4977.7,
-                6297.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.620235,
-                41.891803
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                856.3,
-                964.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6227571,
-                41.8941636
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0030N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p30N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0030N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0030N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5803
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5803.0,6352.7 2588.3,6375.7 2525.5,4740.2 -0.0,4835.5 0.0,-0.0 5803.0,-0.0 5803.0,6352.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0030N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3339.4,
-                519.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6115803,
-                41.8911412
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3339.4,
-                6659.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6151792,
-                41.8911123
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0031N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p31N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0031N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0031N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5753
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3476.5,7201.7 4798.3,7209.5 4799.7,7323.0 2696.6,7323.0 2698.7,6432.3 826.3,6466.0 1325.4,2644.4 394.8,1058.5 5162.4,1024.0 5206.2,6429.4 4855.9,6415.8 4650.5,6418.2 3430.3,6432.5 3476.5,7201.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0031N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1424.2,
-                2803.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6392501,
-                41.8907315
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5172.9,
-                2803.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6370023,
-                41.8907484
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0032N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p32N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0032N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0032N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5803
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4081.4,1042.5 4167.3,4659.4 1336.6,7323.0 -0.0,7323.0 -0.0,6544.3 1667.7,1063.9 4081.4,1042.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0032N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4167.3,
-                4659.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.635528,
-                41.8899603
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1667.7,
-                1063.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6370194,
-                41.8915431
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0035N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p35N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0035N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0035N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5831
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1408.9,2018.0 4043.6,2018.0 4043.9,2795.6 5831.0,2803.3 5831.0,4608.9 1417.2,4558.1 1408.9,2018.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0035N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4043.3,
-                4611.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6310911,
-                41.8900219
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4043.3,
-                1019.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.631127,
-                41.8916211
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0036N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p36N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0036N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0036N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5825
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3543.3,2759.8 1758.6,2749.3 1760.8,978.5 4244.7,971.9 4248.2,2763.9 3723.9,2760.8 3725.0,4767.7 3456.5,4768.5 3543.3,2759.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0036N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4244.7,
-                4559.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6295984,
-                41.8900425
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4244.7,
-                971.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6296377,
-                41.8916443
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0037N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p37N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0037N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0037N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5831
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1455.7,3688.3 1472.6,1880.7 4107.3,1907.7 4092.7,3706.3 1455.7,3688.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0037N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1431.8,
-                5499.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6295984,
-                41.8900425
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4107.3,
-                1907.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.628071,
-                41.8916668
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0038N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p38N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0038N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0038N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5825
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1944.6,3650.0 1948.3,1839.7 4227.2,1844.3 4215.5,3649.2 1944.6,3650.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0038N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1948.3,
-                1839.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.628071,
-                41.8916668
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1948.3,
-                5483.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6280205,
-                41.8900646
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0039N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p39N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0039N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0039N/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5866
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1806.7,3494.0 1821.1,1706.4 3192.8,1707.9 3224.9,3499.7 1806.7,3494.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0039N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4061.4,
-                3501.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6253624,
-                41.8909165
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4061.4,
-                1708.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6253892,
-                41.8917123
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0040N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p40N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0040N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0040N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5820
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"708.8,118.1 2537.6,117.5 2536.2,0.0 5129.8,105.6 5134.6,1497.3 708.1,1601.6 708.8,118.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0040N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                720.0,
-                5427.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62534,
-                41.8901081
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5136.0,
-                1899.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6226853,
-                41.8917508
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0045N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p45N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0045N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0045N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5866
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,6807.9 -0.0,6742.3 -0.0,6527.5 1644.1,6556.1 1665.2,0.0 4110.8,0.0 4083.3,6668.8 2946.1,6650.6 2897.6,6861.8 5866.0,7002.9 5866.0,7323.0 -0.0,7323.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0045N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1672.6,
-                1559.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6310629,
-                41.8892182
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4105.4,
-                1559.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6295795,
-                41.8892418
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0046N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p46N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0046N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0046N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5828.0,7323.0 326.9,7094.9 376.1,6873.7 1565.4,6884.5 1552.0,1539.8 4248.0,1539.8 4130.4,3160.4 4284.5,3114.1 4336.1,3264.4 4324.6,4777.5 4341.0,5451.2 5828.0,5440.4 5828.0,7323.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0046N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4248.0,
-                1539.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6280074,
-                41.8892588
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1552.0,
-                1539.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6295795,
-                41.8892418
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0047N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p47N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0047N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0047N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5866
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"515.4,2061.2 -0.0,2070.2 -0.0,78.0 5365.9,60.0 5397.3,3237.1 5260.1,3561.1 514.0,3643.9 515.4,2061.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0047N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3129.1,
-                1863.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6280205,
-                41.8900646
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                516.2,
-                1863.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6295984,
-                41.8900425
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p48N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5828.0,7323.0 648.7,7323.0 659.3,5224.4 610.7,5079.8 462.6,5123.2 586.7,3568.8 2717.0,3481.7 2854.4,3159.9 2832.6,1.0 5018.1,0.7 5005.5,2942.6 5828.0,2767.5 5828.0,7323.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5016.0,
-                1787.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62534,
-                41.8901081
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                604.0,
-                1787.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6280205,
-                41.8900646
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0049N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p49N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0049N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0049N/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5847
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1553.6,4786.7 737.3,4942.5 811.4,2034.3 -0.0,2018.6 -0.0,279.2 842.5,294.9 849.6,0.0 5247.3,0.0 5221.7,2141.0 5847.0,2154.3 5847.0,3985.8 4296.3,4076.1 4238.3,7241.8 1499.9,7322.0 1553.6,4786.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0049N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                771.9,
-                3801.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62534,
-                41.8901081
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2767.5,
-                2052.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6241601,
-                41.8909467
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0004N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p4N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0004N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0004N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5845
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4038.0,692.1 4116.7,6565.4 1688.9,6575.5 1644.8,1000.4 1776.5,708.0 4038.0,692.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0004N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4116.7,
-                2947.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6385661,
-                41.8955405
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1660.3,
-                2947.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.640025,
-                41.8955262
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0050N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p50N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0050N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0050N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5804
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,4114.3 1570.8,3994.1 1536.8,2138.4 902.5,2136.5 888.0,371.9 5804.0,357.4 5804.0,7323.0 -0.0,7323.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0050N/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0099W/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7349,8 +13937,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62322912526885,
-                41.89190879232868
+                -87.6432593648926,
+                41.87406095021334
               ]
             }
           },
@@ -7358,7 +13946,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5804.0,
+                5867.0,
                 0.0
               ],
               "creator": {
@@ -7370,8 +13958,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.61971105550384,
-                41.89197347291523
+                -87.64319167942071,
+                41.87139667396722
               ]
             }
           },
@@ -7379,7 +13967,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5804.0,
+                5867.0,
                 7323.0
               ],
               "creator": {
@@ -7391,8 +13979,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.61960143434985,
-                41.88866805869454
+                -87.64765748148507,
+                41.87133376802023
               ]
             }
           },
@@ -7412,3164 +14000,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62311950411485,
-                41.88860337810799
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                888.0,
-                371.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6226853,
-                41.8917508
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0052N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p52N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0052N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0052N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5811
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 5811.0,0.0 5811.0,7323.0 -0.0,7323.0 0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0052N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5515.1,
-                3631.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6151792,
-                41.8911123
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5515.1,
-                1839.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6151976,
-                41.8918751
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0056W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p56W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0056W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0056W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5813
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 3926.7,12.2 3947.7,3703.2 4401.0,3703.6 4376.8,6083.2 1404.6,6061.4 2895.7,7323.0 -0.0,7323.0 -0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0056W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4376.8,
-                6083.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6458412,
-                41.8912112
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1396.2,
-                1163.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6476914,
-                41.8933844
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0057W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p57W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0057W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0057W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5865
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"414.3,6056.0 452.1,3683.5 -0.0,3680.5 -0.0,0.0 5464.8,0.0 5463.6,226.5 5865.0,229.9 5865.0,6037.4 414.3,6056.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0057W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                452.1,
-                3683.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6458556,
-                41.8922757
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2832.5,
-                6087.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6443843,
-                41.8912254
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0058W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p58W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0058W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0058W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5813
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1861.3,2442.3 404.2,1245.3 5615.0,1207.8 5574.0,3552.3 5728.0,3547.8 5664.0,5894.0 124.5,6005.0 135.4,7323.0 -0.0,7323.0 -0.0,2469.2 1861.3,2442.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0058W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                416.1,
-                3631.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6476107,
-                41.8900883
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5617.0,
-                1207.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6443843,
-                41.8912254
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0005N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p5N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0005N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0005N/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5879
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1070.1,679.9 1065.0,0.0 5879.0,0.0 5879.0,666.4 4072.8,665.7 4141.4,6418.6 1755.5,6428.2 1678.8,675.6 1070.1,679.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0005N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4099.3,
-                2884.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6371439,
-                41.8955545
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1755.7,
-                2884.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6385661,
-                41.8955405
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0060W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p60W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0060W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0060W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5813
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1662.6,3634.5 1704.3,1259.8 4259.1,1161.2 3959.6,3531.4 3810.3,3532.0 4059.0,3662.8 4062.7,5991.2 1753.6,6006.4 1818.6,3629.9 1662.6,3634.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0060W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4064.7,
-                5991.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6429182,
-                41.8890672
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1704.3,
-                1259.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6443843,
-                41.8912254
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0061W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p61W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0061W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0061W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5865
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"416.1,6037.2 116.6,3697.0 -0.0,3577.5 -0.0,1156.7 418.5,1093.9 257.9,0.0 3923.7,0.0 3959.6,262.7 4749.0,75.2 5865.0,1511.5 5865.0,5323.7 416.1,6037.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0061W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64273128338263,
-                41.89179597196561
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5865.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.639201222224,
-                41.89147972642228
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5865.0,
-                7323.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63973171353643,
-                41.88819698167189
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7323.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64326177469506,
-                41.88851322721521
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                416.1,
-                6039.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6429182,
-                41.8890672
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0062W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p62W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0062W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0062W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3416.0,6091.2 1029.7,6097.3 942.0,1119.5 5828.0,1026.5 5828.0,4888.9 3376.5,4935.4 3393.6,5468.1 3405.1,5730.6 3416.0,6091.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0062W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3416.0,
-                6091.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6399045,
-                41.8868193
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                992.0,
-                1071.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6413995,
-                41.8890802
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0066W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p66W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0066W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0066W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5828,0 5828,7323 0,7323\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0066W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4132.0,
-                4951.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6442158,
-                41.8851166
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1760.0,
-                1195.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6456691,
-                41.8868032
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0067W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p67W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0067W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0067W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5877
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1836.9,6253.2 1455.0,6002.5 871.2,6011.4 883.8,3443.3 -0.0,3454.3 -0.0,1028.8 2476.2,1021.8 2453.9,6246.3 1836.9,6253.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0067W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1748.3,
-                3432.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6442408,
-                41.8857101
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4128.7,
-                1020.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6427857,
-                41.8868117
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0068W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p68W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0068W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0068W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,996.6 5828.0,966.6 5828.0,6237.8 4137.9,6247.0 4123.5,5398.8 1733.6,5460.4 1744.0,6267.2 -0.0,6294.3 -0.0,996.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0068W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1676.0,
-                3423.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6427895,
-                41.8857168
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1676.0,
-                987.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6427857,
-                41.8868117
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0069W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p69W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0069W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0069W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5877
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4124.0,761.9 4096.7,5881.6 4115.7,761.6 4124.0,761.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0069W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4096.7,
-                3104.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6398656,
-                41.8857338
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4096.7,
-                5881.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6397994,
-                41.8844479
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0006N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p6N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0006N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0006N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5839
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1782.4,6597.8 1709.6,745.0 3547.9,744.9 3547.6,66.9 4204.4,36.2 4197.2,6585.5 1782.4,6597.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0006N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4187.3,
-                4791.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6356698,
-                41.8947745
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4187.3,
-                743.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6357005,
-                41.8965708
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0070W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p70W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0070W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0070W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5813
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6238.3 -0.0,1110.4 1300.0,1131.7 1291.0,0.0 5813.0,0.0 5781.1,7323.0 5421.3,7323.0 5425.5,6347.9 -0.0,6238.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0070W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1308.2,
-                3483.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6398656,
-                41.8857338
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1308.2,
-                1131.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6399045,
-                41.8868193
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0071W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p71W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0071W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0071W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5867
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,772.1 1478.1,775.6 1479.2,576.4 5102.2,677.6 5266.7,409.2 5867.0,413.1 5867.0,3412.1 2682.2,3393.6 2659.9,6418.9 381.6,6408.1 372.1,7322.0 -0.0,7322.0 -0.0,772.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0071W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1471.7,
-                2088.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6474219,
-                41.8837316
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1471.7,
-                6409.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6473605,
-                41.8817821
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0072W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p72W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0072W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0072W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5813
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3450.4 3161.6,3445.5 3149.4,470.7 3734.8,470.2 4113.9,726.9 4148.7,6459.1 -0.0,6451.4 -0.0,3450.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0072W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4148.7,
-                4963.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6441207,
-                41.8824978
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4148.7,
-                6459.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.644106,
-                41.8818174
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0074W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p74W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0074W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0074W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5813
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1822.3,6515.1 1832.6,0.0 4203.2,0.0 4217.6,6519.9 1822.3,6515.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0074W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1824.3,
-                6515.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6426722,
-                41.8818475
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1820.3,
-                799.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6427529,
-                41.8844384
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0075W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p75W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0075W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0075W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5867
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4147.3,6381.7 1720.7,6341.5 1752.2,772.4 4178.5,844.9 4053.5,1031.5 4037.0,3265.1 4176.2,3578.2 4147.3,6381.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0075W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1727.7,
-                3497.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6412675,
-                41.8831852
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4147.3,
-                6381.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6397063,
-                41.8818886
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0076W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p76W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0076W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0076W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3914.7,7322.0 3911.6,6464.0 1648.0,6437.8 1648.0,3545.0 1501.0,3223.4 1494.3,918.8 1621.3,725.0 5828.0,783.5 5828.0,7322.0 3914.7,7322.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0076W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1648.0,
-                3545.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6397453,
-                41.8831847
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1648.0,
-                6437.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6397063,
-                41.8818886
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0077W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p77W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0077W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0077W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5873
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4308.7,928.3 4319.5,7271.8 1505.8,7322.0 1488.4,922.7 4308.7,928.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0077W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1496.3,
-                6241.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6473605,
-                41.8817821
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4308.7,
-                928.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6440868,
-                41.8805324
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0078W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p78W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0078W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0078W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1350.6,945.6 4152.0,898.2 4162.0,7322.0 1341.1,7322.0 1350.6,945.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0078W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1344.0,
-                6257.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6473203,
-                41.8804962
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4152.0,
-                896.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6440302,
-                41.8792628
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0079W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p79W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0079W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0079W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5873
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1689.1,6488.0 1715.4,871.6 4062.7,868.2 4062.7,6489.8 1689.1,6488.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0079W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4064.7,
-                868.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6426722,
-                41.8818475
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4064.7,
-                6489.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6425803,
-                41.8792909
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0007N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p7N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0007N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0007N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5835
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1672.1,6479.6 1736.7,0.0 5835.0,0.0 5835.0,715.1 4187.0,719.3 4187.5,6491.7 1672.1,6479.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0007N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4187.3,
-                4719.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6341577,
-                41.8947921
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4187.3,
-                2935.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6341809,
-                41.8955921
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0081W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p81W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0081W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0081W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5853
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5853,0 5853,7322 0,7322\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0081W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4184.7,
-                5121.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6396562,
-                41.8793273
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1760.3,
-                5121.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6411293,
-                41.8793088
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0082W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p82W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0082W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0082W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1136.0,1150.3 5828.0,1208.7 5828.0,6832.1 1128.2,6777.0 1136.0,1150.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0082W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3548.0,
-                4009.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6396933,
-                41.8805976
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1136.0,
-                1152.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6412141,
-                41.8818705
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0083W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p83W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0083W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0083W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5853
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1464.6,878.0 4299.9,855.2 4276.9,7268.7 1455.5,7322.0 1464.6,878.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0083W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2868.5,
-                868.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6440079,
-                41.8786291
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2868.5,
-                6221.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6472535,
-                41.8785826
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0084W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p84W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0084W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0084W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5868
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1590.9,898.4 4376.4,881.9 4408.3,7311.0 1586.1,7323.0 1590.9,898.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0084W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2984.0,
-                883.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6439607,
-                41.8773554
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2984.0,
-                6267.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6472189,
-                41.8773156
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0085W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p85W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0085W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0085W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5853
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1807.1,6458.3 1748.3,876.2 5853.0,844.4 5853.0,6465.2 1807.1,6458.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0085W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1748.3,
-                876.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6440302,
-                41.8792628
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4188.7,
-                6473.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6424927,
-                41.8767364
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p86W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5868
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3480.3,826.2 4137.4,829.4 4140.9,5492.9 3447.1,5484.6 3480.3,826.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1760.0,
-                3663.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6425293,
-                41.8780106
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1760.0,
-                6495.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6424927,
-                41.8767364
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0008N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p8N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0008N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0008N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5839
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1661.7,6559.1 1661.7,717.9 2532.5,716.8 2517.7,6561.8 1661.7,6559.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0008N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1663.7,
-                6559.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6341345,
-                41.8939972
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1659.7,
-                719.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6342099,
-                41.8965861
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0091W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p91W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0091W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0091W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5867
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4110.9,5280.0 1710.2,5263.6 1728.6,1070.9 4115.3,1107.8 4111.4,3143.0 4733.9,3138.3 4737.2,4311.5 4115.8,4310.7 4110.9,5280.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0091W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1707.7,
-                6299.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6438857,
-                41.874359
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4115.3,
-                1107.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6424927,
-                41.8767364
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0095W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p95W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0095W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0095W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5867
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5115.5 -0.0,491.2 1746.3,463.0 1745.2,0.0 4147.0,0.0 4169.0,5058.0 -0.0,5115.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0095W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4175.3,
-                6303.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6423562,
-                41.871991
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1747.7,
-                1035.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6438857,
-                41.874359
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0096W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p96W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0096W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0096W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5866
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4108.7,1077.4 4195.5,7323.0 1815.3,7323.0 1772.6,1083.9 4108.7,1077.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0096W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1772.6,
-                1083.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6424248,
-                41.8743741
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4181.4,
-                6303.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6408982,
-                41.8720083
+                -87.64772516695696,
+                41.87399804426635
               ]
             }
           }
@@ -10587,15 +14019,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:41:12Z",
-      "modified": "2026-08-07T15:41:12Z",
+      "created": "2026-08-15T00:39:38Z",
+      "modified": "2026-08-15T00:39:38Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10614,34 +14046,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1723.1,7323.0 1723.4,6537.8 -0.0,6536.8 -0.0,762.8 787.1,757.9 785.4,43.1 5835.0,0.0 5835.0,752.8 4062.3,754.7 4050.6,7323.0 1723.1,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"1723.4,6537.8 1759.3,2982.1 1477.1,2982.7 1491.1,757.2 -0.0,761.8 -0.0,-0.0 5835.0,0.0 5835.0,752.8 4062.3,754.7 4052.3,6542.9 1723.4,6537.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0009N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4055.3,
-                4771.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6312006,
-                41.8948312
+                -87.63370020056928,
+                41.89693723511631
               ]
             }
           },
@@ -10649,20 +14084,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1595.7,
-                6539.1
+                5835.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6326629,
-                41.8940169
+                -87.63018283822744,
+                41.89698734522058
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5835.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63009835469688,
+                41.89370158047106
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63361571703872,
+                41.89365147036679
               ]
             }
           }

--- a/gallery/columbia_sc_1956_vol_1.iiif.json
+++ b/gallery/columbia_sc_1956_vol_1.iiif.json
@@ -7,6 +7,144 @@
   "label": "Mosaic of main content, Columbia, S.C. | 1956",
   "items": [
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"294.7,657.1 4400.0,861.3 4274.1,4566.7 522.8,4341.6 581.5,3454.1 140.4,3427.2 294.7,657.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03615139505767,
+                34.002246711094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03432306848234,
+                34.00290363299368
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03332810580045,
+                34.001003720832855
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03515643237579,
+                34.00034679893318
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0010/georef",
       "type": "Annotation",
       "@context": [
@@ -24,8 +162,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +182,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1010.7,3142.5 1013.6,2937.2 219.1,2935.0 157.7,62.0 4400.0,0.0 4400.0,5204.7 364.4,5204.3 271.6,3043.9 318.1,3140.3 1010.7,3142.5\" /></svg>"
+          "value": "<svg><polygon points=\"983.6,3145.1 986.8,2939.8 219.3,2939.8 150.0,66.6 4400.0,0.0 4400.0,5198.1 370.8,5208.9 267.9,3040.0 318.8,3144.9 983.6,3145.1\" /></svg>"
         }
       },
       "body": {
@@ -73,8 +211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03841378825136,
-                34.015759020728154
+                -81.03840911955477,
+                34.015764195310936
               ]
             }
           },
@@ -94,8 +232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.035008874412,
-                34.01681753013216
+                -81.03500109870538,
+                34.01681481691583
               ]
             }
           },
@@ -115,8 +253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0334180328863,
-                34.01325181428621
+                -81.03342211181065,
+                34.01324584732678
               ]
             }
           },
@@ -136,8 +274,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03682294672566,
-                34.0121933048822
+                -81.03683013266004,
+                34.01219522572188
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0011/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p11",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0011/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0011/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2087.4,0.0 2529.5,565.5 4051.8,547.1 4048.7,21.7 4243.2,19.0 4260.1,546.7 4400.0,546.0 4400.0,4055.9 4261.7,4059.4 4279.9,5517.0 -0.0,5517.0 0.0,0.0 2087.4,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0011/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.05074866377456,
+                34.00245900720518
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04725363533038,
+                34.00352795601433
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04564736669285,
+                33.999867271980555
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04914239513703,
+                33.99879832317141
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0012/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p12",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0012/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0012/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4203.2,566.0 4184.7,4015.3 347.1,4060.0 414.8,532.0 4203.2,566.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0012/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04758474817235,
+                34.00340956442311
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04410586485396,
+                34.00451984688329
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04242425001546,
+                34.00090475272458
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04590313333385,
+                33.9997944702644
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0013/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p13",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0013/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0013/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"277.4,3993.9 216.4,3672.1 276.5,572.6 -0.0,567.0 -0.0,-0.0 3300.9,0.0 3307.7,580.6 4178.7,591.5 4006.1,4651.7 432.4,4548.8 248.2,4858.4 296.5,4094.5 277.4,3993.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0013/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0444854286738,
+                34.004407019672485
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04097910760295,
+                34.00552792021296
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0392814108015,
+                34.00188431401474
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04278773187234,
+                34.00076341347426
               ]
             }
           }
@@ -162,8 +714,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -182,7 +734,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"76.8,4599.1 15.4,2492.2 288.5,2494.4 281.8,438.6 4254.8,549.7 4259.1,4595.4 76.8,4599.1\" /></svg>"
+          "value": "<svg><polygon points=\"325.9,4624.7 347.7,5492.4 160.2,5499.4 138.7,4633.5 -0.0,4636.1 -0.0,557.2 223.5,551.6 229.4,551.5 4125.3,555.4 4236.5,4519.4 325.9,4624.7\" /></svg>"
         }
       },
       "body": {
@@ -211,8 +763,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.04113674669206,
-                34.0053536641989
+                -81.04112536413093,
+                34.00545319652444
               ]
             }
           },
@@ -232,8 +784,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03771969073527,
-                34.006411936300466
+                -81.03760567151637,
+                34.00645396096006
               ]
             }
           },
@@ -253,8 +805,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03612939902968,
-                34.002833070227304
+                -81.03610179800515,
+                34.00276759800742
               ]
             }
           },
@@ -274,8 +826,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03954645498646,
-                34.00177479812574
+                -81.03962149061971,
+                34.00176683357181
               ]
             }
           }
@@ -300,8 +852,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +872,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"159.7,2579.7 2193.1,519.3 2379.9,516.9 4342.4,4616.6 4333.6,4770.7 150.3,4732.4 159.7,2579.7\" /></svg>"
+          "value": "<svg><polygon points=\"4355.7,0.0 4323.6,2135.9 4400.0,2651.9 4092.0,2644.1 4040.7,4604.2 4368.8,4611.2 4363.0,4780.6 -0.0,4687.2 -0.0,1464.4 317.1,1472.6 336.4,0.0 4355.7,0.0\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +901,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.04157679418543,
-                34.00218795098599
+                -81.04644356311381,
+                34.00071427634976
               ]
             }
           },
@@ -370,8 +922,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03821737273393,
-                34.003255189709954
+                -81.04301771366418,
+                34.001845846931
               ]
             }
           },
@@ -391,8 +943,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03661369475671,
-                33.99973649406701
+                -81.04131736663994,
+                33.99825757656334
               ]
             }
           },
@@ -412,8 +964,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0399731162082,
-                33.998669255343046
+                -81.04474321608957,
+                33.9971260059821
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0016/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p16",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0016/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0016/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,2632.9 372.0,2632.7 221.3,2111.5 198.8,847.6 390.9,512.2 4228.3,562.7 4230.6,1449.2 4400.0,1446.6 4400.0,2618.4 4299.6,2620.1 4311.9,4602.4 4400.0,4602.7 4400.0,4745.4 -0.0,4621.6 -0.0,2632.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0016/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04318950972896,
+                34.00175222027894
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03977786065101,
+                34.00279378162649
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03821274684759,
+                33.999220427244026
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04162439592554,
+                33.99817886589648
               ]
             }
           }
@@ -438,8 +1128,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +1148,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4154.3,4655.9 2157.5,4645.8 2164.4,4503.6 120.8,4499.4 119.1,2566.0 251.3,2564.4 240.3,555.3 4362.1,558.6 4368.8,5517.0 4154.6,5517.0 4154.3,4655.9\" /></svg>"
+          "value": "<svg><polygon points=\"2075.7,4590.1 219.9,4587.9 219.7,4452.7 88.6,4451.8 196.3,604.0 4012.9,597.9 4023.3,4450.9 2082.5,4445.0 2075.7,4590.1\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +1177,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03996406075487,
-                34.00274437528697
+                -81.03995087658798,
+                34.00279698260106
               ]
             }
           },
@@ -508,8 +1198,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03647288716661,
-                34.00382778016908
+                -81.03636908789575,
+                34.00390067212247
               ]
             }
           },
@@ -529,8 +1219,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03484487800509,
-                34.00017117398324
+                -81.03471059744402,
+                34.000149156949334
               ]
             }
           },
@@ -550,8 +1240,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03833605159333,
-                33.99908776910113
+                -81.03829238613625,
+                33.999045467427926
               ]
             }
           }
@@ -576,8 +1266,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +1286,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4049.7,0.0 4067.1,606.6 4400.0,601.2 4400.0,4107.0 2271.8,4180.1 2274.3,4710.0 273.0,4746.0 266.0,3777.9 -0.0,3778.6 -0.0,1524.1 164.6,1558.8 238.4,0.0 4049.7,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,627.2 4356.1,603.0 4400.0,4110.2 2268.7,4186.1 2271.9,4716.6 268.4,4755.2 260.1,3786.1 -0.0,3787.0 -0.0,627.2\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +1315,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.04525334016456,
-                33.99806111546629
+                -81.04524566340697,
+                33.99806663734687
               ]
             }
           },
@@ -646,8 +1336,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.04171978297114,
-                33.99914155111628
+                -81.04171446664887,
+                33.99914203114396
               ]
             }
           },
@@ -667,8 +1357,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0400963258689,
-                33.99544034717586
+                -81.04009858540911,
+                33.9954432996278
               ]
             }
           },
@@ -688,8 +1378,1526 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.04362988306234,
-                33.994359911525876
+                -81.04362978216722,
+                33.99436790583071
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0019/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p19",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0019/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0019/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4400.0,2599.8 4400.0,5517.0 2138.9,5517.0 2139.8,5124.8 1995.9,4922.8 831.4,4874.7 619.2,4733.8 425.5,3904.0 436.0,565.0 2294.0,563.9 2292.3,698.3 4214.1,686.8 4234.5,2600.1 4400.0,2599.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0019/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0421396,
+                33.9991089
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0385963,
+                34.0001908
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0369592,
+                33.9965055
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0405025,
+                33.9954236
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001A/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1A",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001A/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001A/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4116.0,707.6 4115.4,4545.3 3642.3,4556.9 3663.3,4838.6 -0.0,4878.4 -0.0,4616.6 158.6,4617.1 66.8,705.9 4116.0,707.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001A/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03430014588595,
+                34.00283359894702
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03252834074249,
+                34.00337360605871
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03171045520031,
+                34.00153242834786
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03348226034377,
+                34.00099242123617
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001B/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1B",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001B/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001B/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4370.4 231.9,695.8 4400.0,930.4 4199.3,4685.8 -0.0,4370.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001B/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03672993458329,
+                34.00360220669436
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03489323434276,
+                34.004275569438256
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0338733706392,
+                34.00236695575301
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03571007087973,
+                34.001693593009115
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001C/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1C",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001C/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001C/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4036.0,667.6 4185.8,4518.9 425.1,4678.5 218.4,828.8 4036.0,667.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001C/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03492627006423,
+                34.00422017725539
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03306049625134,
+                34.00471473980672
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0323114402636,
+                34.0027759142138
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0341772140765,
+                34.00228135166247
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001D/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1D",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001D/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001D/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,4453.0 191.8,647.5 4278.2,881.9 4178.4,4662.0 0.0,4453.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001D/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03730631382288,
+                34.004946386280665
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03546280145109,
+                34.005610556127046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03445686115299,
+                34.00369486359101
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03630037352478,
+                34.00303069374463
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001E/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1E",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001E/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001E/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4122.8,794.4 4004.0,4669.5 239.0,4529.9 375.1,669.9 4122.8,794.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001E/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03557293864652,
+                34.005478024365146
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03375247126522,
+                34.00609594189123
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03281658394094,
+                34.004204196640245
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03463705132225,
+                34.00358627911416
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001F/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1F",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001F/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001F/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"304.9,0.0 374.4,948.6 4239.8,630.2 4400.0,4454.6 261.2,4750.2 0.0,0.0 304.9,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001F/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03781628124811,
+                34.00642783756983
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0359112990818,
+                34.006884335689605
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03521989483154,
+                34.00490476659469
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03712487699785,
+                34.00444826847492
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001G/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1G",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001G/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001G/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4137.9,4512.5 391.1,4670.7 364.2,4000.8 235.9,817.0 3996.0,675.6 4137.9,4512.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001G/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03611470142174,
+                34.00690262119887
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03424337446292,
+                34.00740507716723
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03348236324065,
+                34.00546048100267
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03535369019947,
+                34.00495802503431
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001H/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1H",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001H/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001H/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"645.0,670.7 4400.0,885.2 4304.4,4717.3 400.5,4504.8 645.0,670.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001H/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03851748114735,
+                34.007591361715825
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03671980700597,
+                34.00825324274671
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03571733330871,
+                34.00638518317328
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0375150074501,
+                34.00572330214239
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001I/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1I",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001I/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001I/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4153.8,815.4 4072.0,4705.4 267.8,4591.0 374.1,717.0 4153.8,815.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001I/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03676685118577,
+                34.00816623638243
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03496154517718,
+                34.008765501890004
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03405390788137,
+                34.006889511634206
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03585921388996,
+                34.00629024612663
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001J/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p1J",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001J/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001J/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4462.3 -0.0,2584.4 20.2,2437.6 392.5,2462.6 506.8,647.6 4337.7,887.2 4197.2,3990.4 4034.8,4689.8 -0.0,4462.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001J/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03905462276376,
+                34.008940718719536
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03725292703629,
+                34.00960274787223
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03625022899627,
+                34.0077305092531
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03805192472373,
+                34.00706848010041
               ]
             }
           }
@@ -714,8 +2922,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +2942,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"457.8,3934.9 239.7,3934.4 242.8,541.7 4164.2,524.1 4236.0,4460.3 2253.8,4467.6 2253.9,4609.1 459.7,4609.5 457.8,3934.9\" /></svg>"
+          "value": "<svg><polygon points=\"238.7,3934.6 241.3,540.9 4164.0,522.5 4266.2,4600.9 458.9,4609.0 456.8,3935.1 238.7,3934.6\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +2971,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03347808021417,
-                34.00474080531527
+                -81.03347642126744,
+                34.004740544852574
               ]
             }
           },
@@ -784,8 +2992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02996384141099,
-                34.00582480832505
+                -81.02996308516948,
+                34.00582373154782
               ]
             }
           },
@@ -805,8 +3013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02833489645803,
-                34.00214412755745
+                -81.02833536690264,
+                34.00214399623952
               ]
             }
           },
@@ -826,8 +3034,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03184913526121,
-                34.00106012454767
+                -81.03184870300059,
+                34.00106080954427
               ]
             }
           }
@@ -852,8 +3060,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +3080,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4169.6 -0.0,502.7 167.4,500.6 115.2,639.3 4166.2,615.7 4175.0,1469.0 4386.9,1466.9 4400.0,4101.7 4202.4,4099.3 4208.9,4719.0 202.8,4753.8 190.9,4167.5 -0.0,4169.6\" /></svg>"
+          "value": "<svg><polygon points=\"246.7,632.1 246.0,493.7 295.5,631.4 2186.6,619.0 2192.3,471.0 4170.0,461.7 4208.2,4103.3 4400.0,4105.6 4400.0,4189.0 4209.1,4190.3 4214.7,4724.8 330.4,4758.7 311.0,2796.0 315.8,2796.0 313.5,2547.9 146.9,2549.0 108.4,632.9 246.7,632.1\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +3109,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03882000863081,
-                34.000087556146276
+                -81.03881177374976,
+                34.00008372795934
               ]
             }
           },
@@ -922,8 +3130,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03528437006506,
-                34.001151237376554
+                -81.03528682217144,
+                34.00114402161263
               ]
             }
           },
@@ -943,8 +3151,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03368604954774,
-                33.99744794256923
+                -81.03369359193273,
+                33.99745192055839
               ]
             }
           },
@@ -964,8 +3172,560 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03722168811349,
-                33.99638426133895
+                -81.03721854351105,
+                33.9963916269051
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0021/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p21",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0021/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0021/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3949.2,529.0 4183.5,523.6 4185.5,0.0 4400.0,0.0 4400.0,666.6 4183.8,667.5 4185.8,2549.4 4400.0,2550.1 4400.0,2785.0 4186.0,2787.8 4188.0,4749.4 243.7,4755.1 242.7,4226.6 31.7,4140.6 33.4,1174.0 33.5,1174.0 34.0,80.0 265.0,81.3 259.9,546.2 2145.7,555.5 2145.4,685.1 3959.4,668.5 3949.2,529.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0021/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03552665105579,
+                34.00113283306469
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03195065105578,
+                34.00222838862024
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03029134133533,
+                33.998512375311236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03386734133534,
+                33.997416819755685
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0022/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p22",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0022/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0022/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4236.4,4804.2 167.2,4801.8 159.2,2794.5 379.4,2792.2 378.7,2551.7 320.0,2551.4 158.2,2550.5 150.4,623.7 4226.5,616.5 4231.1,2533.8 4400.0,2534.1 4400.0,2804.3 4231.6,2803.4 4236.4,4804.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0022/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03222641123392,
+                34.00210013537454
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02875541820904,
+                34.00317058097131
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0271468953952,
+                33.999535082900245
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03061788842008,
+                33.99846463730348
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0023/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p23",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0023/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0023/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4400.0,4537.0 82.4,4552.0 82.4,5517.0 -0.0,5517.0 -0.0,4544.0 236.1,4543.3 225.7,577.2 2252.0,539.7 2252.0,0.0 4400.0,0.0 4400.0,4537.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0023/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0439855049927,
+                33.99526902611046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04049471509259,
+                33.99633509762544
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03888006139609,
+                33.99270763069935
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0423708512962,
+                33.99164155918437
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0024/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p24",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0024/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0024/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"385.9,74.1 -0.0,71.6 0.0,0.0 402.8,0.0 521.3,442.0 703.9,616.0 1970.1,717.6 2068.4,891.3 2064.8,1283.6 4325.3,1297.9 4273.5,4625.7 413.6,4634.0 385.9,74.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0024/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0408271843588,
+                33.99628789213545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03729137409455,
+                33.99738855870916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03562432331334,
+                33.99371430870916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0391601335776,
+                33.992613642135446
               ]
             }
           }
@@ -990,8 +3750,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1010,7 +3770,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"253.5,4652.2 244.3,554.6 4149.4,548.1 4152.5,1327.8 4398.7,1328.1 4400.0,4617.4 253.5,4652.2\" /></svg>"
+          "value": "<svg><polygon points=\"4400.0,4617.4 253.6,4654.5 241.8,551.6 4184.4,542.6 4182.2,0.0 4400.0,0.0 4400.0,4617.4\" /></svg>"
         }
       },
       "body": {
@@ -1039,8 +3799,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03752648495255,
-                33.99728469703761
+                -81.03752296381049,
+                33.99728308057311
               ]
             }
           },
@@ -1060,8 +3820,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03405790068027,
-                33.99835121443312
+                -81.03405816550429,
+                33.99834642186703
               ]
             }
           },
@@ -1081,8 +3841,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0324553715525,
-                33.99471803318174
+                -81.03246040872747,
+                33.994717206239635
               ]
             }
           },
@@ -1102,8 +3862,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03592395582477,
-                33.993651515786226
+                -81.03592520703367,
+                33.99365386494571
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0026/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p26",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0026/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0026/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4267.8,4112.9 4088.1,4494.5 361.4,4570.7 286.4,609.0 4220.0,531.7 4267.8,4112.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0026/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0343078736179,
+                33.99833666045655
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03069927668398,
+                33.99938071336291
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02911797199576,
+                33.99563082683236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03272656892969,
+                33.994586773926
               ]
             }
           }
@@ -1128,8 +4026,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1148,7 +4046,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5517.0 0.0,0.0 4400.0,8.7 4400.0,4146.5 3864.2,4147.6 3883.2,5517.0 -0.0,5517.0\" /></svg>"
+          "value": "<svg><polygon points=\"4005.3,10.0 4102.1,4144.2 3861.4,4145.0 3882.3,5517.0 -0.0,5517.0 0.0,0.0 4005.3,10.0\" /></svg>"
         }
       },
       "body": {
@@ -1177,8 +4075,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0425917887779,
-                33.992291070461505
+                -81.04258789851652,
+                33.99229604486191
               ]
             }
           },
@@ -1198,8 +4096,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03913132000922,
-                33.99336952309296
+                -81.0391238456097,
+                33.9933709353566
               ]
             }
           },
@@ -1219,8 +4117,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0375109543231,
-                33.989744625237606
+                -81.03750882974913,
+                33.989742288121825
               ]
             }
           },
@@ -1240,8 +4138,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.04097142309178,
-                33.98866617260615
+                -81.04097288265595,
+                33.98866739762713
               ]
             }
           }
@@ -1266,8 +4164,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1286,7 +4184,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4218.6,4673.6 298.5,4641.1 397.3,538.5 4400.0,627.6 4348.2,4101.7 4231.4,4099.9 4218.6,4673.6\" /></svg>"
+          "value": "<svg><polygon points=\"4221.2,4665.9 -0.0,4635.4 -0.0,436.1 400.8,443.0 398.6,536.9 4400.0,617.7 4349.7,4093.5 4232.8,4091.9 4221.2,4665.9\" /></svg>"
         }
       },
       "body": {
@@ -1315,8 +4213,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03957266372254,
-                33.993546427025095
+                -81.03956529219934,
+                33.993547911886644
               ]
             }
           },
@@ -1336,8 +4234,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03619305593227,
-                33.9946776963272
+                -81.03618454594545,
+                33.994672799963176
               ]
             }
           },
@@ -1357,8 +4255,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03449330530464,
-                33.991137560729086
+                -81.03449438321361,
+                33.99113147182561
               ]
             }
           },
@@ -1378,8 +4276,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03787291309492,
-                33.99000629142698
+                -81.03787512946751,
+                33.99000658374908
               ]
             }
           }
@@ -1404,8 +4302,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1424,7 +4322,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"382.1,3961.9 212.7,3968.4 326.5,3908.1 335.6,524.7 4294.0,523.8 4224.7,4447.8 4400.0,4444.3 4400.0,5517.0 4282.0,5517.0 4236.0,4615.2 642.5,4653.1 577.7,4466.3 388.9,4467.1 382.1,3961.9\" /></svg>"
+          "value": "<svg><polygon points=\"371.3,3968.0 203.8,3974.0 318.0,3913.8 334.8,522.6 4304.2,530.7 4283.9,4462.6 4400.0,4460.6 4400.0,5517.0 4278.1,5517.0 4234.9,4631.5 633.1,4661.2 568.5,4473.9 376.6,4474.3 371.3,3968.0\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +4351,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03639933394521,
-                33.99454725641187
+                -81.03639786511222,
+                33.99454463140841
               ]
             }
           },
@@ -1474,8 +4372,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03290005328805,
-                33.99564700002981
+                -81.03290970237168,
+                33.99564847137733
               ]
             }
           },
@@ -1495,8 +4393,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0312476513936,
-                33.99198154964965
+                -81.03125114557167,
+                33.99199466686834
               ]
             }
           },
@@ -1516,8 +4414,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03474693205077,
-                33.99088180603171
+                -81.03473930831221,
+                33.99089082689942
               ]
             }
           }
@@ -1542,8 +4440,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1562,7 +4460,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"136.9,4829.8 186.8,4651.0 -0.0,4655.9 -0.0,565.0 4136.9,558.7 4062.5,676.1 4086.2,2191.2 4400.0,3111.9 4394.0,4639.5 4262.3,4640.7 4268.7,4808.7 136.9,4829.8\" /></svg>"
+          "value": "<svg><polygon points=\"171.9,4650.5 -0.0,4654.4 -0.0,550.2 139.7,549.6 165.7,548.8 4144.8,561.4 4400.0,0.0 4389.1,4652.8 4257.1,4653.5 4262.9,4821.9 122.0,4829.5 171.9,4650.5\" /></svg>"
         }
       },
       "body": {
@@ -1591,8 +4489,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03298712712929,
-                33.995633328144876
+                -81.03298362770407,
+                33.995625580318745
               ]
             }
           },
@@ -1612,8 +4510,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02962352426616,
-                33.99667063298601
+                -81.02963206282097,
+                33.99666961529047
               ]
             }
           },
@@ -1633,8 +4531,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02806491894664,
-                33.993147348053185
+                -81.02806334512472,
+                33.99315893982297
               ]
             }
           },
@@ -1654,8 +4552,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03142852180977,
-                33.99211004321205
+                -81.03141491000783,
+                33.99211490485124
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0031/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p31",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0031/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0031/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4120.0,2727.7 3933.7,3121.8 4098.7,3333.2 4092.4,5393.6 4400.0,5383.6 4400.0,5517.0 -0.0,5517.0 -0.0,547.9 4058.7,524.9 4171.2,804.2 4120.0,2727.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0031/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03851434889029,
+                33.990899011773195
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03477468909645,
+                33.99209453410998
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03296397139765,
+                33.98820845313543
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03670363119149,
+                33.98701293079864
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0032/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p32",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0032/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0032/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4236.0,2602.6 4012.6,3665.6 3914.1,5517.0 68.8,5517.0 144.7,3387.9 -0.0,3140.4 187.2,2762.9 304.9,776.8 198.1,484.3 219.7,0.0 381.1,0.0 366.0,490.3 550.8,496.6 604.9,678.4 4073.6,776.2 4079.8,1635.0 4197.0,1639.2 4236.0,2602.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0032/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03521983582499,
+                33.991901274102084
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03165050048953,
+                33.99315453422862
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02975233412117,
+                33.98944544652985
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03332166945663,
+                33.98819218640331
               ]
             }
           }
@@ -1680,8 +4854,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1700,7 +4874,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"26.6,3606.5 163.9,2637.6 99.5,739.7 4064.1,688.1 4070.7,1287.5 4075.5,1376.3 4176.4,1375.5 4155.5,4555.9 2135.8,4576.2 2136.4,4645.4 2139.5,4983.3 2144.4,5517.0 1.6,5517.0 26.6,3606.5\" /></svg>"
+          "value": "<svg><polygon points=\"162.2,2638.5 93.1,734.9 4069.9,673.7 4062.0,510.0 4190.3,507.5 4170.7,4552.7 3.0,4603.8 -0.0,3736.7 162.2,2638.5\" /></svg>"
         }
       },
       "body": {
@@ -1729,8 +4903,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03176754987717,
-                33.99305766211916
+                -81.0317589458806,
+                33.99305514417472
               ]
             }
           },
@@ -1750,8 +4924,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02829613816729,
-                33.99410197890595
+                -81.0282952980147,
+                33.994089347394784
               ]
             }
           },
@@ -1771,8 +4945,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02672704599219,
-                33.99046565359368
+                -81.02674140153367,
+                33.99046115475728
               ]
             }
           },
@@ -1792,8 +4966,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03019845770208,
-                33.98942133680689
+                -81.03020504939957,
+                33.98942695153721
               ]
             }
           }
@@ -1818,8 +4992,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,7 +5012,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4372.4,1779.2 4400.0,5517.0 -0.0,5517.0 -0.0,1798.5 4372.4,1779.2\" /></svg>"
+          "value": "<svg><polygon points=\"4376.7,1777.0 4400.0,5517.0 -0.0,5517.0 -0.0,1799.9 4376.7,1777.0\" /></svg>"
         }
       },
       "body": {
@@ -1867,8 +5041,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03718873904225,
-                33.988208318646684
+                -81.03718165042282,
+                33.98820831001669
               ]
             }
           },
@@ -1888,8 +5062,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03373383438526,
-                33.98929821438251
+                -81.0337341979247,
+                33.98929322769235
               ]
             }
           },
@@ -1909,8 +5083,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03209635198883,
-                33.985678976050544
+                -81.0321041946711,
+                33.98568179598364
               ]
             }
           },
@@ -1930,8 +5104,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03555125664582,
-                33.98458908031472
+                -81.03555164716923,
+                33.984596878307975
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0035/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p35",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0035/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0035/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4222.5,2419.1 4251.6,4538.5 4135.1,4539.5 4155.5,5517.0 262.8,5514.6 166.7,1748.9 482.4,1739.2 477.2,1594.1 4069.1,1367.1 4091.1,2423.4 4222.5,2419.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0035/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03381822059285,
+                33.989239251293014
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03036349311685,
+                33.990243159077245
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0288551827009,
+                33.98662414986956
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03230991017689,
+                33.98562024208533
               ]
             }
           }
@@ -1956,8 +5268,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1976,7 +5288,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4308.1,5517.0 -0.0,5517.0 -0.0,4206.2 110.0,4207.5 125.0,2125.6 -0.0,2137.3 -0.0,1089.2 632.7,1062.5 625.6,915.9 2251.4,932.2 2252.1,0.0 4253.3,0.0 4155.4,4172.8 4227.3,4173.4 4308.1,5517.0\" /></svg>"
+          "value": "<svg><polygon points=\"4310.3,5517.0 -0.0,5517.0 -0.0,4204.9 114.4,4206.2 129.1,2125.5 -0.0,2137.5 -0.0,1089.8 131.9,1084.3 140.2,0.0 4254.8,0.0 4157.5,4171.0 4229.3,4171.6 4310.3,5517.0\" /></svg>"
         }
       },
       "body": {
@@ -2005,8 +5317,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0305677200285,
-                33.98999389975501
+                -81.03057116911569,
+                33.98999365925656
               ]
             }
           },
@@ -2026,8 +5338,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02707695945098,
-                33.99107718029138
+                -81.02707824739845,
+                33.991077195404095
               ]
             }
           },
@@ -2047,8 +5359,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0254493822864,
-                33.98742045599523
+                -81.0254502861903,
+                33.98741820721962
               ]
             }
           },
@@ -2068,8 +5380,916 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0289401428639,
-                33.98633717545886
+                -81.02894320790755,
+                33.986334671072086
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p37 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "4400.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5517.0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4052.4,0.0 4051.7,5517.0 -0.0,5517.0 0.0,0.0 4052.4,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04681086778893,
+                33.994704231719524
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.043680590329,
+                33.99566809329122
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04222074206574,
+                33.992415254168755
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04535101952567,
+                33.99145139259706
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037__4/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p37 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "980.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3374.2"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1963.2"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2142.8"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037__4/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"980.0,3374.2 2943.2,3374.2 2943.2,5517.0 980.0,5517.0 980.0,3374.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037__4/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                980.0,
+                3374.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04130824416606,
+                33.98617581589435
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2943.2,
+                3374.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03969064736717,
+                33.986554703666854
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2943.2,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0391913877683,
+                33.985092281332236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                980.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04080898456719,
+                33.98471339355973
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p38 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "4400.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2625.4"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3742.1,2242.9 646.5,2369.7 642.6,2625.4 0.0,2625.4 -0.0,0.0 2990.0,0.0 2515.7,479.6 3677.0,292.9 3742.1,2242.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03963589238955,
+                34.01966215100775
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03851873327089,
+                34.01679481512708
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                2625.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04058629223698,
+                34.01624212581211
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                2625.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04170345135564,
+                34.019109461692786
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p38 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "2625.4"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "4400.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2891.6"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"491.6,4905.7 529.1,2984.2 3671.3,3005.2 3676.0,4909.9 491.6,4905.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                2625.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0388098283379,
+                34.0176368124006
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                2625.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03749247894031,
+                34.01478111962951
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03976163316389,
+                34.0140629282175
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04107898256149,
+                34.01691862098859
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0039/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p39",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0039/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0039/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4400.0,5517.0 4300.4,5517.0 4301.7,4737.2 240.1,4725.3 217.4,674.0 4313.2,665.0 4332.4,0.0 4400.0,0.0 4400.0,5517.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0039/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02743821077166,
+                34.01581106521351
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02396344029229,
+                34.0168757967957
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02236324587393,
+                34.013236928720204
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0258380163533,
+                34.012172197138014
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0003__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p3",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "4400.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5517.0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0003__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0003/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1484.6,5309.0 791.8,5250.5 784.6,5517.0 210.7,5517.0 308.7,433.8 -0.0,425.6 -0.0,68.8 317.6,77.9 313.7,232.4 1272.9,256.6 1267.0,453.2 2334.9,423.8 2337.5,283.6 3855.2,322.1 3839.3,483.0 4400.0,541.1 4217.3,5517.0 1545.4,5517.0 1484.6,5309.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0003__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03864483474115,
+                34.009062906016354
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03725837412298,
+                34.006187552078174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04161333605549,
+                34.00474680652184
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04299979667366,
+                34.007622160460016
               ]
             }
           }
@@ -2094,8 +6314,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2114,7 +6334,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4118.2,4565.6 177.1,4602.1 145.8,557.9 4072.8,532.0 4118.2,4565.6\" /></svg>"
+          "value": "<svg><polygon points=\"169.6,4595.0 147.0,550.5 4074.3,533.1 4110.9,4567.1 169.6,4595.0\" /></svg>"
         }
       },
       "body": {
@@ -2143,8 +6363,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03459986353874,
-                34.00745650715726
+                -81.03459955164624,
+                34.007450743811546
               ]
             }
           },
@@ -2164,8 +6384,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03109710202014,
-                34.00852120217651
+                -81.03109979098787,
+                34.008521743843374
               ]
             }
           },
@@ -2185,8 +6405,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0294971199801,
-                34.00485266024785
+                -81.02949033402147,
+                34.00485634480112
               ]
             }
           },
@@ -2206,8 +6426,868 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0329998814987,
-                34.0037879652286
+                -81.03299009467985,
+                34.00378534476929
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0040/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p40 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0040/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0040/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4024.0,1887.0 4024.0,3258.2 3269.9,3270.7 3267.9,4623.3 3312.3,4794.2 123.1,4209.5 -0.0,4880.0 0.0,0.0 4400.0,0.0 4400.0,332.7 3444.4,142.1 3260.1,1065.1 3247.2,1895.3 4024.0,1887.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0040/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.05125969747554,
+                34.01571721975927
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04489728133818,
+                34.01882413406014
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04019160203791,
+                34.012212606363335
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04655401817527,
+                34.00910569206246
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0041__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p41",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3306.4"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5517.0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0041__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0041/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5517.0 -0.0,0.0 3306.4,0.0 3306.4,5079.1 2266.6,5097.4 2256.3,4834.2 2159.9,4836.7 2166.8,5098.8 1325.9,5119.5 1195.3,5243.6 1187.5,4838.0 152.7,4851.0 154.7,5126.5 632.3,5121.0 638.2,5517.0 -0.0,5517.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0041__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.05376700061836,
+                34.00885395377826
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3306.4,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04844559883965,
+                34.01041920654504
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3306.4,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04529230307429,
+                34.00306403211353
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.050613704853,
+                34.00149877934675
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0042__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p42 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "4400.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "4300.9"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0042__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0042/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3174.9,0.0 3211.8,58.4 4217.6,59.1 4223.5,3054.4 1681.5,3078.4 1676.3,3362.4 1843.1,3362.1 1839.9,3686.5 1684.6,3741.1 1721.7,3738.9 1737.9,4300.9 -0.0,4300.9 0.0,0.0 3174.9,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0042__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04749127473,
+                34.010759446571576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04040897468764,
+                34.012909377539245
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                4300.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03787004454226,
+                34.00717102458475
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                4300.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04495234458463,
+                34.00502109361708
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0043/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p43",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0043/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0043/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"720.5,4512.0 -0.0,953.8 0.0,-0.0 4400.0,0.0 4400.0,4632.0 830.8,4709.1 720.5,4512.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0043/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04615791475398,
+                34.0179790173202
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03927651520232,
+                34.019968151301185
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03626380687074,
+                34.01281732011594
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0431452064224,
+                34.01082818613496
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0045/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p45",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0045/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0045/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,286.5 0.0,-0.0 4103.4,0.0 4400.0,732.0 4400.0,1123.7 4234.9,1623.4 4255.3,4780.6 3243.6,4799.5 3237.1,4479.8 2227.2,4512.9 2228.0,4817.4 177.6,4853.8 173.6,4551.5 253.8,4549.8 237.2,2816.4 177.8,2815.2 147.1,268.9 -0.0,286.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0045/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03538836449596,
+                34.01710267014864
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0283471312651,
+                34.019160444532694
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02523046135212,
+                34.01184352160272
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03227169458299,
+                34.009785747218665
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0046/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p46",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0046/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0046/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2246.5,2450.4 2234.1,2801.4 248.0,2802.5 277.8,1693.3 435.6,1262.8 463.4,899.7 175.9,104.9 -0.0,102.0 0.0,0.0 4400.0,0.0 4400.0,5517.0 4139.1,5517.0 4149.1,4482.5 4075.1,4481.8 4066.9,4805.5 2262.8,4797.2 2278.3,2477.1 2246.5,2450.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0046/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02917166898719,
+                34.01907509002591
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02201008434152,
+                34.02128082821489
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01866931097845,
+                34.013838841677774
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02583089562413,
+                34.01163310348879
               ]
             }
           }
@@ -2232,8 +7312,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2252,7 +7332,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2232.3,0.0 2227.7,642.6 3980.1,667.1 3919.4,4715.2 150.4,4657.8 189.6,0.0 2232.3,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"151.5,4657.7 191.1,0.0 2233.8,0.0 2229.1,642.7 4400.0,673.2 4400.0,2703.0 4233.3,2701.7 4202.8,4719.9 151.5,4657.7\" /></svg>"
         }
       },
       "body": {
@@ -2281,8 +7361,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02942304527247,
-                34.01211112080158
+                -81.02942413676591,
+                34.01211073465078
               ]
             }
           },
@@ -2302,8 +7382,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02598207020446,
-                34.013222944521246
+                -81.02598340979524,
+                34.01322270638883
               ]
             }
           },
@@ -2323,8 +7403,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02431117196177,
-                34.009619313961714
+                -81.02431228910395,
+                34.00961933565424
               ]
             }
           },
@@ -2344,8 +7424,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02775214702979,
-                34.008507490242046
+                -81.02775301607461,
+                34.008507363916195
               ]
             }
           }
@@ -2370,8 +7450,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2390,7 +7470,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4310.6,716.4 4400.0,4696.1 -0.0,4690.8 -0.0,694.8 4310.6,716.4\" /></svg>"
+          "value": "<svg><polygon points=\"284.6,2693.7 449.2,2692.6 420.5,688.5 4320.2,713.4 4339.1,4695.0 283.1,4686.9 284.6,2693.7\" /></svg>"
         }
       },
       "body": {
@@ -2419,8 +7499,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02631335741096,
-                34.013143594668755
+                -81.02631769500631,
+                34.01313725179875
               ]
             }
           },
@@ -2440,8 +7520,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0228071486475,
-                34.01422631526216
+                -81.02281427708064,
+                34.01422156782996
               ]
             }
           },
@@ -2461,8 +7541,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0211799695444,
-                34.01055440877615
+                -81.02118470025547,
+                34.01055258407219
               ]
             }
           },
@@ -2482,8 +7562,974 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02468617830786,
-                34.00947168818275
+                -81.02468811818115,
+                34.009468268040976
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0049/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p49",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0049/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0049/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"189.7,3577.9 178.7,2629.9 2371.3,2523.0 2345.1,951.5 3154.0,934.3 3148.9,537.3 4144.8,518.8 4149.5,4635.5 4194.9,4634.9 4202.9,5007.6 4400.0,5005.4 4400.0,5517.0 2429.5,5517.0 2413.9,4297.0 2200.1,4299.7 2205.6,4664.7 202.6,4700.3 191.2,3711.1 273.9,3710.4 272.7,3576.8 189.7,3577.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0049/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03051262950505,
+                34.00615369954377
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02341346697423,
+                34.00824757358479
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02024212113783,
+                34.00087045321364
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02734128366865,
+                33.99877657917263
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0005/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p5",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0005/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0005/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"298.8,4571.0 382.0,699.6 4241.2,875.3 4084.0,4717.4 298.8,4571.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0005/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03739133191173,
+                34.00947497446657
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03559863400193,
+                34.01009191199479
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03466423096567,
+                34.008229023490365
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03645692887548,
+                34.007612085962144
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0050/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p50",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0050/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0050/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2400.5,929.0 3317.5,937.9 3317.1,485.2 4265.6,502.7 4262.9,0.0 4400.0,0.0 4400.0,5517.0 2538.7,5517.0 2559.6,4331.4 2361.5,4328.5 2400.5,929.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0050/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02418850131674,
+                34.00811120993007
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01724085898853,
+                34.01026218931855
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01398302236882,
+                34.00304252171292
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02093066469703,
+                34.00089154232444
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0051/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p51",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0051/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0051/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2122.9,4465.3 2124.5,4389.1 141.8,4395.1 131.0,381.8 4184.4,369.6 4183.5,0.0 4400.0,0.0 4400.0,5440.1 4337.2,5440.6 4344.0,4263.7 3383.0,4258.1 3432.5,4215.2 2949.8,4405.9 2122.9,4465.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0051/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03112679993426,
+                33.99941467875787
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02414788540501,
+                34.00155664698565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0209036969353,
+                33.994304482759425
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02788261146455,
+                33.99216251453165
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0052/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p52 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0052/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0052/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"280.2,5517.0 -0.0,5517.0 -0.0,0.0 4267.4,0.0 4347.4,5191.0 280.3,5236.6 280.2,5517.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0052/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02522044111566,
+                33.99047950648384
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02346826272692,
+                33.9910203586851
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02265564995194,
+                33.98918489380948
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02440782834067,
+                33.98864404160822
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p53",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"297.1,4849.5 254.6,4185.3 219.4,4185.3 284.5,152.5 2226.6,135.4 2225.4,210.1 2589.7,201.1 3180.9,115.3 3458.6,0.0 4400.0,0.0 4400.0,4477.2 3957.9,4480.4 3981.3,5517.0 -0.0,5517.0 -0.0,4852.2 297.1,4849.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02886913414717,
+                33.99377223526985
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02172954943524,
+                33.99592471452565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01846944114212,
+                33.98850558929908
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02560902585405,
+                33.98635311004328
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053A/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p53A",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053A/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053A/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"472.9,3841.4 553.2,285.5 619.0,286.1 623.8,0.0 4400.0,0.0 4400.0,5517.0 -0.0,5517.0 -0.0,3834.1 472.9,3841.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053A/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02204747148372,
+                33.99446157533667
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0154310126483,
+                33.99659743504449
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01219607603852,
+                33.98972191796095
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01881253487393,
+                33.98758605825313
               ]
             }
           }
@@ -2508,8 +8554,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2528,7 +8574,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 4167.1,0.0 4400.0,1604.0 4367.6,5517.0 -0.0,5517.0 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"3969.0,5517.0 -0.0,5517.0 -0.0,-0.0 130.0,0.0 106.8,1367.4 4037.8,1414.0 4064.8,4594.8 3986.0,4594.2 3969.0,5517.0\" /></svg>"
         }
       },
       "body": {
@@ -2557,8 +8603,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.04971702300554,
-                33.99982227377837
+                -81.04964537046624,
+                33.99967535617411
               ]
             }
           },
@@ -2578,8 +8624,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.04614762212037,
-                34.0008219677973
+                -81.04613533573755,
+                34.00078825365061
               ]
             }
           },
@@ -2599,8 +8645,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.04464545787226,
-                33.99708329204067
+                -81.04444976024001,
+                33.997140788391434
               ]
             }
           },
@@ -2620,8 +8666,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.04821485875743,
-                33.99608359802174
+                -81.0479597949687,
+                33.99602789091493
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053E/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p53E",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053E/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053E/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4241.2,4685.0 217.0,4669.0 223.9,3948.0 72.5,3947.2 -0.0,609.9 4236.8,621.9 4241.2,4685.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053E/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03261987950592,
+                34.01112239846092
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0291572536515,
+                34.012201208460375
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02752330646412,
+                34.00860300830405
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03098593231853,
+                34.007524198304594
               ]
             }
           }
@@ -2646,8 +8830,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2666,7 +8850,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 126.5,0.0 121.5,624.5 4400.0,656.6 4400.0,5517.0 2079.0,5517.0 2082.2,4744.0 100.4,4707.9 105.9,4039.9 -0.0,4040.6 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 147.0,0.0 144.0,699.8 4400.0,693.6 4400.0,5517.0 2055.8,5517.0 2056.0,4691.4 138.7,4673.5 141.6,4023.4 -0.0,4025.6 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -2695,8 +8879,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03134617894331,
-                34.00850917103295
+                -81.0313938002997,
+                34.00856583022286
               ]
             }
           },
@@ -2716,8 +8900,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02789933718363,
-                34.00959482939387
+                -81.02781885077417,
+                34.009661548381324
               ]
             }
           },
@@ -2737,8 +8921,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02626783095735,
-                34.00598490094301
+                -81.02615929477813,
+                34.00594662667667
               ]
             }
           },
@@ -2758,8 +8942,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02971467271705,
-                34.00489924258209
+                -81.02973424430365,
+                34.0048509085182
               ]
             }
           }
@@ -2784,8 +8968,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2804,7 +8988,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"375.6,615.4 4207.2,643.7 4181.8,4713.1 2138.2,4706.1 2135.0,5517.0 372.3,5495.2 375.6,615.4\" /></svg>"
+          "value": "<svg><polygon points=\"2136.1,5517.0 475.6,5517.0 494.9,616.8 4206.3,642.1 4183.1,4712.8 2138.8,4707.0 2136.1,5517.0\" /></svg>"
         }
       },
       "body": {
@@ -2833,8 +9017,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02817973466671,
-                34.00947371293246
+                -81.02817788478698,
+                34.00947470649192
               ]
             }
           },
@@ -2854,8 +9038,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02474744750103,
-                34.01055696190463
+                -81.02474597657609,
+                34.01055603343159
               ]
             }
           },
@@ -2875,8 +9059,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02311954348309,
-                34.00696231771053
+                -81.0231209609841,
+                34.00696178611792
               ]
             }
           },
@@ -2896,8 +9080,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02655183064878,
-                34.005879068738366
+                -81.026552869195,
+                34.00588045917825
               ]
             }
           }
@@ -2922,8 +9106,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2942,7 +9126,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"246.8,644.5 4400.0,682.0 4400.0,5517.0 216.9,5517.0 246.8,644.5\" /></svg>"
+          "value": "<svg><polygon points=\"4325.3,679.0 4335.0,3947.9 223.6,3939.7 244.6,644.1 4325.3,679.0\" /></svg>"
         }
       },
       "body": {
@@ -2971,8 +9155,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02509560797805,
-                34.01045346888866
+                -81.02509343482707,
+                34.010453829450086
               ]
             }
           },
@@ -2992,8 +9176,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02162180309853,
-                34.011551825772266
+                -81.02161980465445,
+                34.01155054481228
               ]
             }
           },
@@ -3013,8 +9197,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.01997117617611,
-                34.00791374132938
+                -81.01997164463461,
+                34.007912643338344
               ]
             }
           },
@@ -3034,8 +9218,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02344498105562,
-                34.00681538444578
+                -81.02344527480723,
+                34.00681592797615
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053I/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p53I",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053I/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053I/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4076.0,4625.5 2172.7,4608.7 2182.1,5517.0 62.1,5517.0 0.0,0.0 127.4,0.0 133.4,785.0 4400.0,754.2 4336.0,3614.2 4061.0,3616.9 4076.0,4625.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053I/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02170124928591,
+                34.011598619183594
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01822644098534,
+                34.01264285968546
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0166448521682,
+                34.00903200009622
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02011966046877,
+                34.00798775959436
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053J/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p53J",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053J/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053J/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"438.1,3949.2 396.0,1460.7 496.2,1459.9 493.9,690.6 4236.0,671.6 4246.5,0.0 4400.0,0.0 4400.0,4702.9 573.3,4736.7 565.9,3949.0 438.1,3949.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053J/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02316905565463,
+                34.01407294026622
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01970409892311,
+                34.015108536108706
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01813560315931,
+                34.01150791381301
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02160055989083,
+                34.010472317970525
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053K/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p53K",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053K/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053K/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"163.5,0.0 150.7,655.1 2082.7,702.2 2069.9,1534.2 4400.0,1569.2 4400.0,4625.2 27.0,4718.8 7.4,0.0 163.5,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053K/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03019954616762,
+                34.00584984476113
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02667271687572,
+                34.00698103206739
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02495943991462,
+                34.003316114677226
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02848626920652,
+                34.00218492737097
               ]
             }
           }
@@ -3060,8 +9658,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3080,7 +9678,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"518.1,4599.5 68.8,4602.7 79.7,1553.4 4176.0,1556.9 4176.1,1401.9 4400.0,1405.7 4400.0,4635.8 4287.4,4636.4 4271.6,4509.0 4112.7,4522.4 4110.9,4652.0 515.6,4736.7 518.1,4599.5\" /></svg>"
+          "value": "<svg><polygon points=\"4125.1,0.0 4400.0,1402.0 4384.4,4644.9 515.8,4747.5 67.2,4613.0 85.9,0.0 4125.1,0.0\" /></svg>"
         }
       },
       "body": {
@@ -3109,8 +9707,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02381364758908,
-                34.00789489705669
+                -81.02380896943922,
+                34.007889870370285
               ]
             }
           },
@@ -3130,8 +9728,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02026739589508,
-                34.00901908084754
+                -81.02027694203751,
+                34.009009008663035
               ]
             }
           },
@@ -3151,8 +9749,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.01857800707151,
-                34.00530501104946
+                -81.01859513513384,
+                34.00530983694747
               ]
             }
           },
@@ -3172,8 +9770,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02212425876552,
-                34.00418082725861
+                -81.02212716253554,
+                34.00419069865472
               ]
             }
           }
@@ -3198,8 +9796,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3218,7 +9816,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,2839.8 -0.0,575.9 517.2,559.2 518.3,695.2 4079.9,516.3 4078.3,387.8 4235.4,370.3 4254.5,496.2 4366.1,492.6 4400.0,3835.5 4285.3,3836.8 4245.3,1750.1 4104.1,1750.3 4178.0,5517.0 1698.8,5517.0 1692.5,4884.2 553.0,4866.6 536.0,2829.5 -0.0,2839.8\" /></svg>"
+          "value": "<svg><polygon points=\"98.7,5517.0 91.1,4767.1 -0.0,4767.5 -0.0,448.7 551.3,578.9 4194.2,448.7 4400.0,430.5 4400.0,5517.0 98.7,5517.0\" /></svg>"
         }
       },
       "body": {
@@ -3247,8 +9845,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0225725710475,
-                34.00519031174178
+                -81.0225590119429,
+                34.00508648919216
               ]
             }
           },
@@ -3268,8 +9866,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0189614106879,
-                34.00624410465924
+                -81.01904380173846,
+                34.00616083164847
               ]
             }
           },
@@ -3289,8 +9887,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.01737785612607,
-                34.00246192790945
+                -81.01741662101556,
+                34.00250798827498
               ]
             }
           },
@@ -3310,8 +9908,316 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.02098901648567,
-                34.00140813499199
+                -81.02093183122,
+                34.001433645818665
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p53N [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "4400.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2252.0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3184.9,2252.0 3158.9,307.7 0.0,350.0 -0.0,337.1 1785.1,326.1 1784.2,0.0 4400.0,0.0 4400.0,2252.0 3184.9,2252.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01819854564287,
+                34.00512084979306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01669563996336,
+                34.00160269056385
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                2252.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01886953139962,
+                34.000965541888185
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                2252.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02037243707913,
+                34.004483701117394
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__3/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p53N [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "2251.6"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "4400.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3265.4"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__3/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3356.7,2775.0 3372.5,5517.0 -0.0,5517.0 -0.0,4559.5 1264.0,4560.9 1279.8,2720.9 222.1,2712.5 223.4,2648.9 65.1,2645.6 68.1,2564.5 1886.1,2588.7 1884.3,2736.7 3356.7,2775.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__3/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                2251.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.01972867288943,
+                34.00816540215515
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                2251.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.0183307875546,
+                34.00526463865271
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02091149887552,
+                34.004397870018714
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.02230938421035,
+                34.007298633521145
               ]
             }
           }
@@ -3336,8 +10242,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3356,7 +10262,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4111.3,4598.1 154.5,4594.8 144.5,559.6 4400.0,568.6 4400.0,4599.1 4284.9,4598.7 4287.4,3976.8 4161.3,3977.3 4111.3,4598.1\" /></svg>"
+          "value": "<svg><polygon points=\"152.7,4598.7 141.3,553.9 4051.1,560.8 4075.6,4600.6 152.7,4598.7\" /></svg>"
         }
       },
       "body": {
@@ -3385,8 +10291,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03579331728527,
-                34.01010698883814
+                -81.0357883384421,
+                34.01010334573841
               ]
             }
           },
@@ -3406,8 +10312,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03232633997403,
-                34.01118526761421
+                -81.0323290744598,
+                34.0111780871031
               ]
             }
           },
@@ -3427,8 +10333,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03070589381193,
-                34.00755431774824
+                -81.03071394434843,
+                34.007555215372086
               ]
             }
           },
@@ -3448,8 +10354,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03417287112316,
-                34.00647603897217
+                -81.03417320833074,
+                34.0064804740074
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0007/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbia, S.C. | 1956 p7",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0007/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0007/info.json",
+          "type": "ImageService2",
+          "height": 5517,
+          "width": 4400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4199.9,950.2 4189.1,4560.8 344.5,4565.6 344.2,4250.0 -0.0,4260.2 -0.0,1447.3 341.8,1442.2 341.0,558.7 4116.7,527.7 4199.9,950.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0007/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.04022618024219,
+                34.011794230353615
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03668707631759,
+                34.01286572603589
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03506420727,
+                34.00918805341685
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5517.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -81.03860331119459,
+                34.008116557734574
               ]
             }
           }
@@ -3474,8 +10518,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3494,7 +10538,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"235.3,4619.7 242.8,0.0 324.6,0.0 346.1,521.7 3962.0,528.5 3893.7,4635.3 235.3,4619.7\" /></svg>"
+          "value": "<svg><polygon points=\"4176.8,4599.5 222.4,4590.0 245.8,977.8 163.5,554.7 -0.0,554.7 -0.0,0.0 299.0,0.0 324.0,557.2 4355.3,561.6 4337.6,3997.9 4177.6,3998.0 4176.8,4599.5\" /></svg>"
         }
       },
       "body": {
@@ -3523,8 +10567,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03705541287246,
-                34.01273979554817
+                -81.0370546237343,
+                34.01277369020242
               ]
             }
           },
@@ -3544,8 +10588,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0336078580459,
-                34.013817303622986
+                -81.03354876130268,
+                34.01386323067674
               ]
             }
           },
@@ -3565,8 +10609,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03198851939005,
-                34.01020680790539
+                -81.0319113396922,
+                34.010191671576855
               ]
             }
           },
@@ -3586,8 +10630,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03543607421663,
-                34.00912929983058
+                -81.03541720212382,
+                34.00910213110254
               ]
             }
           }
@@ -3612,8 +10656,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
+      "created": "2026-08-15T00:52:21Z",
+      "modified": "2026-08-15T00:52:21Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3632,7 +10676,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"236.0,4605.1 262.2,2557.5 -0.0,2554.0 0.0,-0.0 2359.9,0.0 2362.3,423.0 4295.8,417.2 4400.0,5061.9 4316.1,4628.6 236.0,4605.1\" /></svg>"
+          "value": "<svg><polygon points=\"2365.6,0.0 2367.6,424.8 4301.9,421.0 4378.8,4063.7 4153.6,4062.2 4149.9,4632.9 409.1,4607.7 400.9,5517.0 28.7,5517.0 -0.0,-0.0 2365.6,0.0\" /></svg>"
         }
       },
       "body": {
@@ -3661,8 +10705,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.0414524051365,
-                34.01437957110801
+                -81.04145595518916,
+                34.014378022663195
               ]
             }
           },
@@ -3682,8 +10726,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03805031787856,
-                34.01545459613313
+                -81.03805643182517,
+                34.01545539678354
               ]
             }
           },
@@ -3703,8 +10747,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03643468015905,
-                34.01189178466871
+                -81.03643726368846,
+                34.011895270338634
               ]
             }
           },
@@ -3724,4491 +10768,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -81.03983676741699,
-                34.01081675964358
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"689.5,678.2 4397.4,862.6 4274.1,4566.7 4400.0,4818.5 472.8,4638.6 689.5,678.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                492.0,
-                667.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0358265,
-                34.0020903
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4268.0,
-                4689.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0335322,
-                34.001269
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0012/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p12",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0012/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0012/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"268.2,0.0 274.9,530.7 2371.1,547.5 2385.6,0.0 3970.4,12.4 3975.9,561.6 4203.2,566.0 4263.9,4441.4 4362.7,4574.4 4180.9,4827.0 4164.9,5517.0 -0.0,5517.0 73.9,0.0 268.2,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0012/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4184.0,
-                2594.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0434858,
-                34.0027652
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2236.0,
-                547.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0456499,
-                34.0036149
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0013/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p13",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0013/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0013/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"246.3,4395.5 224.0,547.7 -0.0,541.1 -0.0,0.0 3288.1,0.0 3271.9,584.4 4325.5,607.4 4282.2,2600.9 4019.0,2593.5 4027.2,4637.6 437.7,4537.2 246.3,4395.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0013/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                224.0,
-                547.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0440889,
-                34.0040993
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4116.0,
-                4637.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0396804,
-                34.0024121
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0016/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p16",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0016/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0016/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1423.1 272.5,1484.4 288.3,764.5 482.2,473.8 4265.9,613.9 4211.9,2656.2 2248.4,2616.0 2205.5,4730.0 4056.8,4766.8 4031.6,5517.0 317.6,5517.0 340.4,4717.0 -0.0,4714.6 -0.0,1423.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0016/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                304.0,
-                4633.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0415969,
-                33.9987828
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2280.0,
-                579.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.04131,
-                34.0019032
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001A/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1A",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001A/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001A/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4116.0,707.6 4115.4,4545.3 3640.3,4556.9 3655.7,4838.6 306.3,4875.1 158.6,4617.1 66.8,705.9 4116.0,707.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001A/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4116.0,
-                707.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0325378,
-                34.0031026
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4116.0,
-                4689.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0319475,
-                34.0017737
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001B/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1B",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001B/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001B/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4199.3,4685.8 387.1,4466.9 620.1,719.5 4400.0,930.4 4199.3,4685.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001B/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                424.0,
-                707.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0364213,
-                34.0034226
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4132.0,
-                4681.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0341397,
-                34.002615
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001C/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1C",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001C/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001C/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4036.0,667.6 4185.8,4518.9 425.1,4678.5 218.4,828.8 4036.0,667.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001C/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                356.0,
-                4681.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0341397,
-                34.002615
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4036.0,
-                667.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0331242,
-                34.0044392
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001D/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1D",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001D/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001D/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4453.1 191.8,647.5 2309.6,782.2 4392.3,888.1 4178.4,4662.0 -0.0,4453.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001D/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                384.0,
-                659.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0370252,
-                34.0047753
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4112.0,
-                4657.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0347342,
-                34.0039498
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001E/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1E",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001E/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001E/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"239.0,4529.9 375.1,669.9 4122.8,794.4 4004.0,4669.5 239.0,4529.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001E/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                308.0,
-                667.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0353323,
-                34.0052924
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4004.0,
-                4669.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0331242,
-                34.0044392
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001F/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1F",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001F/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001F/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"374.4,948.6 4239.8,630.2 4400.0,4455.1 261.2,4750.2 -0.0,0.0 304.9,0.0 374.4,948.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001F/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4172.0,
-                635.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0359304,
-                34.0066326
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                456.0,
-                4737.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0370252,
-                34.0047753
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001G/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1G",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001G/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001G/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3996.0,675.6 4137.9,4512.5 274.4,4676.0 235.9,817.0 3996.0,675.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001G/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                324.0,
-                4673.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0353323,
-                34.0052924
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3996.0,
-                675.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.034322,
-                34.0071208
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001H/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1H",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001H/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001H/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4400.0,885.2 4304.4,4717.3 400.5,4504.8 461.5,3547.9 157.0,3506.0 259.0,648.6 4400.0,885.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001H/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                452.0,
-                659.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.038213,
-                34.007436
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4236.0,
-                4713.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0359304,
-                34.0066326
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001I/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1I",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001I/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001I/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4153.8,815.4 4072.0,4705.4 267.8,4591.0 374.1,717.0 4153.8,815.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001I/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4072.0,
-                4705.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.034322,
-                34.0071208
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                308.0,
-                715.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0365228,
-                34.0079648
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001J/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p1J",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001J/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001J/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4034.8,4689.8 265.7,4477.3 506.8,647.6 4337.7,887.2 4034.8,4689.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0001J/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                316.0,
-                635.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0388097,
-                34.0087726
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4100.0,
-                4693.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0365228,
-                34.0079648
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0021/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p21",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0021/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0021/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4400.0,2785.0 4186.0,2787.8 4188.0,4749.4 243.7,4755.1 238.9,5517.0 -0.0,5517.0 31.7,4140.6 226.6,4144.1 242.3,702.6 3955.6,668.5 3948.2,529.0 4183.5,523.6 4185.5,0.0 4400.0,0.0 4400.0,667.4 4183.8,668.0 4185.8,2549.4 4400.0,2550.1 4400.0,2785.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0021/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2208.0,
-                4749.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0323037,
-                33.9984836
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4188.0,
-                4749.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0306945,
-                33.9989766
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0022/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p22",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0022/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0022/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"252.0,4745.4 253.1,2800.0 465.3,2797.7 465.7,2564.7 253.2,2563.6 254.2,696.3 2218.6,696.2 2219.1,557.3 4152.5,548.9 4176.9,2545.1 4400.0,2545.4 4400.0,2807.5 4176.2,2806.4 4172.0,4745.4 252.0,4745.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0022/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                252.0,
-                4745.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0306945,
-                33.9989766
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4172.0,
-                4745.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0274838,
-                33.999965
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0023/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p23",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0023/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0023/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4400.0,4537.0 75.6,4557.0 77.0,5517.0 -0.0,5517.0 -0.0,4544.0 236.1,4543.3 225.7,577.2 2252.0,539.7 2252.0,0.0 4400.0,0.0 4400.0,4537.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0023/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2252.0,
-                2594.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0414395,
-                33.9941087
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2252.0,
-                539.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0420409,
-                33.9954598
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0024/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p24",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0024/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0024/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"357.9,4542.8 385.9,74.1 -0.0,71.6 0.0,0.0 4191.1,0.0 4193.5,587.5 4326.5,587.8 4268.1,4625.8 605.7,4635.1 357.9,4542.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0024/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4260.0,
-                2634.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0366078,
-                33.995599
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4260.0,
-                587.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0372263,
-                33.9969622
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0026/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p26",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0026/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0026/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4267.8,4112.9 4088.1,4494.5 342.4,4571.8 286.4,609.0 4220.0,531.7 4267.8,4112.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0026/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2280.0,
-                2562.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0317051,
-                33.9971354
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4220.0,
-                531.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0306945,
-                33.9989766
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0003/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p3",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0003/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0003/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4285.2,2377.9 4250.5,5517.0 1472.6,5517.0 1224.4,5365.0 698.6,5386.9 699.0,5517.0 103.9,5517.0 47.6,210.2 2142.9,200.2 2145.3,410.6 3702.8,359.7 4325.2,402.3 4328.5,2308.6 4285.2,2377.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0003/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4244.0,
-                331.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0376425,
-                34.0060887
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4244.0,
-                4413.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0407915,
-                34.0051369
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0031/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p31",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0031/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0031/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4120.0,2727.7 3933.7,3121.8 4098.7,3333.2 4092.4,5393.6 4400.0,5383.6 4400.0,5517.0 -0.0,5517.0 -0.0,547.9 4058.7,524.9 4171.2,804.2 4120.0,2727.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0031/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2196.0,
-                583.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0364564,
-                33.9910845
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4136.0,
-                583.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0348075,
-                33.9916117
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0032/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p32",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0032/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0032/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3923.0,5350.0 4400.0,5375.1 4400.0,5517.0 68.8,5517.0 144.7,3387.9 -0.0,3140.4 187.2,2762.9 304.9,776.8 198.1,484.3 219.7,0.0 383.4,0.0 368.6,490.4 550.8,496.6 604.9,678.4 4073.6,776.2 4079.9,1653.0 4193.7,1657.3 4236.0,2602.6 4051.9,3522.9 3923.0,5350.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0032/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4236.0,
-                2602.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0308881,
-                33.9913581
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                276.0,
-                547.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0348075,
-                33.9916117
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0035/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p35",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0035/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0035/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4145.2,2516.4 4112.0,4569.5 4004.2,4567.8 3995.6,5517.0 -0.0,5517.0 -0.0,5426.9 251.9,5426.4 255.2,4509.9 190.9,4508.9 265.3,1770.5 565.2,1768.7 564.3,1628.1 4031.9,1493.8 4022.7,2517.4 4145.2,2516.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0035/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                228.0,
-                2550.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0329975,
-                33.9876005
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4112.0,
-                4569.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0292392,
-                33.9872322
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p37 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "4400.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "5517.0"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4052.4,0.0 4051.7,5517.0 -0.0,5517.0 0.0,0.0 4052.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0037__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4052.0,
-                3314.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0430512,
-                33.9936378
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4052.0,
-                1127.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0436299,
-                33.9949271
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p38 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "4400.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "2625.4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3742.1,2242.9 646.5,2369.7 642.6,2625.4 -0.0,2625.4 -0.0,0.0 2023.5,0.0 360.6,673.4 390.0,821.2 3677.0,292.9 3742.1,2242.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                392.0,
-                823.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0401836,
-                34.0192351
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                648.0,
-                2369.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0413379,
-                34.018742
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p38 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "2625.4"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "4400.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "2891.6"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"491.6,4905.7 529.1,2984.2 3671.3,3005.2 3676.0,4909.9 491.6,4905.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0038__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2348.0,
-                4909.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0398996,
-                34.0155455
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3676.0,
-                4909.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.039502,
-                34.0146836
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0039/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p39",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0039/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0039/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4246.8,5517.0 4260.5,4710.2 276.7,4657.1 316.0,659.6 4333.8,692.5 4397.3,5517.0 4246.8,5517.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0039/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                316.0,
-                2670.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.026455,
-                34.0140827
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                316.0,
-                659.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.027071,
-                34.0154191
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0040/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p40 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0040/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0040/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3030.7,651.4 3705.5,605.4 3797.3,1840.5 4400.0,1918.6 4400.0,2806.0 4355.9,3206.0 3882.9,3166.9 3154.2,3226.0 3277.2,4649.1 4294.5,4796.3 4288.3,4853.1 397.7,4349.2 279.3,5408.7 59.0,5387.3 42.2,5517.0 -0.0,5517.0 -0.0,-0.0 4400.0,0.0 4400.0,339.4 3109.0,172.7 3030.7,651.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0040/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2368.0,
-                4597.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0438822,
-                34.0118408
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                776.0,
-                4317.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0465636,
-                34.0111692
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0041__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p41",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "3306.4"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "5517.0"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0041__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0041/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3306.4,5078.1 2266.6,5097.4 2256.3,4834.2 2159.9,4836.7 2168.8,5517.0 -0.0,5517.0 -0.0,0.0 3306.4,0.0 3306.4,5078.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0041__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3198.5,
-                3082.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0468576,
-                34.0062588
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2186.9,
-                3082.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0484856,
-                34.00578
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0042__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p42 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "4400.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "4300.9"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0042__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0042/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"204.9,0.0 4303.5,18.6 4310.6,1014.8 4400.0,1013.1 4400.0,3018.9 1794.1,3073.0 1797.1,3358.2 1859.5,3357.4 1870.2,3651.3 1781.1,3733.6 1806.9,4300.9 -0.0,4300.9 -0.0,1085.9 223.9,1078.8 204.9,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0042__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1236.0,
-                2078.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0442748,
-                34.0085902
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3260.0,
-                3041.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0404606,
-                34.0082571
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0043/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p43",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0043/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0043/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 4400.0,0.0 4400.0,4646.4 760.5,4601.5 454.4,3147.9 -0.0,501.5 -0.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0043/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2964.0,
-                2374.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0402364,
-                34.0162632
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                760.0,
-                4601.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0424558,
-                34.0123586
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0045/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p45",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0045/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0045/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4857.9 -0.0,2818.8 181.1,2815.3 143.4,265.6 -0.0,286.5 0.0,-0.0 4103.4,0.0 4400.0,732.0 4400.0,1123.7 4234.9,1623.4 4255.3,4780.6 3243.6,4799.5 3237.1,4479.8 2227.2,4512.9 2228.0,4817.4 -0.0,4857.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0045/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2228.0,
-                4817.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0291015,
-                34.0117556
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1208.0,
-                3817.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0312984,
-                34.0126041
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0046/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p46",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0046/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0046/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"248.0,2802.5 277.8,1693.3 435.6,1262.8 463.4,899.7 175.9,104.9 -0.0,102.0 0.0,0.0 4400.0,0.0 4400.0,5517.0 4139.1,5517.0 4149.1,4482.5 4075.1,4481.8 4066.9,4805.5 2284.2,4801.5 2234.1,2801.4 248.0,2802.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0046/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                248.0,
-                2802.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.027071,
-                34.0154191
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2280.0,
-                2802.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0237637,
-                34.0164378
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0049/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p49",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "23"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0049/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0049/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"191.2,3711.1 305.3,3710.1 303.5,3576.4 189.7,3577.9 178.7,2629.9 2371.3,2523.0 2328.3,952.9 3154.0,934.8 3148.9,537.3 4144.8,518.8 4173.7,2487.3 4137.2,2488.1 4127.6,3645.4 4400.0,3641.0 4400.0,4682.4 4195.8,4678.5 4243.7,5517.0 3210.1,5517.0 3210.1,5517.0 2429.5,5517.0 2413.9,4297.0 2200.1,4299.7 2205.6,4664.7 202.6,4700.3 191.2,3711.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0049/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2180.0,
-                2562.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0255222,
-                34.0037645
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4168.0,
-                1483.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0229352,
-                34.0061539
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0005/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p5",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0005/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0005/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"298.8,4571.0 382.0,699.6 4241.2,875.3 4084.0,4717.4 298.8,4571.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0005/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                380.0,
-                699.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0371172,
-                34.0092923
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4084.0,
-                4717.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0349284,
-                34.0084547
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0050/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p50",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0050/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0050/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3317.5,937.9 3317.1,485.2 4265.6,502.7 4260.2,947.0 4400.0,948.3 4400.0,5517.0 2538.7,5517.0 2559.6,4331.4 2388.8,4328.5 2408.4,929.1 3317.5,937.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0050/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2292.0,
-                1479.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0196959,
-                34.007296
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2292.0,
-                4317.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0180198,
-                34.0035815
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0051/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p51",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0051/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0051/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2949.8,4405.9 2122.9,4465.3 2124.5,4389.1 141.8,4395.1 147.8,3656.9 -0.0,3217.4 -0.0,2454.9 123.1,2186.4 131.0,381.8 4184.4,369.6 4183.5,0.0 4400.0,0.0 4400.0,5440.1 4337.2,5440.6 4344.0,4263.7 3383.0,4258.1 3432.5,4215.2 2949.8,4405.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0051/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3716.0,
-                4093.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0228245,
-                33.9958401
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2156.0,
-                379.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0274838,
-                33.999965
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0052/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p52 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0052/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0052/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3665.5,5517.0 3016.1,4992.3 120.4,974.9 -0.0,735.3 0.0,-0.0 4400.0,-0.0 4400.0,5517.0 3665.5,5517.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0052/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3408.0,
-                2026.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0209107,
-                33.989341
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4072.0,
-                5017.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.025299,
-                33.9868608
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p53",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3257.5,4151.8 219.4,4185.3 277.7,569.6 229.0,570.0 222.3,153.5 2226.6,135.4 2225.4,210.1 2589.7,201.1 3180.9,115.3 3458.6,0.0 4400.0,0.0 4400.0,1152.9 4224.0,1155.4 4238.2,1904.8 4400.0,2045.3 4400.0,2931.3 4230.9,3121.8 3262.8,3149.4 3257.5,4151.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                252.0,
-                3186.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0265774,
-                33.9896107
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4224.0,
-                1155.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0213324,
-                33.9942849
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053A/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p53A",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053A/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053A/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1045.0,2383.0 1025.0,2300.9 1120.5,2205.5 1118.2,1827.1 970.9,1691.7 510.2,2187.7 522.4,1229.6 868.9,851.8 887.4,288.4 1412.6,294.3 1411.3,145.4 621.3,152.3 623.8,0.0 4400.0,0.0 4400.0,5517.0 -0.0,5517.0 -0.0,3834.1 1443.9,3856.4 1431.0,2390.2 1045.0,2383.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053A/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2536.0,
-                2386.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0168339,
-                33.9927184
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2308.0,
-                1667.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0176011,
-                33.9935064
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053E/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p53E",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053E/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053E/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4236.8,621.9 4241.2,4685.0 332.2,4669.4 355.3,610.9 4236.8,621.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053E/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2212.0,
-                619.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0306956,
-                34.0112606
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4232.0,
-                2654.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0285017,
-                34.0104292
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053I/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p53I",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053I/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053I/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4073.8,5517.0 4076.0,4625.5 2172.7,4608.7 2182.1,5517.0 128.0,5517.0 73.9,785.4 3946.8,757.7 3948.1,0.0 4400.0,0.0 4400.0,5517.0 4073.8,5517.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053I/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2156.0,
-                771.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0197774,
-                34.0116053
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4076.0,
-                4625.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0171563,
-                34.0095386
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053J/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p53J",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053J/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053J/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"550.3,1496.1 538.4,699.2 4236.0,671.6 4246.5,0.0 4400.0,0.0 4400.0,4702.9 508.1,4737.3 396.1,1499.0 550.3,1496.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053J/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4236.0,
-                671.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0196423,
-                34.0146316
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                492.0,
-                4737.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0214347,
-                34.0110969
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053K/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p53K",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053K/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053K/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"163.5,0.0 150.7,655.1 2082.7,702.2 2071.1,1460.3 4400.0,1475.2 4400.0,4625.2 27.0,4718.8 14.4,0.0 163.5,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053K/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4032.0,
-                2898.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0260692,
-                34.0049605
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2020.0,
-                4677.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0271278,
-                34.0032619
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p53N [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "4400.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "2252.0"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4400.0,460.3 824.1,520.2 0.0,526.1 -0.0,401.4 1785.2,378.7 1784.2,0.0 4400.0,0.0 4400.0,460.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4232.0,
-                400.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0171391,
-                34.0016239
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                288.0,
-                400.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0184863,
-                34.0047774
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__3/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p53N [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "2251.6"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "4400.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "3265.4"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__3/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5504.4 -0.0,4427.2 445.4,4418.2 418.5,2686.1 1387.1,2654.6 1380.7,2276.1 4400.0,2251.6 4400.0,5517.0 1155.0,5517.0 1153.1,5416.7 -0.0,5504.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0053N__3/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1248.0,
-                2607.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0171391,
-                34.0016239
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3036.0,
-                2607.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0164319,
-                33.9998749
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0007/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbia, S.C. | 1956 p7",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T14:19:10Z",
-      "modified": "2026-08-07T14:19:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0007/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0007/info.json",
-          "type": "ImageService2",
-          "height": 5517,
-          "width": 4400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4199.9,950.2 4189.1,4560.8 2199.0,4563.6 2198.8,4563.6 308.8,4566.2 352.8,558.6 4116.7,527.7 4199.9,950.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd391m:g3914m:g3914cm:g3914cm_g08131195601:08131_01_1956-0007/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2204.0,
-                2562.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0376996,
-                34.0106227
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2204.0,
-                547.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -81.0382923,
-                34.0119658
+                -81.03983678705245,
+                34.01081789621829
               ]
             }
           }

--- a/gallery/columbus_oh_1951_vol_3.iiif.json
+++ b/gallery/columbus_oh_1951_vol_3.iiif.json
@@ -7,6 +7,468 @@
   "label": "Mosaic of main content, Columbus, Ohio | 1951 | Vol. 3",
   "items": [
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0201__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p201 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3567.5"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6552.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "4227.5"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0201__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0201/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6552
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5179.9,6386.9 6552.0,6088.4 6552.0,7795.0 -0.0,7795.0 0.0,3567.5 4452.2,3659.1 5179.9,6386.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0201__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3567.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0206780269101,
+                40.02528657041383
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                3567.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0168328370542,
+                40.02511408697952
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0169781874558,
+                40.0232140103231
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.02082337731171,
+                40.023386493757414
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p202 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6473.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7796.0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6473
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6340.2,6732.2 6473.0,6755.8 6387.9,7796.0 -0.0,7796.0 -0.0,3923.2 1096.7,4204.1 1473.6,2731.5 169.2,2589.9 143.0,0.0 6473.0,0.0 6473.0,3377.5 6333.3,3403.8 6340.2,6732.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0181451539687,
+                40.02507617953364
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6473.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01419889470714,
+                40.02566405237804
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6473.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01327472549782,
+                40.02202617966565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01722098475939,
+                40.02143830682125
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p202 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "4109.6"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1680.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3686.4"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6473
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"148.1,7514.0 151.2,4271.2 298.8,4244.4 299.6,4109.6 1081.4,4109.6 1018.4,4354.3 1680.8,4526.0 1680.8,7796.0 148.1,7514.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                4109.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01400178089895,
+                40.02412372593353
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1680.8,
+                4109.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01295347047288,
+                40.02428525193694
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1680.8,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01249042122456,
+                40.02252299823935
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01353873165063,
+                40.02236147223594
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0203/georef",
       "type": "Annotation",
       "@context": [
@@ -24,8 +486,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +506,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"727.0,1818.8 -0.0,1816.1 -0.0,-0.0 6296.2,0.0 6243.6,7637.4 -0.0,7795.0 -0.0,6018.8 97.6,5993.5 -0.0,5222.6 1572.7,5116.4 727.0,1818.8\" /></svg>"
+          "value": "<svg><polygon points=\"80.3,5230.6 1570.4,5122.6 716.9,1826.0 -0.0,1824.9 -0.0,-0.0 6552.0,0.0 6365.1,65.9 6401.4,7637.9 -0.0,7795.0 -0.0,6334.7 253.0,6271.7 80.3,5230.6\" /></svg>"
         }
       },
       "body": {
@@ -73,8 +535,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.01328581581359,
-                40.02495464041496
+                -83.01327670656309,
+                40.02495819317676
               ]
             }
           },
@@ -94,8 +556,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00931096823625,
-                40.02479795270794
+                -83.00930344827215,
+                40.024794432301434
               ]
             }
           },
@@ -115,8 +577,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00955272121315,
-                40.02115058576744
+                -83.0095561144446,
+                40.02114852408569
               ]
             }
           },
@@ -136,8 +598,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0135275687905,
-                40.021307273474456
+                -83.01352937273555,
+                40.02131228496101
               ]
             }
           }
@@ -162,8 +624,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -182,7 +644,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6489.0,7596.3 6455.4,7481.6 150.0,7432.5 151.7,7613.3 -0.0,7618.7 -0.0,0.0 6489.0,115.2 6489.0,7596.3\" /></svg>"
+          "value": "<svg><polygon points=\"78.2,112.9 263.0,46.8 6489.0,111.7 6489.0,1845.2 6377.3,1845.7 6412.2,6898.6 5855.6,6900.6 5852.3,7470.4 147.5,7427.0 78.2,112.9\" /></svg>"
         }
       },
       "body": {
@@ -211,8 +673,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00946457842203,
-                40.024824903466865
+                -83.00946274957734,
+                40.02482372568889
               ]
             }
           },
@@ -232,8 +694,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00549482126941,
-                40.024647285808754
+                -83.00549132098608,
+                40.024645466715405
               ]
             }
           },
@@ -253,8 +715,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0057713991449,
-                40.02097091523122
+                -83.00576889745459,
+                40.020967547788025
               ]
             }
           },
@@ -274,8 +736,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00974115629754,
-                40.021148532889335
+                -83.00974032604584,
+                40.02114580676151
               ]
             }
           }
@@ -300,8 +762,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +782,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,261.6 -0.0,-0.0 5248.5,0.0 5246.1,229.5 6552.0,221.5 6552.0,7795.0 6274.8,7795.0 6272.7,7656.8 644.9,7744.3 589.2,258.0 -0.0,261.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7052.4 557.6,7047.2 493.5,1987.6 605.4,1986.6 595.4,250.6 -0.0,254.2 -0.0,-0.0 5249.3,0.0 5246.6,228.6 6552.0,222.5 6552.0,7795.0 -0.0,7622.9 -0.0,7052.4\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +811,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00584897410155,
-                40.02473265815868
+                -83.00584912033386,
+                40.02472878369341
               ]
             }
           },
@@ -370,8 +832,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00184722205755,
-                40.024530888085536
+                -83.00184784668247,
+                40.02453135014609
               ]
             }
           },
@@ -391,8 +853,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00215853137186,
-                40.02085882025101
+                -83.0021524647503,
+                40.020859715771245
               ]
             }
           },
@@ -412,8 +874,746 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00616028341587,
-                40.02106059032415
+                -83.0061537384017,
+                40.021057149318565
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p206 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6489.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3919.5"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6489
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1280.1,3767.4 1311.0,273.7 -0.0,267.1 0.0,0.0 5355.9,65.8 5341.5,3767.5 1280.1,3767.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0026311807336,
+                40.024584565982195
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6489.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99875287575024,
+                40.02442226598218
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6489.0,
+                3919.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99888084985824,
+                40.02262896379265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3919.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0027591548416,
+                40.02279126379266
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p206 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3889.1"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6489.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3905.9"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6489
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"595.7,6925.9 595.7,3889.1 6489.0,3889.1 6489.0,6925.6 595.7,6925.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3889.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99979352711489,
+                40.02443668040528
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6489.0,
+                3889.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99585847651085,
+                40.02426029313731
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6489.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99599713271694,
+                40.022446322177125
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99993218332098,
+                40.022622709445095
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0207/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p207",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0207/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0207/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6552
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3245.7,6321.0 508.5,6313.6 507.9,5117.0 779.5,5119.9 821.3,776.7 4920.0,779.9 4920.0,3336.3 4584.1,3362.6 4573.4,5699.9 3248.5,5677.1 3245.7,6321.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0207/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00245071879642,
+                40.0232012138868
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99857024232294,
+                40.02304108851199
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99881903575681,
+                40.01950517052633
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0026995122303,
+                40.01966529590114
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0208/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p208",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0208/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0208/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6489
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"335.6,3180.1 323.9,0.0 6489.0,0.0 6489.0,7795.0 -0.0,7795.0 -0.0,3180.2 335.6,3180.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0208/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99973193758119,
+                40.02301875201956
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6489.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99588780824912,
+                40.02284654978725
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6489.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99615783976837,
+                40.01931139083036
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00000196910044,
+                40.01948359306267
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0209__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p209 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6552.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0209__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0209/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6552
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,7795 0,0 6552,0 6552,7795 0,7795\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0209__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.02063085767792,
+                40.02352479655256
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01288229700951,
+                40.02425184075847
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01175267858758,
+                40.017191169806026
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01950123925599,
+                40.016464125600116
               ]
             }
           }
@@ -438,8 +1638,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +1658,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1416.8,7644.0 -0.0,1424.9 0.0,0.0 5685.4,0.0 5482.8,199.2 5463.6,2851.9 5366.8,2867.0 5153.5,7775.5 1416.8,7644.0\" /></svg>"
+          "value": "<svg><polygon points=\"1385.2,7514.0 -0.0,7795.0 0.0,-0.0 5682.7,0.0 5480.6,190.1 5463.3,2845.9 5366.5,2861.1 5156.7,7775.5 1415.6,7646.7 1385.2,7514.0\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +1687,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.01296038986531,
-                40.02128943932574
+                -83.01295532241204,
+                40.02128704357877
               ]
             }
           },
@@ -508,8 +1708,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00917284740913,
-                40.02122165882289
+                -83.00917226370285,
+                40.02121708972403
               ]
             }
           },
@@ -529,8 +1729,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00927838682584,
-                40.017713863496105
+                -83.00928118719435,
+                40.01771344697557
               ]
             }
           },
@@ -550,8 +1750,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.01306592928202,
-                40.01778164399895
+                -83.01306424590354,
+                40.01778340083031
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0211/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p211",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0211/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0211/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6552
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,384.9 185.3,294.0 182.5,0.0 6552.0,0.0 6552.0,1586.4 5944.5,1710.9 6032.0,7683.0 -0.0,7730.1 -0.0,2971.3 92.3,2952.7 -0.0,384.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0211/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0097473874243,
+                40.021321000810566
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00578081505996,
+                40.021119624488044
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00609368750192,
+                40.017505090116266
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01006025986625,
+                40.01770646643879
               ]
             }
           }
@@ -576,8 +1914,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +1934,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6318.2,5453.2 6322.4,7703.4 7.0,7651.6 -0.0,1607.9 641.4,1487.8 666.5,0.0 6489.0,0.0 6489.0,5448.0 6318.2,5453.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1618.0 620.9,1499.3 640.3,0.0 6489.0,120.9 6489.0,7694.2 11.1,7667.1 -0.0,1618.0\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +1963,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00618179835124,
-                40.02108066094714
+                -83.00616556950874,
+                40.021086295219405
               ]
             }
           },
@@ -646,8 +1984,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00232362555201,
-                40.02093254350419
+                -83.00230913806985,
+                40.020926313380286
               ]
             }
           },
@@ -667,8 +2005,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00255425468154,
-                40.01735931853968
+                -83.00255824088696,
+                40.017354701167406
               ]
             }
           },
@@ -688,8 +2026,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00641242748077,
-                40.017507435982644
+                -83.00641467232585,
+                40.017514683006524
               ]
             }
           }
@@ -714,8 +2052,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +2072,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"583.9,0.0 4656.9,0.0 4682.5,2225.6 6552.0,2202.5 6552.0,6974.2 562.7,7053.4 512.2,4804.9 682.8,4796.1 583.9,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"3329.6,0.0 4653.2,0.0 4679.2,2225.5 5610.8,2213.8 5706.1,6984.8 721.3,7051.6 614.2,676.1 3340.8,636.9 3329.6,0.0\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +2101,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00268957057958,
-                40.02065416283979
+                -83.00268750973221,
+                40.02065443500441
               ]
             }
           },
@@ -784,8 +2122,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.99879860695607,
-                40.02044271803286
+                -82.99879639589626,
+                40.0204424585699
               ]
             }
           },
@@ -805,8 +2143,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.99912482408249,
-                40.016872100611735
+                -82.9991234332179,
+                40.01687170330342
               ]
             }
           },
@@ -826,8 +2164,1680 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00301578770599,
-                40.017083545418664
+                -83.00301454705385,
+                40.01708367973793
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0214/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p214",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0214/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0214/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6489
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3636.1,7151.8 -0.0,7056.9 -0.0,2331.6 5442.8,2376.2 5462.4,0.0 6489.0,0.0 6489.0,7795.0 3690.6,7795.0 3636.1,7151.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0214/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99937741882127,
+                40.020538710527276
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6489.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99545289837883,
+                40.02038762011321
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6489.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99568974006115,
+                40.01677724764823
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99961426050359,
+                40.01692833806229
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0215/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p215",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0215/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0215/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6552
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2648.1,7479.6 -0.0,7472.4 -0.0,-0.0 6255.4,0.0 6237.9,7795.0 2647.2,7795.0 2648.1,7479.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0215/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01588448720152,
+                40.01732373532137
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01208053580639,
+                40.01792183685059
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0111513250692,
+                40.01445533420636
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01495527646433,
+                40.01385723267714
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0216/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p216",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0216/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0216/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6513
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"801.3,59.4 5729.5,1363.4 5723.1,7474.3 804.0,7525.0 801.3,59.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0216/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0127093183679,
+                40.01778901464995
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00892609663613,
+                40.018376041463625
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00800904490052,
+                40.01490941213308
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01179226663228,
+                40.0143223853194
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0217/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p217",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0217/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0217/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6552
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1376.3,7065.4 -0.0,1398.9 -0.0,963.0 5641.9,1076.1 6552.0,5170.4 6552.0,7060.3 5247.0,7382.3 4952.8,6179.2 3766.6,6473.8 4058.0,7676.0 2819.6,7795.0 2591.2,6856.5 1376.3,7065.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0217/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00914033033582,
+                40.018132044148786
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00527128773975,
+                40.018018407191605
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00544783533596,
+                40.01449261118158
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00931687793204,
+                40.01460624813876
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0218/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p218",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0218/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0218/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6513
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1467.5,6952.8 1032.7,7069.0 996.7,5160.5 -0.0,1042.9 5707.0,1049.6 5757.6,7795.0 1689.9,7795.0 1467.5,6952.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0218/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00579820585821,
+                40.018014101444955
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00199221910647,
+                40.01784718926235
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00225296912166,
+                40.01435970324022
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0060589558734,
+                40.014526615422824
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0219/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p219",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0219/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0219/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6552
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7495.8 -0.0,413.6 6552.0,471.2 6552.0,7529.2 -0.0,7495.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0219/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00248627495759,
+                40.01758392542453
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99864595861159,
+                40.01743764334395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99887322374,
+                40.013938020761515
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.002713540086,
+                40.01408430284209
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0220/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p220",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0220/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0220/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6513
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3972.6,461.1 4031.0,1122.6 6513.0,1113.8 6513.0,6941.8 3764.9,6930.9 3766.3,7427.0 1847.6,7425.0 1819.0,389.4 3972.6,461.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0220/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99971695772108,
+                40.01744547866704
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99588723149147,
+                40.0172876277371
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99613382539827,
+                40.01377837988762
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99996355162789,
+                40.01393623081756
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0221__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p221 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6552.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0221__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0221/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6552
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6353.5,0.0 6334.5,4081.0 4651.2,7795.0 -0.0,7795.0 -0.0,-0.0 6353.5,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0221__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01713646567147,
+                40.01366840278293
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0133404539403,
+                40.014257062040144
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01242594708226,
+                40.01079766475146
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01622195881343,
+                40.01020900549425
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0222/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p222",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0222/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0222/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6513
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1729.0,4164.9 1716.5,371.5 5365.8,341.0 5426.5,7545.1 2361.3,7496.3 430.9,7005.9 1729.0,4164.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0222/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01444196804032,
+                40.01411493705019
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01071535283863,
+                40.01467593492567
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00984514078039,
+                40.0112369348884
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01357175598207,
+                40.01067593701292
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0223/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p223",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0223/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0223/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6552
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"801.1,0.0 5760.4,0.0 5758.7,155.1 5144.2,147.8 5093.7,6441.5 3209.6,5909.6 3221.4,7795.0 -0.0,7795.0 -0.0,7365.4 724.4,7388.7 801.1,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0223/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01181765658542,
+                40.01443967171442
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00805048570604,
+                40.015055223108575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6552.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00709418638401,
+                40.01162216088429
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0108613572634,
+                40.01100660949014
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0224/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p224",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0224/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0224/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6513
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3074.3,88.7 4296.7,85.0 4295.9,1324.4 6086.2,1321.6 6080.4,6304.4 4076.6,6299.1 3833.3,7217.3 3813.3,6298.4 3057.7,6296.4 3014.5,7159.9 -0.0,6390.7 -0.0,91.7 1841.4,92.5 1839.6,1146.9 3070.9,1326.4 3074.3,88.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0224/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00885267202086,
+                40.01489846169233
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00508289771496,
+                40.01549026781
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00415840623981,
+                40.012035861652684
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00792818054572,
+                40.011444055535016
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0225/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p225",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0225/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0225/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6522
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"937.3,2039.7 3234.3,2070.9 3242.2,2497.0 6437.3,2437.6 6390.8,567.4 6522.0,601.8 6522.0,7516.2 -0.0,5848.2 937.3,2039.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0225/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01302946283077,
+                40.01183885816388
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00923493545542,
+                40.01240263665666
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00835533960755,
+                40.00892968466295
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0121498669829,
+                40.00836590617017
               ]
             }
           }
@@ -852,8 +3862,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +3882,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5762.0,498.7 6513.0,519.5 6513.0,1458.2 6234.2,2416.5 5479.2,2193.0 3872.4,7795.0 757.2,6885.4 817.8,0.0 5699.4,1358.5 5762.0,498.7\" /></svg>"
+          "value": "<svg><polygon points=\"6513.0,521.8 6513.0,1438.1 6228.3,2418.0 5473.2,2194.9 3869.8,7795.0 719.0,6876.9 943.0,0.0 5692.9,1360.6 5755.1,501.1 6513.0,521.8\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +3911,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00970624748027,
-                40.01202057788381
+                -83.00970423174692,
+                40.01202340272774
               ]
             }
           },
@@ -922,8 +3932,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00597116072899,
-                40.01268287989636
+                -83.00596718849526,
+                40.01268464406868
               ]
             }
           },
@@ -943,8 +3953,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00494383835992,
-                40.00923595728484
+                -83.00494151137512,
+                40.009235915901954
               ]
             }
           },
@@ -964,4971 +3974,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0086789251112,
-                40.008573655272286
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0236/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p236",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0236/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0236/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6511
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"233.5,0.0 6511.0,0.0 6511.0,569.4 5360.9,584.0 5317.4,1376.6 5314.2,1435.8 5455.4,7795.0 482.0,7795.0 233.5,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0236/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01757644274342,
-                40.008724856650694
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6511.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01383059967995,
-                40.00848814709433
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6511.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01419797442387,
-                40.00502898470428
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01794381748732,
-                40.00526569426064
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0238/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p238",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0238/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0238/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6490
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6121.6,7107.3 3231.1,7297.2 3138.0,2872.9 2599.1,2848.3 328.6,2863.5 283.7,488.4 5537.9,410.1 6250.1,2946.5 6490.0,2948.7 6490.0,4369.3 5504.4,4380.3 6121.6,7107.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0238/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01252002144143,
-                40.00946303274719
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6490.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00872269539467,
-                40.009253965111554
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6490.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00904817261913,
-                40.00573649244972
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0128454986659,
-                40.00594556008536
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0244/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p244 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0244/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0244/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6515
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5418.4,585.3 5389.0,1564.6 6399.8,6498.4 6352.7,6577.9 6515.0,7796.0 -0.0,7796.0 -0.0,136.3 5115.3,85.0 5205.4,581.2 5418.4,585.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0244/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01225560445702,
-                40.00618851167566
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6515.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00840597007915,
-                40.00607250988972
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6515.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00858588949905,
-                40.002519571905324
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01243552387692,
-                40.002635573691265
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0245/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p245",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0245/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0245/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6547
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,2283.1 -0.0,775.4 6462.6,696.4 6501.0,7022.0 1365.7,7050.6 1165.5,7215.3 -0.0,2283.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0245/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00901491548441,
-                40.00641182888698
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6547.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00517732394478,
-                40.00620725787816
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6547.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00549306320889,
-                40.00268273315065
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00933065474852,
-                40.00288730415947
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0251/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p251",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0251/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0251/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6520
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4056.3,5254.2 4130.1,7627.8 -0.0,7795.0 -0.0,2261.8 843.8,2244.3 654.9,1022.2 902.4,778.4 6038.5,796.8 5872.3,1367.7 6162.7,2030.2 4996.4,2703.2 4531.0,4309.9 4514.5,4658.9 4989.0,5050.4 4056.3,5254.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0251/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00900185199924,
-                40.003557845955704
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6520.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00517832937295,
-                40.00338116843189
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6520.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00545217685666,
-                39.9998543371587
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00927569948296,
-                40.00003101468251
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0252/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p252",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0252/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0252/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6515
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"427.2,4403.1 1011.8,2596.8 2174.4,1926.0 1922.3,1298.1 2044.6,1016.9 2087.3,0.0 6121.3,0.0 5323.7,3915.3 4272.4,4781.5 4752.7,4832.0 5250.5,5181.1 5282.4,7645.8 -0.0,7458.5 -0.0,5100.0 931.9,4926.6 427.2,4403.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0252/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00672110774418,
-                40.00339728815286
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6515.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00286781128233,
-                40.003311914892606
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6515.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00300021928554,
-                39.99975542512263
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0068535157474,
-                39.999840798382884
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0255/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p255",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0255/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0255/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6511
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1214.4,7795.0 -0.0,7795.0 -0.0,530.8 1451.8,356.0 6511.0,369.2 6511.0,7463.6 1211.5,7455.6 1214.4,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0255/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00804790307673,
-                40.000213190717645
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6511.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00426324989526,
-                40.00003301794849
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6511.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00454284442367,
-                39.996537581180505
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00832749760514,
-                39.99671775394966
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0258/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p258",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0258/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0258/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6522
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"124.2,7378.4 94.7,0.0 6522.0,0.0 6522.0,7167.2 6120.1,7164.9 6143.6,7389.4 124.2,7378.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0258/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99879521366714,
-                39.999764684144154
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6522.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99496139563412,
-                39.9995956667081
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6522.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99522319496678,
-                39.996061311243885
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9990570129998,
-                39.996230328679935
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0276/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p276",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0276/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0276/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6555
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,737.6 6019.4,742.9 5923.9,7654.0 -0.0,7597.5 -0.0,737.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0276/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01552603614077,
-                39.98913283395026
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6555.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01168150865531,
-                39.988987206233546
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6555.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01190594251217,
-                39.98545972746293
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01575046999763,
-                39.98560535517964
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0279/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p279",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0279/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0279/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6526
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"22.3,7583.1 55.3,341.7 6496.1,272.4 6526.0,7413.9 22.3,7583.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0279/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0120216642894,
-                39.989022455565404
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6526.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00813474394653,
-                39.98884733357373
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6526.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00840578988144,
-                39.98526565342808
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0122927102243,
-                39.985440775419754
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0280/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p280",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0280/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0280/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6555
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3859.9,3618.4 5173.7,3615.5 4478.6,0.0 6430.0,0.0 6394.3,3616.3 6336.7,3616.2 6555.0,4807.9 6555.0,6292.4 5706.8,6288.2 5971.5,7633.8 1805.0,7768.2 2321.9,7543.2 459.3,7497.1 528.1,686.7 3607.8,715.0 3581.4,2268.6 3859.9,3618.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0280/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00846837747818,
-                39.98884488004599
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6555.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00462123571434,
-                39.98871419708858
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6555.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00482263658797,
-                39.98518430389253
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00866977835182,
-                39.985314986849936
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0281/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p281",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0281/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0281/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6526
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"307.3,7470.9 -0.0,6121.5 -0.0,2925.7 693.1,2915.5 195.9,611.6 2097.8,163.9 6335.4,124.2 6393.2,7380.4 2892.3,7425.0 2865.3,3648.0 875.8,3769.1 1647.4,7445.3 307.3,7470.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0281/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00621113905474,
-                39.9904504699934
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6526.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00245979450894,
-                39.990273810324794
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6526.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00273322637598,
-                39.98681713486001
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00648457092178,
-                39.986993794528615
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0284/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p284",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0284/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0284/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6581
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6581.0,7589.6 1047.5,7605.1 926.3,2196.3 1041.9,2034.4 1023.8,823.1 2746.3,820.3 2744.2,0.0 6581.0,0.0 6581.0,7589.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0284/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99761558877069,
-                39.99020576412734
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6581.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9937982812233,
-                39.99004477182802
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6581.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99404534304384,
-                39.986557220297556
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99786265059122,
-                39.98671821259687
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0285/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p285",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0285/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0285/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6526
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5810.7,576.0 6510.4,7796.0 674.3,7387.2 161.3,2760.7 1011.8,2838.8 1141.1,1349.3 1025.8,134.7 5810.7,576.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0285/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00544410879847,
-                39.987122110282186
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6526.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00164009070157,
-                39.98724724324924
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6526.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00144642022113,
-                39.98374187009616
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00525043831803,
-                39.983616737129104
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0286/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p286",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0286/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0286/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6581
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1759.5,7317.3 1063.6,27.7 6581.0,569.8 6581.0,7790.1 1759.5,7317.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0286/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00266194017792,
-                39.9869674037591
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6581.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99883657251104,
-                39.98709744865593
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6581.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99863701228485,
-                39.9836023734423
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00246237995172,
-                39.98347232854548
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0289/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p289",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0289/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0289/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6519
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5984.0,7795.0 -0.0,7795.0 -0.0,306.9 4031.5,323.9 4031.6,233.5 4031.7,101.7 5992.5,131.7 5984.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0289/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.02126095299643,
-                39.98597192537519
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6519.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01748004642751,
-                39.98583380080319
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6519.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01769408245406,
-                39.98234538311231
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.02147498902298,
-                39.98248350768431
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0290/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p290",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0290/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0290/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6601
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6518.4,7795.0 -0.0,7795.0 130.7,7698.0 85.9,174.6 6466.1,192.6 6518.4,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0290/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01783426849357,
-                39.98586792908932
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6601.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01392386699861,
-                39.98570367521722
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6601.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01417515453213,
-                39.98214166176952
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0180855560271,
-                39.98230591564162
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0291/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p291",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0291/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0291/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6519
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"721.8,103.5 5909.1,91.4 5883.5,7732.4 815.7,7795.0 721.8,103.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0291/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01442701743547,
-                39.985684941778
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6519.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01062811525146,
-                39.98550972685034
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6519.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01089962471697,
-                39.98200468902096
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.01469852690096,
-                39.98217990394863
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0293/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p293",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0293/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0293/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6487
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6402.8,7723.9 1060.4,7796.0 1149.1,159.6 4789.7,64.6 6402.8,7723.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0293/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00796452625399,
-                39.985417365966974
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6487.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00416460215321,
-                39.98525650067137
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6487.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00441510419442,
-                39.98173321390226
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0082150282952,
-                39.981894079197865
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0294/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p294",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0294/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0294/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6601
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"530.7,4620.0 527.2,0.0 6311.8,1087.8 6364.8,1099.8 6324.9,7795.0 -0.0,7795.0 -0.0,4508.6 530.7,4620.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0294/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00517017538536,
-                39.98377795726927
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6601.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0013809001636,
-                39.984222898062995
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6601.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00070021324534,
-                39.980771138770486
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0044894884671,
-                39.98032619797675
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0296/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p296",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0296/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0296/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6601
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,165.6 2114.3,378.0 2085.1,634.6 6601.0,1098.3 6601.0,7795.0 -0.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0296/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99822458196559,
-                39.98366083262871
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6601.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.994358728776,
-                39.9838045849944
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6601.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99413881240125,
-                39.98028304746051
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.99800466559081,
-                39.980139295094816
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0201__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p201 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "3567.5"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6552.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "4227.5"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0201__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0201/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6552
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,3567.5 4302.9,3567.5 5179.9,6386.9 6552.0,6017.2 6552.0,7795.0 -0.0,7795.0 0.0,3567.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0201__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5180.0,
-                6387.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.017735,
-                40.023883
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6672.0,
-                5999.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.016921,
-                40.023981
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p202 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6473.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7796.0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6473
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"106.3,2570.9 110.7,0.0 6473.0,0.0 6473.0,7796.0 -0.0,7796.0 -0.0,3868.1 907.2,4152.3 1354.9,2721.6 106.3,2570.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1495.3,
-                2636.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.016921,
-                40.023981
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                111.9,
-                -232.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0180683,
-                40.0251282
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p202 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "4109.6"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "1680.8"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "3686.4"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6473
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1680.8,4526.0 1680.8,7796.0 200.7,7523.7 105.4,7796.0 84.7,4109.6 1070.6,4109.6 1008.9,4351.8 1680.8,4526.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0202__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                148.1,
-                5772.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0137006,
-                40.0233432
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                148.1,
-                7512.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0134818,
-                40.0225105
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p206 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6489.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "3919.5"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6489
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1284.6,3733.6 1317.8,251.9 -0.0,246.2 -0.0,-0.0 5347.7,41.9 5336.0,3730.8 1284.6,3733.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1731.2,
-                2007.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0016664,
-                40.0236099
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5341.5,
-                2007.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9995012,
-                40.0235181
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p206 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "3889.1"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6489.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "3905.9"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6489
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"595.7,6925.9 595.7,3889.1 6489.0,3889.1 6489.0,6925.6 595.7,6925.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0206__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                595.7,
-                4121.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9994405,
-                40.0243128
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                595.7,
-                7535.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9995617,
-                40.0227272
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0207/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p207",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0207/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0207/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6552
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"468.1,5652.7 464.5,5137.5 752.8,5140.2 790.0,761.6 4923.7,754.5 4930.1,3330.2 4591.8,3357.5 4586.8,5712.5 468.1,5652.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0207/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1292.0,
-                6343.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0018814,
-                40.0203045
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4920.0,
-                2531.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9996228,
-                40.0219273
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0208/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p208",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0208/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0208/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6489
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"335.6,3180.1 323.9,0.0 6489.0,0.0 6489.0,7795.0 -0.0,7795.0 -0.0,3180.2 335.6,3180.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0208/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                323.9,
-                2387.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9996228,
-                40.0219273
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                323.9,
-                623.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9995617,
-                40.0227272
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0209__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p209 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6552.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7795.0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0209__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0209/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6552
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3434.4,1997.6 3465.2,2426.8 3213.7,2031.5 3434.4,1997.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0209__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4604.0,
-                2859.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.014771,
-                40.0214455
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6080.0,
-                5043.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.012712,
-                40.019631
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0211/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p211",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0211/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0211/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6552
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,384.9 185.3,294.0 182.5,0.0 6552.0,0.0 6552.0,1586.4 5924.8,1715.1 6032.0,7683.0 -0.0,7730.1 -0.0,2971.3 92.4,2952.7 -0.0,384.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0211/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5584.0,
-                1787.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0064398,
-                40.0203204
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6032.0,
-                7683.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.006404,
-                40.017573
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0214/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p214",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0214/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0214/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6489
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"829.5,7062.9 922.3,2339.2 5441.7,2376.3 5461.2,0.0 6489.0,0.0 6489.0,7795.0 1315.0,7795.0 1313.9,7078.3 829.5,7062.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0214/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1459.3,
-                7067.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9987096,
-                40.0172315
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1459.3,
-                4071.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9986185,
-                40.0186195
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0215/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p215",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0215/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0215/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6552
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2648.0,7691.0 2648.1,7316.4 -0.0,7228.9 -0.0,-0.0 6255.4,0.0 6238.4,7596.6 6552.0,7684.1 2648.0,7691.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0215/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2648.0,
-                2699.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0140253,
-                40.0163649
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2648.0,
-                7691.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0134303,
-                40.0141452
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0216/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p216",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "13"
-        },
-        {
-          "label": "intersections",
-          "value": "29"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0216/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0216/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6513
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5768.3,1366.8 5765.1,1793.4 5865.0,1393.1 6513.0,1568.7 6513.0,7721.7 5721.4,7662.7 5722.6,7508.0 778.7,7527.4 823.9,24.7 5768.3,1366.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0216/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2051.1,
-                3883.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0110626,
-                40.016243
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3270.5,
-                5135.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0102073,
-                40.0158017
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0217/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p217",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0217/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0217/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6552
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5570.4,1074.7 6552.0,5127.6 6552.0,5693.8 2117.0,6772.3 670.0,976.4 5570.4,1074.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0217/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3768.0,
-                6475.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0070627,
-                40.0151385
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2444.0,
-                1011.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.007721,
-                40.017632
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0218/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p218",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0218/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0218/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6513
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1545.8,5546.7 1006.0,5688.9 995.2,5117.2 -0.0,1042.9 6442.9,1050.5 6481.5,5802.0 5708.5,5728.5 5694.5,7795.0 2137.8,7795.0 1545.8,5546.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0218/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4509.9,
-                5711.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0033538,
-                40.0153433
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                771.6,
-                1043.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0053822,
-                40.0175273
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0219/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p219",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0219/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0219/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6552
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4855.3,5275.0 4841.4,7496.5 -0.0,7541.7 -0.0,5126.5 770.9,5194.4 700.4,461.7 6278.5,424.6 6341.4,4560.4 6508.3,5250.7 4855.3,5275.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0219/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                732.0,
-                2711.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0021331,
-                40.0163679
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4384.0,
-                5275.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.00009,
-                40.015112
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0220/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p220",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0220/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0220/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6513
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1651.2,5195.3 1480.2,4506.4 1407.7,1123.8 6513.0,1021.7 6513.0,6800.4 3682.5,6849.6 3692.9,7393.5 -0.0,7450.4 -0.0,5229.9 1651.2,5195.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0220/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1651.2,
-                5195.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.998844,
-                40.015062
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1651.2,
-                7427.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.998936,
-                40.01406
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0221__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p221 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6552.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7795.0"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0221__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0221/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6552
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6259.2,369.2 6552.0,359.6 6552.0,7249.6 5177.7,6980.5 4836.0,7795.0 -0.0,7795.0 -0.0,-0.0 6247.1,0.0 6259.2,369.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0221__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5156.0,
-                6975.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0134133,
-                40.0110612
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6016.0,
-                5103.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.013095,
-                40.0119785
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0222/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p222",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0222/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0222/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6513
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1846.5,7278.7 2076.6,231.9 5398.1,232.1 5381.5,7531.0 2657.7,7465.4 1846.5,7278.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0222/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1771.2,
-                2755.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0131361,
-                40.0130323
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5381.5,
-                7531.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0104947,
-                40.0112536
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0223/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p223",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "12"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0223/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0223/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6552
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"800.2,96.8 5760.4,0.0 5661.3,6601.8 3210.1,5988.7 3221.4,7795.0 -0.0,7795.0 -0.0,7365.4 724.4,7388.7 800.2,96.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0223/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4492.0,
-                3891.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0087575,
-                40.0131478
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                764.0,
-                2619.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.011057,
-                40.0133577
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0224/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p224",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0224/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0224/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6513
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6513.0,2304.2 6083.8,2191.1 6086.5,6312.8 4081.3,6311.1 3833.9,7252.2 3811.2,6310.9 3062.5,6310.3 3020.8,7174.2 570.2,6530.6 604.0,0.0 6513.0,0.0 6513.0,2304.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0224/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1835.2,
-                5083.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0071906,
-                40.0128192
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6085.2,
-                1327.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0051732,
-                40.0148658
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0225/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Columbus, Ohio | 1951 | Vol. 3 p225",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "12"
-        },
-        {
-          "label": "intersections",
-          "value": "24"
-        }
-      ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0225/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0225/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6522
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"992.4,2001.8 1305.6,2009.7 3279.4,2061.2 3282.0,2485.7 6464.4,2466.2 6522.0,7534.3 4.0,5780.5 992.4,2001.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0225/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5034.5,
-                5099.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.0095248,
-                40.0100014
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3998.8,
-                4815.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -83.010163,
-                40.010034
+                -83.00867855462678,
+                40.00857467456102
               ]
             }
           }
@@ -5946,15 +3993,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "12"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "22"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5973,34 +4020,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5682.3,7546.0 -0.0,7515.6 -0.0,5530.8 1950.0,5019.5 893.6,1013.3 4883.8,1014.6 4881.3,1371.3 5252.5,1373.7 5673.3,1367.5 5682.3,7546.0\" /></svg>"
+          "value": "<svg><polygon points=\"5682.7,7545.8 -0.0,7515.8 -0.0,5530.9 1949.7,5019.7 892.9,1013.7 4946.5,1014.7 4949.1,1371.8 5673.3,1367.5 5682.7,7545.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0227/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2891.1,
-                7531.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0041175,
-                40.0115051
+                -83.00556116586456,
+                40.01496146427784
               ]
             }
           },
@@ -6008,20 +4058,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4690.6,
-                3779.5
+                6522.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0029369,
-                40.0131439
+                -83.00173660493377,
+                40.01479445454462
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00199713717693,
+                40.011293571164565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00582169810772,
+                40.01146058089778
               ]
             }
           }
@@ -6039,15 +4131,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "21"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6073,27 +4165,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0228/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3694.3,
-                1375.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0041175,
-                40.0115051
+                -83.00623527356758,
+                40.01222182458269
               ]
             }
           },
@@ -6101,20 +4196,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5517.5,
-                5339.3
+                6513.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0031862,
-                40.0096769
+                -83.00241673546493,
+                40.01204709658909
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00268967693854,
+                40.00854787378407
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0065082150412,
+                40.00872260177766
               ]
             }
           }
@@ -6132,15 +4269,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6159,34 +4296,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"389.9,7257.5 387.9,507.9 6554.0,510.1 6554.0,7269.3 389.9,7257.5\" /></svg>"
+          "value": "<svg><polygon points=\"387.1,546.5 6554.0,534.6 6554.0,7266.4 402.7,7267.0 387.1,546.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0229/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3998.8,
-                507.9
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.000166,
-                40.014113
+                -83.00248929294112,
+                40.01445798572421
               ]
             }
           },
@@ -6194,20 +4334,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                387.9,
-                507.9
+                6554.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.00228,
-                40.014202
+                -82.99863608535333,
+                40.014289789781685
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6554.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99889722818934,
+                40.01078044873104
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00275043577713,
+                40.01094864467357
               ]
             }
           }
@@ -6225,15 +4407,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6252,34 +4434,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"985.0,7189.9 998.9,535.4 2567.2,536.8 2566.2,0.0 6513.0,0.0 6513.0,7795.0 2540.6,7795.0 2544.8,7194.8 985.0,7189.9\" /></svg>"
+          "value": "<svg><polygon points=\"997.9,7230.3 992.5,502.1 2550.8,495.9 2547.5,0.0 6513.0,0.0 6513.0,7795.0 2559.9,7795.0 2561.1,7227.5 997.9,7230.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0230/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2550.8,
-                5051.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.997889,
-                40.011955
+                -82.99922073342134,
+                40.01430034097812
               ]
             }
           },
@@ -6287,20 +4472,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                539.8,
-                2911.6
+                6513.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.999018,
-                40.012977
+                -82.99539006521032,
+                40.0141307731485
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6513.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99565495378974,
+                40.01062053748316
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99948562200076,
+                40.01079010531278
               ]
             }
           }
@@ -6318,15 +4545,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6345,34 +4572,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"502.6,5541.8 539.8,639.9 5344.2,681.5 5259.4,7088.2 4143.0,7069.8 4147.3,5575.7 502.6,5541.8\" /></svg>"
+          "value": "<svg><polygon points=\"4159.6,5566.4 500.0,5536.8 535.1,649.2 5331.6,684.8 5255.7,7072.9 4155.9,7056.2 4159.6,5566.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0231/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4150.7,
-                4951.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.000524,
-                40.009188
+                -83.00278628487658,
+                40.011476061883556
               ]
             }
           },
@@ -6380,20 +4610,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                539.8,
-                639.9
+                6554.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.002496,
-                40.011176
+                -82.99900889111488,
+                40.011334904580615
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6554.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99922650671456,
+                40.00787015893764
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00300390047626,
+                40.008011316240584
               ]
             }
           }
@@ -6411,15 +4683,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6438,34 +4710,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,662.9 3059.5,651.9 3060.2,1273.4 6511.0,1245.7 6511.0,6499.4 3079.7,6530.0 3084.1,7127.0 -0.0,7116.8 -0.0,662.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,659.8 3059.5,651.9 3059.5,1227.9 6511.0,1220.5 6511.0,6447.8 3073.7,6455.3 3077.7,7069.1 -0.0,7056.0 -0.0,659.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0232/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3059.5,
-                2819.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9980358,
-                40.0100259
+                -82.9997096378887,
+                40.0113496042434
               ]
             }
           },
@@ -6473,20 +4748,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3059.5,
-                651.9
+                6511.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.99796,
-                40.010979
+                -82.99593805654992,
+                40.01117644762678
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6511.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99620870053872,
+                40.007718017058295
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9999802818775,
+                40.00789117367491
               ]
             }
           }
@@ -6504,15 +4821,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6531,34 +4848,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5908.7,7077.8 3513.0,7035.5 3529.4,6474.7 -0.0,6367.1 -0.0,2492.3 3804.2,1636.6 3940.8,751.0 5909.1,759.9 5908.7,7077.8\" /></svg>"
+          "value": "<svg><polygon points=\"5908.7,7077.8 2387.7,7015.6 2335.8,7634.0 -0.0,7328.5 -0.0,2697.1 3797.8,1720.9 3940.8,751.0 5909.1,759.9 5908.7,7077.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0234/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5911.1,
-                4699.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0123744,
-                40.0092335
+                -83.0157120402757,
+                40.01149231400687
               ]
             }
           },
@@ -6566,20 +4886,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5911.1,
-                759.9
+                6511.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.012254,
-                40.0110111
+                -83.01187616965923,
+                40.01133989717907
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6511.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01211440275566,
+                40.007822595250126
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01595027337213,
+                40.00797501207793
               ]
             }
           }
@@ -6597,15 +4959,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6624,7 +4986,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6554.0,7795.0 -0.0,7795.0 -0.0,-0.0 6554.0,0.0 6554.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6554.0,7795.0 -0.0,7795.0 0.0,-0.0 6554.0,0.0 6554.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -6653,8 +5015,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.02130185997108,
-                40.00889379205612
+                -83.02129811269643,
+                40.00888946114679
               ]
             }
           },
@@ -6674,8 +5036,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.01744013623176,
-                40.008747168085925
+                -83.01744315658111,
+                40.00874309413332
               ]
             }
           },
@@ -6695,8 +5057,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.01766774631098,
-                40.005229454646816
+                -83.01767036777643,
+                40.005231545444325
               ]
             }
           },
@@ -6716,8 +5078,83 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0215294700503,
-                40.00537607861701
+                -83.02152532389175,
+                40.00537791245779
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0236/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p236",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0236/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0236/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6511
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3677.4 -0.0,-0.0 5524.7,0.0 5533.7,194.5 5467.3,272.2 6051.2,4668.9 230.5,5408.8 -0.0,3677.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0236/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0172295649427,
+                40.00836773945293
               ]
             }
           },
@@ -6725,20 +5162,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3890.8,
-                5283.3
+                6511.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0191636,
-                40.0064225
+                -83.01409434424572,
+                40.007926105084955
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6511.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01478460052435,
+                40.005051120690275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01791982122133,
+                40.00549275505825
               ]
             }
           }
@@ -6756,15 +5235,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6783,34 +5262,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6554.0,4983.3 4266.3,4961.6 4297.7,7795.0 -0.0,7795.0 -0.0,1184.3 132.2,334.0 6554.0,476.1 6554.0,4983.3\" /></svg>"
+          "value": "<svg><polygon points=\"391.3,4931.1 -0.0,4928.9 -0.0,1184.2 132.3,333.9 6554.0,476.2 6554.0,7795.0 796.2,7795.0 738.6,5205.3 738.6,5205.3 704.6,4927.4 392.0,4925.9 391.3,4931.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0237/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2551.2,
-                2547.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0131825,
-                40.0072352
+                -83.01458681124235,
+                40.008421842727806
               ]
             }
           },
@@ -6818,20 +5300,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                703.8,
-                4927.4
+                6554.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.014321,
-                40.0062204
+                -83.0107901130918,
+                40.00827680239535
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6554.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01101529787411,
+                40.00481882945657
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01481199602466,
+                40.00496386978902
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0238/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p238",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0238/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0238/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6490
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3145.3,2877.8 337.7,2862.8 297.5,489.2 6490.0,422.7 6490.0,7108.1 6433.0,7109.2 6433.2,7795.0 3239.0,7795.0 3145.3,2877.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0238/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.012528768179,
+                40.00946375865147
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6490.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00872840927421,
+                40.00926041149815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6490.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00904498083186,
+                40.00574012949232
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01284533973664,
+                40.00594347664564
               ]
             }
           }
@@ -6849,15 +5511,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6876,34 +5538,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1596.1,3053.7 907.8,462.1 5809.2,473.0 5810.2,523.9 5802.6,7250.0 1738.3,7284.8 1733.2,7795.0 1516.1,7795.0 824.3,4503.3 1820.8,4505.2 1838.6,3059.2 1596.1,3053.7\" /></svg>"
+          "value": "<svg><polygon points=\"1854.9,469.8 5641.7,521.6 5809.3,472.6 5831.8,7259.3 1777.5,7289.3 1854.9,469.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0239/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4658.6,
-                7251.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0073545,
-                40.0059906
+                -83.00980302095253,
+                40.00932489030381
               ]
             }
           },
@@ -6911,20 +5576,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5810.2,
-                523.9
+                6554.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0064593,
-                40.0089448
+                -83.00601161864681,
+                40.00915796627974
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6554.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00627076858322,
+                40.00570467366282
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01006217088894,
+                40.00587159768689
               ]
             }
           }
@@ -6942,15 +5649,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6969,34 +5676,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7126.0 2.3,557.6 728.7,561.0 728.7,561.0 6397.1,587.2 6422.9,7130.9 -0.0,7126.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7123.5 18.3,515.0 6451.7,595.1 6426.1,7178.7 -0.0,7123.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0240/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2411.6,
-                4451.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0051675,
-                40.0071112
+                -83.00645443429855,
+                40.00917784294309
               ]
             }
           },
@@ -7004,20 +5714,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1179.8,
-                4451.4
+                6491.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.005898,
-                40.0071444
+                -83.00262675963782,
+                40.009026858878585
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6491.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00286347248013,
+                40.00550614325147
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00669114714086,
+                40.00565712731598
               ]
             }
           }
@@ -7025,7 +5777,7 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
@@ -7035,15 +5787,31 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "29"
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6554.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7052,7 +5820,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241__1/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241/info.json",
@@ -7062,34 +5830,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4960.9,7795.0 3937.4,7795.0 3931.4,7292.3 302.8,7313.8 245.6,98.1 3866.3,77.2 3884.4,1561.3 6554.0,1565.0 6554.0,6752.5 6246.8,6756.3 5517.1,7795.0 5145.0,7454.6 4960.9,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"318.8,6768.8 275.1,138.8 3844.1,122.9 3860.0,1585.8 5547.8,1590.4 5595.6,6716.3 4124.3,6389.1 4054.2,6760.6 318.8,6768.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2035.4,
-                3107.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0017208,
-                40.0076126
+                -83.00281014490545,
+                40.0090747011547
               ]
             }
           },
@@ -7097,20 +5868,216 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3898.8,
-                3707.5
+                6554.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.000658,
-                40.007293
+                -82.99893943176218,
+                40.00889256803385
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6554.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99922218789905,
+                40.00536696307779
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00309290104232,
+                40.00554909619864
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p241 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "5363.2"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "5827.7"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1190.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "1967.3"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6554
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6554.0,7795.0 5514.8,7795.0 5363.2,7029.6 5363.2,5827.7 6554.0,5827.7 6554.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0241__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5363.2,
+                5827.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00060614124301,
+                40.006070338358114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6554.0,
+                5827.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99992585091721,
+                40.005938380015216
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6554.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00021025728854,
+                40.00507800160446
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5363.2,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00089054761435,
+                40.00520995994736
               ]
             }
           }
@@ -7128,15 +6095,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7155,34 +6122,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"888.9,5751.0 944.8,569.9 2423.6,588.0 2424.5,0.0 6515.0,0.0 6515.0,6225.9 2422.1,6225.4 2420.6,5748.3 888.9,5751.0\" /></svg>"
+          "value": "<svg><polygon points=\"163.0,2964.1 193.0,5728.3 -0.0,5728.7 -0.0,558.7 2423.6,588.0 2424.4,0.0 6515.0,0.0 6515.0,6198.9 2422.9,6199.0 2399.1,2941.2 163.0,2964.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0242/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2423.6,
-                7076.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9983688,
-                40.0052339
+                -82.9995743063219,
+                40.0084518858592
               ]
             }
           },
@@ -7190,20 +6160,354 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2423.6,
-                588.0
+                6515.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9981723,
-                40.0081314
+                -82.99575731776656,
+                40.008299594757595
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6515.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99599519571528,
+                40.00480157135432
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99981218427062,
+                40.00495386245593
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0243__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p243 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3937.1"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6547.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3857.9"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0243__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0243/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6547
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6547.0,7795.0 -0.0,7795.0 -0.0,6989.8 685.4,7004.4 742.2,4433.2 6518.6,4584.9 6547.0,4867.3 6547.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0243__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3937.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01801099205184,
+                40.0065835405385
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6547.0,
+                3937.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01429463052793,
+                40.00650381527438
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6547.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01435555584912,
+                40.00481386719351
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01807191737304,
+                40.004893592457634
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0245/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p245",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0245/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0245/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6547
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1240.3,7795.0 -0.0,7795.0 -0.0,2254.7 -0.0,2254.7 -0.0,772.9 6469.6,693.7 6508.0,7020.6 1371.6,7049.2 1171.3,7213.9 1240.3,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0245/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00901834395991,
+                40.006410698637445
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6547.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0051815570246,
+                40.00620619288515
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6547.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00549719549552,
+                40.00268240628739
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00933398243083,
+                40.002886912039685
               ]
             }
           }
@@ -7221,15 +6525,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7248,34 +6552,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1222.7,652.5 5238.1,633.4 5223.1,6093.2 1192.2,6237.4 1222.7,652.5\" /></svg>"
+          "value": "<svg><polygon points=\"1228.8,630.6 5264.5,617.0 5240.2,6110.0 3186.3,6180.5 1961.9,7796.0 1173.0,7796.0 1070.2,7562.3 1183.2,7273.6 1228.8,630.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0246/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1231.8,
-                4992.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0054144,
-                40.003932
+                -83.00595359402902,
+                40.0062138361395
               ]
             }
           },
@@ -7283,20 +6590,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5295.2,
-                4992.0
+                6515.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.003016,
-                40.003813
+                -83.00212521444875,
+                40.00602804016525
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6515.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00241541625235,
+                40.00251944958411
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00624379583262,
+                40.00270524555837
               ]
             }
           }
@@ -7314,15 +6663,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7341,34 +6690,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1052.2,7031.8 1307.3,5817.2 1391.8,485.9 5009.9,504.7 5010.4,1005.9 5941.3,1016.2 6218.2,679.9 6547.0,905.7 5988.5,2113.6 5610.1,2363.3 5007.9,2445.3 5010.9,7067.9 1052.2,7031.8\" /></svg>"
+          "value": "<svg><polygon points=\"1103.2,7004.6 1346.4,5800.9 1389.6,0.0 5151.1,0.0 5001.8,1591.6 6025.5,1787.2 6238.9,670.4 6547.0,878.6 5979.8,2071.5 5605.0,2322.9 5006.2,2409.1 5044.1,7010.6 1103.2,7004.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0247/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1391.8,
-                4895.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.003016,
-                40.003813
+                -83.0036824886806,
+                40.00604137508224
               ]
             }
           },
@@ -7376,20 +6728,216 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1391.8,
-                487.9
+                6547.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.002883,
-                40.005786
+                -82.99984224689267,
+                40.0058671116167
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6547.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00011310593348,
+                40.00236485552888
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0039533477214,
+                40.00253911899442
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0248__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p248 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2352.4"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3542.0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0248__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0248/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6515
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2266.7,-0.0 2252.6,3542.0 0.0,3542.0 -0.0,-0.0 2266.7,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0248__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9995692323257,
+                40.00711808464575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2352.4,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99820890856981,
+                40.00707450284414
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2352.4,
+                3542.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99829403784696,
+                40.0054933228616
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3542.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99965436160285,
+                40.0055369046632
               ]
             }
           }
@@ -7407,11 +6955,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -7430,8 +6978,8 @@
           "value": "7796.0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7450,34 +6998,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6300.9,7666.1 2267.7,7628.0 2269.4,2379.8 2855.3,2300.9 3223.8,2058.4 3716.1,997.4 4526.4,0.0 6312.0,0.0 6300.9,7666.1\" /></svg>"
+          "value": "<svg><polygon points=\"6300.9,7666.1 2267.7,7628.0 2269.4,2379.8 3004.6,2227.1 3290.0,1922.4 3788.5,897.6 3489.3,691.4 3627.8,0.0 4137.7,0.0 4144.3,739.4 6312.5,721.2 6300.9,7666.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0248__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2267.7,
-                3356.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0008602,
-                40.0043768
+                -83.00212078068125,
+                40.00597268748733
               ]
             }
           },
@@ -7485,20 +7036,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2267.7,
-                7628.0
+                6515.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.000989,
-                40.002412
+                -82.99820841266609,
+                40.00582220215352
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6515.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99844346060617,
+                40.002236626123555
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00235582862133,
+                40.00238711145737
               ]
             }
           }
@@ -7516,15 +7109,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7550,27 +7143,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0249/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                427.9,
-                843.9
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9983688,
-                40.0052339
+                -82.99859445390706,
+                40.00562377951657
               ]
             }
           },
@@ -7578,20 +7174,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                427.9,
-                7359.1
+                6547.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9985681,
-                40.0023013
+                -82.99474721779315,
+                40.00547036499207
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6547.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99498566819216,
+                40.001961686416244
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99883290430607,
+                40.00211510094074
               ]
             }
           }
@@ -7609,15 +7247,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7636,34 +7274,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4978.4,834.1 5048.4,1241.4 6515.0,1236.5 6515.0,6551.1 415.1,6538.0 394.2,814.6 4978.4,834.1\" /></svg>"
+          "value": "<svg><polygon points=\"394.2,814.6 4978.4,834.1 5048.4,1241.4 6515.0,1236.5 6515.0,7796.0 5952.5,7796.0 5880.1,6966.2 4890.8,6952.9 4676.3,6731.4 2756.5,6701.6 2441.6,6926.7 416.5,6919.4 394.2,814.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0250/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                407.9,
-                4960.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9986931,
-                40.0004623
+                -82.99877023899735,
+                40.00267230039659
               ]
             }
           },
@@ -7671,20 +7312,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                407.9,
-                3024.0
+                6515.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.998631,
-                40.001321
+                -82.99499737644473,
+                40.00251219221525
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6515.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9952474444199,
+                39.99905432795908
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99902030697253,
+                39.99921443614042
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0251/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p251",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0251/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0251/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6520
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4134.1,7630.4 -0.0,7795.0 -0.0,1513.9 759.1,1520.0 649.0,1018.8 896.6,774.4 6040.5,786.9 5874.7,1358.9 5977.2,1592.0 6520.0,1593.0 6520.0,1754.7 4998.9,2697.4 4546.3,4056.6 4518.6,4656.6 4994.2,5048.2 4057.6,5254.1 4134.1,7630.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0251/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00899724791094,
+                40.00355573841741
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6520.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00517979574217,
+                40.00337596078632
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6520.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00545844818087,
+                39.99985472684941
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00927590034965,
+                40.000034504480496
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0252/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p252",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0252/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0252/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6515
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"430.3,4401.9 1015.3,2593.9 2788.0,1572.5 4080.6,0.0 6127.5,0.0 5331.1,3913.3 4301.6,4779.1 4221.2,7609.4 -0.0,7459.9 -0.0,5100.1 935.5,4925.8 430.3,4401.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0252/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00672262657022,
+                40.003394985573735
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6515.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00287277619796,
+                40.00330951067009
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6515.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00300534198102,
+                39.999756205247984
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00685519235329,
+                39.999841680151626
               ]
             }
           }
@@ -7702,15 +7661,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7729,34 +7688,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5503.0,7357.6 1092.0,7295.1 1003.9,4771.6 489.7,4425.0 -0.0,4383.9 1049.8,3473.7 1334.4,2220.9 1518.2,475.5 5500.0,515.9 5503.0,7357.6\" /></svg>"
+          "value": "<svg><polygon points=\"5522.7,7330.2 -0.0,7286.5 -0.0,4399.1 -0.0,4376.0 1025.7,3457.1 1303.7,2197.1 1477.3,442.9 5476.9,458.5 5522.7,7330.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0253/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1092.0,
-                7295.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0037267,
-                39.9998401
+                -83.00411818918947,
+                40.003098204672526
               ]
             }
           },
@@ -7764,20 +7726,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5500.0,
-                515.9
+                6520.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0009674,
-                40.0027573
+                -83.00034935866222,
+                40.00293409623759
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6520.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00060551979232,
+                39.99948208062192
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00437435031957,
+                39.999646189056854
               ]
             }
           }
@@ -7795,15 +7799,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7822,34 +7826,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5333.2,1248.2 5366.4,7284.8 1239.5,7253.6 1198.6,1238.2 5333.2,1248.2\" /></svg>"
+          "value": "<svg><polygon points=\"5376.9,1271.8 5361.0,7286.8 1220.4,7225.1 1228.4,1231.2 5376.9,1271.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0254/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1215.6,
-                3415.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.001052,
-                40.001435
+                -83.00167068142498,
+                40.00299379098145
               ]
             }
           },
@@ -7857,20 +7864,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5354.4,
-                5347.3
+                6522.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9986931,
-                40.0004623
+                -82.99786283056477,
+                40.00284852432733
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99808785145825,
+                39.99933826844846
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00189570231846,
+                39.999483535102584
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0255/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p255",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0255/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0255/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6511
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1314.6,7795.0 -0.0,7795.0 -0.0,526.6 1448.5,357.4 6511.0,372.1 6511.0,7472.7 1313.9,7463.5 1314.6,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0255/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00804529034968,
+                40.0002133711115
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6511.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00426382336815,
+                40.0000342272849
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6511.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00454182112753,
+                39.99654173270407
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00832328810907,
+                39.99672087653067
               ]
             }
           }
@@ -7888,15 +8075,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7915,34 +8102,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6165.8,7454.5 783.9,7411.2 826.0,309.5 6144.1,360.0 6165.8,7454.5\" /></svg>"
+          "value": "<svg><polygon points=\"6176.3,7451.3 802.6,7432.6 810.1,340.3 6122.3,366.4 6176.3,7451.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0256/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6142.1,
-                5143.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0013215,
-                39.9975695
+                -83.00473964997884,
+                40.00004194220793
               ]
             }
           },
@@ -7950,20 +8140,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6142.1,
-                360.0
+                6522.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0011667,
-                39.999713
+                -83.00091972938883,
+                39.99986662794881
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00119320279352,
+                39.99636981634995
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00501312338353,
+                39.996545130609064
               ]
             }
           }
@@ -7981,15 +8213,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8015,27 +8247,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0257/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5303.2,
-                5195.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9988968,
-                39.9974519
+                -83.00180567855105,
+                39.999902103148514
               ]
             }
           },
@@ -8043,20 +8278,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1119.8,
-                360.0
+                6511.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0011667,
-                39.999713
+                -82.99802024167774,
+                39.99973471515329
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6511.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99828182753197,
+                39.996263025154676
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00206726440528,
+                39.9964304131499
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0258/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p258",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0258/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0258/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6522
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"92.2,366.1 4185.3,164.8 4504.5,391.7 5480.1,403.2 5552.2,1215.7 6106.9,1214.8 6105.9,0.0 6522.0,0.0 6522.0,7093.4 6111.5,7097.6 6142.4,7393.4 1038.4,7381.4 1042.3,7795.0 117.2,7795.0 92.2,366.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0258/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99879295749615,
+                39.99976117295825
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99496331488024,
+                39.99959388076833
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99522244189521,
+                39.99606337457608
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99905208451112,
+                39.996230666766
               ]
             }
           }
@@ -8074,15 +8489,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8101,34 +8516,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6511.0,7536.8 1842.3,7550.6 1265.4,4721.3 2580.9,4665.9 2301.4,3347.3 959.7,3317.4 685.6,3528.1 -0.0,3587.7 -0.0,156.6 6263.0,224.0 6263.0,2587.7 6511.0,2589.5 6511.0,7536.8\" /></svg>"
+          "value": "<svg><polygon points=\"2876.9,7590.2 2855.8,4720.4 2511.4,4719.2 2222.8,3407.1 875.2,3385.7 601.3,3597.6 -0.0,3660.6 -0.0,241.1 6181.8,264.6 6196.1,2621.6 6511.0,2621.8 6511.0,7554.7 2876.9,7590.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0259/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6263.0,
-                2587.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.004019,
-                39.9955975
+                -83.00754003501649,
+                39.996941654786866
               ]
             }
           },
@@ -8136,20 +8554,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6263.0,
-                224.0
+                6511.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0039459,
-                39.9966578
+                -83.00374485948288,
+                39.99676802506546
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6511.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00401428745538,
+                39.99326270135745
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00780946298899,
+                39.99343633107886
               ]
             }
           }
@@ -8167,15 +8627,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8194,34 +8654,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2827.4,7366.3 2825.1,7481.9 1148.8,7487.5 1146.9,2576.2 900.8,2574.5 899.9,228.0 5246.4,272.2 5250.9,7348.0 2827.4,7366.3\" /></svg>"
+          "value": "<svg><polygon points=\"2800.3,7370.5 2797.2,7486.6 1150.1,7481.8 1208.9,2552.6 896.5,2548.5 910.4,193.1 5273.1,264.9 5233.1,7367.4 2800.3,7370.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0260/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                899.9,
-                228.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0039459,
-                39.9966578
+                -83.00447566760175,
+                39.99676398286723
               ]
             }
           },
@@ -8229,20 +8692,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2803.6,
-                2587.7
+                6511.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0028971,
-                39.9955458
+                -83.00064871188324,
+                39.99662642707035
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6511.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00086366639385,
+                39.9931164793443
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00469062211236,
+                39.99325403514118
               ]
             }
           }
@@ -8260,15 +8765,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8287,34 +8792,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"427.1,7366.9 395.8,230.0 5630.3,259.2 5601.9,4788.7 6511.0,4781.5 6511.0,7356.2 427.1,7366.9\" /></svg>"
+          "value": "<svg><polygon points=\"427.1,7366.9 395.8,230.0 4567.9,256.7 4569.2,681.4 5507.9,681.4 5549.5,4789.2 6511.0,4781.5 6511.0,7356.2 427.1,7366.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0261/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2515.6,
-                7363.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0003922,
-                39.9933173
+                -83.001605052972,
+                39.99664529219521
               ]
             }
           },
@@ -8322,20 +8830,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4575.3,
-                2619.7
+                6511.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9990437,
-                39.9953682
+                -82.997837030785,
+                39.996480684651495
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6511.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99809425832507,
+                39.99302478917786
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00186228051206,
+                39.993189396721576
               ]
             }
           }
@@ -8353,15 +8903,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8380,34 +8930,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4781.5 -0.0,249.3 5054.8,229.6 5029.4,0.0 6511.0,0.0 6511.0,7106.1 1117.5,7181.8 1119.7,7343.1 925.7,7344.6 909.6,4768.7 -0.0,4781.5\" /></svg>"
+          "value": "<svg><polygon points=\"6511.0,7157.5 923.8,7253.3 949.6,4711.0 -0.0,4708.9 -0.0,234.8 5113.7,298.7 5085.6,0.0 6511.0,0.0 6511.0,7157.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0262/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1119.8,
-                7343.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9979675,
-                39.9932146
+                -82.99842213809374,
+                39.996496835478865
               ]
             }
           },
@@ -8415,20 +8968,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4735.3,
-                2599.7
+                6511.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9957035,
-                39.9952142
+                -82.99460452823747,
+                39.99635977593062
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6511.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9948187085827,
+                39.99285842128255
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99863631843897,
+                39.99299548083079
               ]
             }
           }
@@ -8446,15 +9041,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8473,34 +9068,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1923.4,7576.0 1923.4,7796.0 -0.0,7796.0 0.0,0.0 5974.6,0.0 5979.4,7576.0 1923.4,7576.0\" /></svg>"
+          "value": "<svg><polygon points=\"5954.8,0.0 5992.9,5194.6 6526.0,5194.2 6526.0,7576.2 1923.4,7576.0 1923.4,7796.0 -0.0,7796.0 -0.0,0.0 5954.8,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0263/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3798.8,
-                7576.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.017424,
-                39.9922844
+                -83.0194523154251,
+                39.995791607080655
               ]
             }
           },
@@ -8508,20 +9106,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1923.4,
-                7576.0
+                6526.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.018531,
-                39.992325
+                -83.01560023866607,
+                39.99565032946871
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01582046194764,
+                39.99212590329799
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01967253870667,
+                39.992267180909934
               ]
             }
           }
@@ -8539,15 +9179,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8566,34 +9206,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,17.4 5416.2,0.0 5415.9,122.4 6387.6,141.2 6394.1,7602.6 -0.0,7596.0 -0.0,17.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5195.1 -0.0,-0.0 5411.5,0.0 5410.6,142.1 6403.0,168.0 6359.5,7625.3 515.7,7580.1 533.1,5198.6 -0.0,5195.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0264/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2603.6,
-                2755.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0144652,
-                39.9943691
+                -83.01593735022261,
+                39.99566325359298
               ]
             }
           },
@@ -8601,20 +9244,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6403.0,
-                5215.3
+                6575.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0122933,
-                39.9931764
+                -83.0120554468094,
+                39.995542725312006
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6575.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01224195778217,
+                39.99201699286444
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01612386119538,
+                39.992137521145416
               ]
             }
           }
@@ -8632,15 +9317,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8659,34 +9344,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5416.3,7484.4 1007.6,7421.5 983.5,147.6 -0.0,150.1 0.0,0.0 6526.0,0.0 6526.0,151.3 5427.8,150.6 5416.3,7484.4\" /></svg>"
+          "value": "<svg><polygon points=\"1005.2,7662.4 1000.9,193.1 -0.0,193.6 0.0,0.0 4882.7,0.0 4847.3,7665.9 1005.2,7662.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0265/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1011.7,
-                5284.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0122933,
-                39.9931764
+                -83.01274150665981,
+                39.995578464748654
               ]
             }
           },
@@ -8694,20 +9382,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5418.3,
-                5284.0
+                6526.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0097249,
-                39.9930786
+                -83.00892158694965,
+                39.99543912358733
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00913727381895,
+                39.991919523472575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0129571935291,
+                39.9920588646339
               ]
             }
           }
@@ -8725,15 +9455,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8752,34 +9482,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"535.4,7684.2 554.0,222.4 1640.4,224.1 1640.5,74.4 3701.1,0.0 3700.2,229.7 4381.9,173.2 4609.2,0.0 5988.8,0.0 6261.4,1311.8 4953.5,1361.6 6211.1,7682.5 535.4,7684.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,33.3 3765.1,0.0 3763.4,234.2 3896.9,233.5 4587.6,0.0 5959.7,0.0 6235.0,1306.7 6575.0,1310.6 6575.0,4163.6 5591.5,4165.3 6202.5,7660.5 -0.0,7679.5 -0.0,33.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0266/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                539.9,
-                5299.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0097249,
-                39.9930786
+                -83.0098824349508,
+                39.99548928000541
               ]
             }
           },
@@ -8787,20 +9520,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5255.2,
-                2859.6
+                6575.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.006877,
-                39.994076
+                -83.00599868336678,
+                39.995335870913046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6575.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00623607341417,
+                39.99180842723216
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01011982499818,
+                39.99196183632452
               ]
             }
           }
@@ -8818,15 +9593,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8845,34 +9620,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"867.0,5182.5 1387.6,7751.0 -0.0,7756.4 -0.0,3998.6 631.4,3997.2 -0.0,476.6 6271.7,471.3 6270.1,7332.0 3256.4,7329.1 2093.6,7526.5 2035.8,5189.4 867.0,5182.5\" /></svg>"
+          "value": "<svg><polygon points=\"842.5,5191.4 1360.2,7762.7 -0.0,7766.0 -0.0,4005.4 608.2,4004.8 -0.0,480.5 6257.8,483.2 6247.4,7349.6 3231.2,7342.8 2067.2,7539.0 2012.3,5199.8 842.5,5191.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0267/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6270.1,
-                5180.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.003179,
-                39.991218
+                -83.00669256114747,
+                39.99368967103387
               ]
             }
           },
@@ -8880,20 +9658,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6270.1,
-                7332.0
+                6526.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.003243,
-                39.990251
+                -83.00286676996338,
+                39.993544810774
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00309257509647,
+                39.99004439138163
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00691836628057,
+                39.9901892516415
               ]
             }
           }
@@ -8911,15 +9731,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8938,34 +9758,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5352.6,7627.0 3294.2,7632.3 3289.0,7212.7 874.3,7235.0 836.3,309.1 5301.5,207.2 5352.6,7627.0\" /></svg>"
+          "value": "<svg><polygon points=\"5360.6,7647.0 3295.0,7651.1 3290.0,7230.0 866.8,7250.9 832.8,299.7 5313.6,200.2 5360.6,7647.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0268/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3283.5,
-                3659.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0017,
-                39.991807
+                -83.00351328874531,
+                39.993542259806674
               ]
             }
           },
@@ -8973,20 +9796,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                847.9,
-                3015.6
+                6575.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.003117,
-                39.992161
+                -82.99964312072989,
+                39.993375583438834
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6575.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99990107687138,
+                39.98986096626379
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0037712448868,
+                39.99002764263163
               ]
             }
           }
@@ -9004,15 +9869,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9038,27 +9903,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0269/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3303.0,
-                3616.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.999279,
-                39.991703
+                -83.00110848886854,
+                39.99340702909513
               ]
             }
           },
@@ -9066,20 +9934,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3303.0,
-                7604.0
+                6526.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9994009,
-                39.989909
+                -82.99727542655914,
+                39.993254156282006
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99751372455312,
+                39.989747129200765
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00134678686251,
+                39.98990000201389
               ]
             }
           }
@@ -9097,15 +10007,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9124,34 +10034,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"368.6,7501.8 369.8,0.0 6603.0,0.0 6603.0,6728.8 3951.8,6713.4 3949.8,7516.9 368.6,7501.8\" /></svg>"
+          "value": "<svg><polygon points=\"4002.4,7542.0 403.9,7552.0 353.3,171.6 6603.0,0.0 6603.0,6701.2 3998.6,6721.7 4001.4,7323.1 4002.4,7542.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0270/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3959.4,
-                3580.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9959273,
-                39.9915699
+                -82.9981714088485,
+                39.99330164828459
               ]
             }
           },
@@ -9159,20 +10072,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2283.7,
-                168.0
+                6603.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9968265,
-                39.9931663
+                -82.99425383918926,
+                39.993132719189504
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6603.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99451413459467,
+                39.98958961264128
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99843170425392,
+                39.98975854173637
               ]
             }
           }
@@ -9190,15 +10145,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9224,27 +10179,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0271/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6366.0,
-                3984.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0186376,
-                39.9906142
+                -83.02225642758536,
+                39.992538625716705
               ]
             }
           },
@@ -9252,20 +10210,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6366.0,
-                172.0
+                6526.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.018531,
-                39.992325
+                -83.01843246557739,
+                39.99239876447326
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01865047544099,
+                39.98889997202835
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.02247443744896,
+                39.9890398332718
               ]
             }
           }
@@ -9283,15 +10283,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9310,34 +10310,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7796.0 -0.0,746.3 6382.7,719.6 6383.0,1408.0 6603.0,1406.8 6603.0,3648.6 6375.0,3648.1 6404.7,7796.0 -0.0,7796.0\" /></svg>"
+          "value": "<svg><polygon points=\"6383.0,3652.0 6395.8,7796.0 -0.0,7796.0 -0.0,730.1 6402.6,729.4 6400.2,1416.4 6603.0,1416.2 6603.0,3653.4 6383.0,3652.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0272/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6383.0,
-                5616.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0188783,
-                39.9867158
+                -83.02245128469077,
+                39.98936657445409
               ]
             }
           },
@@ -9345,20 +10348,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6383.0,
-                1408.0
+                6603.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0187509,
-                39.9885954
+                -83.01859277601798,
+                39.9892251346307
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6603.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01881069882856,
+                39.985735194101174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.02266920750135,
+                39.98587663392456
               ]
             }
           }
@@ -9376,15 +10421,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9410,27 +10455,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0273/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2067.4,
-                268.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.017424,
-                39.9922844
+                -83.01862570754676,
+                39.992451455461016
               ]
             }
           },
@@ -9438,20 +10486,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                219.9,
-                6340.0
+                6526.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0186849,
-                39.9896052
+                -83.01480723975602,
+                39.99230324428987
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01503826519208,
+                39.98880947967919
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01885673298281,
+                39.988957690850334
               ]
             }
           }
@@ -9469,15 +10559,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9496,34 +10586,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"469.4,3679.7 481.3,1465.2 264.0,1465.2 267.8,675.2 5657.8,697.2 5642.7,7627.2 252.0,7555.9 244.2,3678.1 469.4,3679.7\" /></svg>"
+          "value": "<svg><polygon points=\"244.2,3678.1 461.9,3679.6 464.8,1465.2 264.0,1465.2 267.8,675.2 5665.4,697.2 5642.7,7627.3 252.0,7555.9 244.2,3678.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0274/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3999.4,
-                3700.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.016607,
-                39.987506
+                -83.01886649088442,
+                39.98926364755101
               ]
             }
           },
@@ -9531,20 +10624,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6307.0,
-                3700.0
+                6603.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0152446,
-                39.9874574
+                -83.01496818516522,
+                39.98912458585256
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6603.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01518244373958,
+                39.98559864725239
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01908074945878,
+                39.98573770895084
               ]
             }
           }
@@ -9562,15 +10697,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9589,34 +10724,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"872.1,239.9 6526.0,229.2 6526.0,7350.0 6007.4,7350.1 6002.0,7796.0 869.6,7729.6 872.1,239.9\" /></svg>"
+          "value": "<svg><polygon points=\"869.9,7057.2 872.1,239.9 5030.5,232.0 5027.5,4000.3 6047.8,3995.9 6010.9,7058.4 869.9,7057.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0275/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5030.5,
-                232.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0123651,
-                39.9920977
+                -83.01532143858995,
+                39.992316633437646
               ]
             }
           },
@@ -9624,20 +10762,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                603.8,
-                4020.0
+                6526.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0150849,
-                39.9904892
+                -83.01147726854497,
+                39.99216840278512
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01170831979753,
+                39.988651052241416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01555248984252,
+                39.98879928289394
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0276/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p276",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0276/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0276/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6555
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5930.9,7655.7 -0.0,7605.6 -0.0,671.2 858.0,671.3 858.6,0.0 6028.2,0.0 5930.9,7655.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0276/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01552115418882,
+                39.98913232774452
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6555.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01168131984666,
+                39.9889836071735
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6555.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01191052024957,
+                39.98546043451424
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01575035459173,
+                39.98560915508526
               ]
             }
           }
@@ -9655,15 +10973,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9682,34 +11000,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"441.0,278.2 436.1,0.0 4831.4,0.0 4834.1,210.2 5440.0,200.8 5514.3,7380.9 2045.4,7428.8 1947.6,254.9 441.0,278.2\" /></svg>"
+          "value": "<svg><polygon points=\"1532.9,4062.1 508.6,4078.1 468.7,294.0 5450.7,228.5 6526.0,214.4 6526.0,7474.0 6053.2,7368.8 6053.6,7067.6 1530.7,7081.0 1532.9,4062.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0277/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3722.9,
-                7412.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0107145,
-                39.9888117
+                -83.01262925220226,
+                39.992242696695875
               ]
             }
           },
@@ -9717,20 +11038,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2651.2,
-                244.0
+                6526.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0110726,
-                39.9920497
+                -83.00880301909004,
+                39.992061900476585
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00908488519075,
+                39.98856163252103
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01291111830297,
+                39.988742428740316
               ]
             }
           }
@@ -9748,15 +11111,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9775,34 +11138,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2558.7,7796.0 -0.0,7376.1 -0.0,235.9 4455.2,213.1 6490.5,1395.4 6555.0,3727.4 6321.7,6227.0 5632.6,7796.0 2558.7,7796.0\" /></svg>"
+          "value": "<svg><polygon points=\"1015.1,7472.8 1073.3,230.4 4478.8,213.0 6490.5,1395.4 6555.0,3727.4 6321.7,6227.0 5637.5,7796.0 2558.7,7796.0 1015.1,7472.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0278/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2567.6,
-                6244.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.008122,
-                39.989222
+                -83.0094343224037,
+                39.99209531821121
               ]
             }
           },
@@ -9810,20 +11176,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5323.2,
-                1392.0
+                6555.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.006349,
-                39.99134
+                -83.00558159408548,
+                39.99193700506911
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6555.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00582731039117,
+                39.98842692399561
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00968003870939,
+                39.98858523713771
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0279/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p279",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0279/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0279/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6526
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"50.5,0.0 4504.2,0.0 4502.7,294.5 6490.8,273.3 6526.0,7467.3 15.2,7584.5 50.5,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0279/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01201785410716,
+                39.98902238781879
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00813153410033,
+                39.98884758936374
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00840207929161,
+                39.985266462565946
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01228839929844,
+                39.985441261020995
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0280/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p280",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0280/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0280/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6555
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3615.8,722.9 3588.3,2299.4 3860.4,3624.0 5173.2,3622.2 4479.8,0.0 6431.6,0.0 6335.2,3623.9 6555.0,4828.0 6555.0,6298.1 5703.6,6293.2 5966.9,7637.8 465.5,7501.6 533.9,691.9 3615.8,722.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0280/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00847223468175,
+                39.98884745808519
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6555.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00462174037239,
+                39.98871914804888
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6555.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00481948423985,
+                39.98518617876978
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00866997854921,
+                39.98531448880609
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0281/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p281",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0281/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0281/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6526
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6146.9 -0.0,2923.6 689.1,2913.7 192.4,608.2 2095.6,160.9 6335.8,122.7 6391.1,7383.3 2829.2,7427.5 2863.0,3735.6 2862.4,3647.4 869.6,3758.5 1642.4,7446.6 301.5,7471.8 -0.0,6146.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0281/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.006209329925,
+                39.99044867749094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00246018116646,
+                39.99027314714821
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00273186508029,
+                39.9868184950521
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00648101383884,
+                39.98699402539483
               ]
             }
           }
@@ -9841,15 +11663,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9868,34 +11690,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"591.2,7366.0 552.0,232.2 1837.7,212.6 1843.5,633.5 5962.7,615.5 6041.0,7337.1 591.2,7366.0\" /></svg>"
+          "value": "<svg><polygon points=\"595.1,7363.0 572.4,251.4 1854.1,234.8 1859.0,654.4 5965.4,645.9 6028.1,7346.7 595.1,7363.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0282/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                571.9,
-                2720.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0026472,
-                39.9891012
+                -83.0029035710582,
+                39.99035215726012
               ]
             }
           },
@@ -9903,20 +11728,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1867.7,
-                7356.0
+                6555.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.002043,
-                39.986976
+                -82.99903125597504,
+                39.99018638293748
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6555.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9992885441545,
+                39.986658339796826
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00316085923765,
+                39.986824114119464
               ]
             }
           }
@@ -9934,15 +11801,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9968,27 +11835,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0283/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3510.9,
-                3928.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9982782,
-                39.9884859
+                -83.0001720741298,
+                39.99029142244178
               ]
             }
           },
@@ -9996,20 +11866,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3510.9,
-                800.0
+                6526.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9981839,
-                39.9898591
+                -82.99643168668125,
+                39.99014063828932
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99666671315182,
+                39.98671817435071
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00040710060037,
+                39.98686895850317
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0284/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p284",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0284/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0284/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6581
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6581.0,7618.0 1019.7,7596.8 934.2,2194.5 1050.7,2033.5 1040.6,823.8 2760.8,832.3 2764.1,0.0 6581.0,0.0 6581.0,7618.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0284/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9976294292408,
+                39.990204041905955
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6581.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99380581701729,
+                39.990062245651814
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6581.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99402342022465,
+                39.98656893407117
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99784703244816,
+                39.98671073032531
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0285/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p285",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0285/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0285/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6526
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6513.6,7796.0 677.1,7386.5 163.6,2761.6 1018.1,2839.9 1144.8,1363.5 1027.8,135.3 5812.7,572.6 6513.6,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0285/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00544519623166,
+                39.987122397665374
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00164143159765,
+                39.98724708785566
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6526.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00144844667682,
+                39.98374194343054
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00525221131083,
+                39.983617253240254
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0286/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p286",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0286/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0286/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6581
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4996.0,7635.3 1754.2,7316.0 1061.2,22.9 6581.0,567.8 6581.0,1901.0 5418.0,1790.2 5776.3,5265.1 4765.0,5163.8 4996.0,7635.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0286/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00266018619746,
+                39.98696509925994
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6581.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99883655695831,
+                39.987096412034575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6581.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99863505111188,
+                39.983602925148176
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00245868035103,
+                39.98347161237354
               ]
             }
           }
@@ -10027,15 +12353,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10054,34 +12380,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2959.5,7526.4 2306.8,317.0 5894.6,327.6 5856.6,3049.7 5194.1,3047.9 5177.6,5125.0 5856.5,5121.7 5807.6,7547.8 2959.5,7526.4\" /></svg>"
+          "value": "<svg><polygon points=\"5839.1,7560.3 1389.7,7562.8 914.5,5110.4 1930.7,5111.5 1229.2,1666.9 2397.3,1662.4 2264.9,327.1 5867.9,308.7 5851.8,3042.7 5142.2,3046.5 5186.8,5132.3 5868.5,5123.5 5839.1,7560.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0287/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3371.5,
-                1651.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.998237,
-                39.986223
+                -83.00012700883744,
+                39.98704271198272
               ]
             }
           },
@@ -10089,20 +12418,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3567.5,
-                7531.0
+                6519.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9982836,
-                39.9835903
+                -82.99634061367725,
+                39.98688401796172
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6519.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99658826400535,
+                39.98341508375824
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00037465916554,
+                39.983573777779235
               ]
             }
           }
@@ -10120,15 +12491,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10147,34 +12518,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"672.5,5221.1 -0.0,5128.6 -0.0,3060.3 659.4,3056.8 675.7,346.0 5265.5,347.0 5265.4,0.0 6581.0,0.0 6581.0,7796.0 643.6,7796.0 672.5,5221.1\" /></svg>"
+          "value": "<svg><polygon points=\"672.5,5221.1 -0.0,5128.6 -0.0,3060.3 659.4,3056.8 675.7,346.0 5300.2,347.1 5297.9,0.0 6581.0,0.0 6581.0,7796.0 643.6,7796.0 672.5,5221.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0288/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                675.7,
-                5120.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9968812,
-                39.9846198
+                -82.9971135241015,
+                39.98693435057297
               ]
             }
           },
@@ -10182,20 +12556,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                675.7,
-                344.0
+                6581.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9967286,
-                39.9867625
+                -82.99325678125255,
+                39.98677309674412
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6581.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99350597890654,
+                39.983274041612155
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99736272175548,
+                39.983435295441005
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0289/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p289",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0289/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0289/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6519
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5983.8,7795.0 -0.0,7795.0 -0.0,430.3 4067.8,421.2 4067.4,200.0 5968.8,224.8 5983.8,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0289/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.02135188662417,
+                39.98602598966743
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6519.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01745322678269,
+                39.9858763630336
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6519.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01768672084208,
+                39.98230448283555
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.02158538068356,
+                39.98245410946939
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0290/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p290",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0290/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0290/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6601
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"115.3,7795.0 102.4,175.2 6418.0,224.9 6437.4,7795.0 115.3,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0290/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01784510422748,
+                39.985868658052
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6601.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01389374367498,
+                39.9857179492643
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6601.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0141259359763,
+                39.98214384718618
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01807729652879,
+                39.98229455597388
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0291/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p291",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0291/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0291/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6519
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"819.9,7795.0 719.2,104.8 5907.1,88.1 5855.7,7795.0 819.9,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0291/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01442534462942,
+                39.985685724677275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6519.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01062704461378,
+                39.98550791708786
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6519.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01090257161486,
+                39.98200343484607
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0147008716305,
+                39.98218124243549
               ]
             }
           }
@@ -10213,15 +13043,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10240,34 +13070,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6601.0,0.0 6081.0,241.6 6601.0,152.1 6601.0,7795.0 431.6,7722.1 406.5,192.5 6601.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"449.7,167.2 6601.0,0.0 6601.0,16.6 6601.0,192.4 6048.0,260.4 6077.3,2849.4 5446.8,2974.1 5543.2,7603.6 6601.0,7595.7 6601.0,7795.0 372.5,7795.0 449.7,167.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0292/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4821.8,
-                5239.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.008556,
-                39.98305
+                -83.0112502415931,
+                39.985574444427606
               ]
             }
           },
@@ -10275,20 +13108,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                419.8,
-                4211.5
+                6601.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0111368,
-                39.9836515
+                -83.00729142442783,
+                39.98538886039458
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6601.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00757734481702,
+                39.98180797469739
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.01153616198229,
+                39.981993558730416
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0293/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p293",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0293/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0293/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6487
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6342.1,7768.4 -0.0,7675.3 -0.0,2875.2 643.6,2854.7 679.7,177.1 1232.2,165.3 1235.6,0.0 4849.2,88.2 6342.1,7768.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0293/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.008022126651,
+                39.98539769358043
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6487.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00419170868494,
+                39.985279425488386
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6487.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00437717744967,
+                39.98175275441708
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00820759541573,
+                39.981871022509125
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0294/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p294",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0294/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0294/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6601
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"522.0,0.0 6308.6,1041.4 6308.3,1086.6 6361.2,1098.5 6325.2,7795.0 -0.0,7795.0 -0.0,4512.1 528.1,4622.7 522.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0294/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0051673207223,
+                39.98377926739223
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6601.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00137839680573,
+                39.98422246813818
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6601.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.0007003732952,
+                39.98077102164069
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00448929721176,
+                39.98032782089474
               ]
             }
           }
@@ -10306,15 +13457,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:15:16Z",
-      "modified": "2026-08-07T15:15:16Z",
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10333,34 +13484,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7796.0 -0.0,6638.7 204.2,6665.4 -0.0,8.8 5349.5,915.6 4898.2,7796.0 -0.0,7796.0\" /></svg>"
+          "value": "<svg><polygon points=\"4906.9,7796.0 -0.0,7796.0 -0.0,6638.6 204.2,6665.4 0.0,8.8 6367.9,1088.2 6487.0,6850.2 6350.4,7713.2 4928.2,7468.0 4906.9,7796.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0295/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1191.8,
-                1552.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -83.0006177,
-                39.9830861
+                -83.00142105623378,
+                39.983723912063354
               ]
             }
           },
@@ -10368,20 +13522,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2247.7,
-                1728.0
+                6487.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9999862,
-                39.983061
+                -82.99761338393115,
+                39.98405596368471
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6487.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99709266622673,
+                39.98055018251018
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -83.00090033852936,
+                39.98021813088882
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0296/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Columbus, Ohio | 1951 | Vol. 3 p296",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:03:08Z",
+      "modified": "2026-08-15T01:03:08Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0296/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0296/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6601
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,6732.5 1445.9,6885.9 1518.2,5915.9 1030.3,268.9 2109.2,375.5 2079.9,632.1 6601.0,1098.8 6601.0,7795.0 -0.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd408m:g4084m:g4084cm:g4084cm_g06656195103:06656_03_1951-0296/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99822161356936,
+                39.98365929120862
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6601.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99435590643647,
+                39.9838046684002
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6601.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99413350434997,
+                39.980283264038015
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.99799921148286,
+                39.980137886846435
               ]
             }
           }

--- a/gallery/detroit_mich_1929_vol_11.iiif.json
+++ b/gallery/detroit_mich_1929_vol_11.iiif.json
@@ -24,8 +24,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6467.7 -0.0,-0.0 6285.0,0.0 6234.0,6470.4 -0.0,6467.7\" /></svg>"
+          "value": "<svg><polygon points=\"6265.4,0.0 6217.3,6464.9 15.8,6501.8 -0.0,-0.0 6265.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -73,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.98802410427868,
-                42.36946903019445
+                -82.98802990703429,
+                42.369479829381824
               ]
             }
           },
@@ -94,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.98456086729912,
-                42.37085486555634
+                -82.9845457329942,
+                42.370853051714406
               ]
             }
           },
@@ -115,8 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9823088944092,
-                42.367739390386646
+                -82.98229837776057,
+                42.36774088698897
               ]
             }
           },
@@ -136,8 +136,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.98577213138876,
-                42.36635355502476
+                -82.98578255180065,
+                42.36636766465639
               ]
             }
           }
@@ -162,8 +162,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -182,7 +182,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"182.6,7152.5 159.6,0.0 5948.2,0.0 5978.4,6227.2 2147.8,6268.8 2154.8,7124.0 182.6,7152.5\" /></svg>"
+          "value": "<svg><polygon points=\"183.5,7154.4 160.2,0.0 5948.6,0.0 5979.0,6228.7 2148.6,6270.4 2155.6,7125.9 183.5,7154.4\" /></svg>"
         }
       },
       "body": {
@@ -211,8 +211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96116532722284,
-                42.37923607857756
+                -82.96116620903813,
+                42.3792367383712
               ]
             }
           },
@@ -232,8 +232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95764111929529,
-                42.380500179036524
+                -82.95764179378646,
+                42.38050081620928
               ]
             }
           },
@@ -253,8 +253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95558664606003,
-                42.37733034716154
+                -82.9555873573165,
+                42.37733079785635
               ]
             }
           },
@@ -274,8 +274,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95911085398758,
-                42.37606624670257
+                -82.95911177256816,
+                42.37606672001827
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0100/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p100",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0100/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0100/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4773.7,0.0 6335.0,0.0 6335.0,7795.0 -0.0,7795.0 -0.0,1943.9 806.1,1943.8 805.5,904.2 1034.9,903.0 1035.0,693.7 4773.9,684.6 4773.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0100/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93520061227304,
+                42.36201227679688
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93166265320457,
+                42.36328995145668
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.92953499058748,
+                42.36007345078638
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93307294965595,
+                42.358795776126584
               ]
             }
           }
@@ -300,8 +438,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +458,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5950.0,0.0 5875.6,7067.3 496.8,7032.3 580.7,0.0 5950.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5869.0,7066.2 495.9,7027.7 571.4,776.9 -0.0,767.3 -0.0,-0.0 5948.0,0.0 5869.0,7066.2\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +487,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95843107038877,
-                42.380599607291614
+                -82.95843405378999,
+                42.38059977889306
               ]
             }
           },
@@ -370,8 +508,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95495096966562,
-                42.38190013529712
+                -82.95495138487607,
+                42.38190339537775
               ]
             }
           },
@@ -391,8 +529,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95283724685318,
-                42.37877004337921
+                -82.95283264241861,
+                42.37877099356315
               ]
             }
           },
@@ -412,8 +550,560 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95631734757633,
-                42.377469515373704
+                -82.95631531133253,
+                42.37746737707846
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0012/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p12",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0012/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0012/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"290.4,7022.8 241.5,0.0 5960.8,6.8 5985.0,6902.6 290.4,7022.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0012/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9553565886715,
+                42.381758637365415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95179184990748,
+                42.38301518230923
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94973510937764,
+                42.379831572510305
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95329984814167,
+                42.37857502756649
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0013/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p13",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0013/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0013/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"381.3,6931.9 414.2,0.0 6095.9,66.4 6065.4,6845.8 381.3,6931.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0013/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95228579922735,
+                42.38283595844004
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94875385510025,
+                42.384107605533394
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94667247850418,
+                42.380953157595236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95020442263129,
+                42.37968151050188
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0014/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p14",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0014/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0014/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"632.3,6773.2 637.5,0.0 6447.0,0.0 6418.2,6760.5 632.3,6773.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0014/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94927871077905,
+                42.383886594514685
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94573690010289,
+                42.38514961468074
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94366954124435,
+                42.381986511481266
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94721135192052,
+                42.38072349131521
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0015/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p15",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0015/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0015/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6172.4,348.1 6140.3,7086.1 188.4,7144.4 186.1,7795.0 -0.0,7795.0 -0.0,374.4 6172.4,348.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0015/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98625569077616,
+                42.36703741046995
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98275818941588,
+                42.36842147710622
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98049304664572,
+                42.36529746351399
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.983990548006,
+                42.36391339687772
               ]
             }
           }
@@ -438,8 +1128,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +1148,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6021.8,0.0 5930.2,6262.1 6347.8,6235.0 6316.6,7795.0 -0.0,7795.0 -0.0,652.4 95.8,653.5 104.6,0.0 6021.8,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"96.4,0.0 6023.2,0.0 5936.0,6258.8 6354.3,6231.4 6324.1,7795.0 -0.0,7795.0 96.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +1177,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.98413681746639,
-                42.36419533482199
+                -82.98412960584963,
+                42.36419341001336
               ]
             }
           },
@@ -508,8 +1198,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.98063860202724,
-                42.36561485135238
+                -82.98063573931263,
+                42.36560878234813
               ]
             }
           },
@@ -529,8 +1219,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97833206329514,
-                42.36246768385088
+                -82.97833593716832,
+                42.36246552353074
               ]
             }
           },
@@ -550,8 +1240,698 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.98183027873428,
-                42.36104816732049
+                -82.98182980370532,
+                42.36105015119596
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0017/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p17",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0017/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0017/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5378.6,6857.4 452.9,6908.7 415.9,959.9 5465.9,998.8 5378.6,6857.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0017/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98330254289829,
+                42.36851975027871
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97981456519481,
+                42.369867129759406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97760966085565,
+                42.36675134477219
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98109763855912,
+                42.36540396529149
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0018/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p18",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0018/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0018/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5666.2,6761.7 -0.0,6907.4 -0.0,1015.3 5751.8,1097.7 5666.2,6761.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0018/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98034026380988,
+                42.36966951345373
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97684505109117,
+                42.37097103707916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9747151599537,
+                42.36784882884467
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97821037267241,
+                42.36654730521924
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0019/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p19",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0019/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0019/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3874.8,1116.3 3871.1,2099.3 5656.2,2114.9 5795.5,5949.7 3856.5,5955.0 3854.1,6577.2 140.3,6708.5 152.1,1092.7 3874.8,1116.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0019/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97729845485802,
+                42.370804956034746
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97377489179152,
+                42.372092723811626
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97168223657545,
+                42.368923043035345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97520579964194,
+                42.367635275258465
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0002/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p2",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0002/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0002/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5167.9,6540.1 255.8,6526.1 222.3,0.0 5204.3,0.0 5167.9,6540.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0002/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98477741824902,
+                42.370786548384295
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98127854836643,
+                42.37212411000873
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97908963253457,
+                42.368998706229135
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98258850241716,
+                42.3676611446047
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0020/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p20",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0020/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0020/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6447.0,6353.1 -0.0,6396.6 -0.0,-0.0 6447.0,0.0 6447.0,6353.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0020/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97425633944268,
+                42.371929507292506
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97069527656605,
+                42.37333274458643
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96839891275826,
+                42.370151744578344
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97195997563489,
+                42.36874850728442
               ]
             }
           }
@@ -576,8 +1956,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +1976,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5028.8,7132.8 358.6,7497.9 368.6,296.3 5139.0,280.6 5028.8,7132.8\" /></svg>"
+          "value": "<svg><polygon points=\"5030.3,7134.2 359.5,7499.5 369.3,297.8 5135.2,281.9 5030.3,7134.2\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +2005,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.98138531930378,
-                42.365893541202105
+                -82.98138611973657,
+                42.36589397598435
               ]
             }
           },
@@ -646,8 +2026,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97792262263508,
-                42.36725418379044
+                -82.97792344358069,
+                42.36725449802798
               ]
             }
           },
@@ -667,8 +2047,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.975711712636,
-                42.36413901883221
+                -82.97571272945486,
+                42.364139351523846
               ]
             }
           },
@@ -688,8 +2068,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97917440930472,
-                42.362778376243874
+                -82.97917540561073,
+                42.36277882948021
               ]
             }
           }
@@ -714,8 +2094,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +2114,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5692.9,6503.2 -0.0,7113.1 -0.0,298.9 5795.2,183.7 5692.9,6503.2\" /></svg>"
+          "value": "<svg><polygon points=\"5689.6,6501.3 -0.0,7106.6 -0.0,296.6 5796.5,185.7 5689.6,6501.3\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +2143,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97862821440553,
-                42.366987142595356
+                -82.97863027482573,
+                42.36698523270351
               ]
             }
           },
@@ -784,8 +2164,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97511655943991,
-                42.36831368713223
+                -82.9751178553486,
+                42.36831451129402
               ]
             }
           },
@@ -805,8 +2185,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97296101956472,
-                42.36515453008797
+                -82.97295787283205,
+                42.36515466647948
               ]
             }
           },
@@ -826,8 +2206,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97647267453034,
-                42.3638279855511
+                -82.97647029230919,
+                42.36382538788897
               ]
             }
           }
@@ -852,8 +2232,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +2252,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"172.2,753.6 3918.7,633.9 3923.2,0.0 5878.8,0.0 5897.7,573.3 6447.0,557.1 6447.0,6475.8 131.4,7149.3 172.2,753.6\" /></svg>"
+          "value": "<svg><polygon points=\"133.4,7148.9 169.9,750.3 3918.0,627.9 3922.1,0.0 5878.9,0.0 5897.9,566.3 6241.6,555.3 6195.4,6493.6 133.4,7148.9\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +2281,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97571589809847,
-                42.36837407246421
+                -82.97571336212059,
+                42.36837321483251
               ]
             }
           },
@@ -922,8 +2302,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9722285355544,
-                42.369659541677144
+                -82.97222641775251,
+                42.369656326134695
               ]
             }
           },
@@ -943,8 +2323,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9701396946456,
-                42.366522306923294
+                -82.97014140836328,
+                42.36651946757238
               ]
             }
           },
@@ -964,8 +2344,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97362705718967,
-                42.36523683771036
+                -82.97362835273135,
+                42.365236356270195
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0026/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p26",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0026/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0026/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5807.7,382.5 5817.1,6207.2 3052.1,6254.8 292.6,6541.9 285.2,621.5 5807.7,382.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0026/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97250918430073,
+                42.369588479545705
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96897132274421,
+                42.370843093818706
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96691823145383,
+                42.36768273495156
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97045609301036,
+                42.366428120678556
               ]
             }
           }
@@ -990,8 +2508,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1010,7 +2528,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"531.1,651.8 4391.2,554.9 4672.2,1128.4 5237.8,1385.4 5226.8,2179.4 6447.0,2145.0 6441.9,6651.3 5346.4,6433.4 530.3,6484.4 531.1,651.8\" /></svg>"
+          "value": "<svg><polygon points=\"539.5,650.1 1301.7,580.1 1278.6,0.0 6447.0,0.0 6411.4,6088.7 4317.2,6132.1 4295.9,6438.0 531.9,6474.4 539.5,650.1\" /></svg>"
         }
       },
       "body": {
@@ -1039,8 +2557,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96968224353682,
-                42.37072296904861
+                -82.96968730406833,
+                42.370720444853774
               ]
             }
           },
@@ -1060,8 +2578,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96617675439084,
-                42.37198927136032
+                -82.96617881238737,
+                42.371991648649015
               ]
             }
           },
@@ -1081,8 +2599,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.964118983428,
-                42.368835845715516
+                -82.96411307639882,
+                42.368835522020014
               ]
             }
           },
@@ -1102,8 +2620,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96762447257399,
-                42.3675695434038
+                -82.96762156807978,
+                42.36756431822477
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0003/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p3",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0003/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0003/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6748.1 -0.0,-0.0 5991.4,0.0 5838.3,6861.5 -0.0,6748.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0003/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9820137035962,
+                42.37195420468383
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97849924856236,
+                42.37327946720235
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97633045644277,
+                42.37014014722951
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9798449114766,
+                42.36881488471099
               ]
             }
           }
@@ -1128,8 +2784,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1148,7 +2804,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5099.0,204.1 5028.1,7795.0 -0.0,7795.0 -0.0,-0.0 1266.0,0.0 1264.3,184.2 5099.0,204.1\" /></svg>"
+          "value": "<svg><polygon points=\"5037.3,7447.6 128.9,7375.0 122.7,7795.0 -0.0,7795.0 -0.0,-0.0 1264.6,0.0 1263.2,183.5 5094.7,197.7 5037.3,7447.6\" /></svg>"
         }
       },
       "body": {
@@ -1177,8 +2833,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96326048239428,
-                42.37539175051685
+                -82.96326065475255,
+                42.37539235787727
               ]
             }
           },
@@ -1198,8 +2854,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95981116631864,
-                42.37666938486815
+                -82.95980590687785,
+                42.376667224796044
               ]
             }
           },
@@ -1219,8 +2875,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95773482459374,
-                42.37356672374173
+                -82.95773406263386,
+                42.373559677763744
               ]
             }
           },
@@ -1240,8 +2896,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96118414066937,
-                42.37228908939043
+                -82.96118881050856,
+                42.37228481084497
               ]
             }
           }
@@ -1266,8 +2922,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1286,7 +2942,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4480.3,7795.0 -0.0,6399.4 -0.0,417.2 4946.2,336.7 5012.6,7795.0 4480.3,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"4946.6,0.0 5015.8,7795.0 4478.3,7795.0 -0.0,6404.9 -0.0,-0.0 4946.6,0.0\" /></svg>"
         }
       },
       "body": {
@@ -1315,8 +2971,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96122989566133,
-                42.37247795676055
+                -82.96123137330166,
+                42.37247773106389
               ]
             }
           },
@@ -1336,8 +2992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95777616686635,
-                42.37370547005022
+                -82.9577781305058,
+                42.37370504028091
               ]
             }
           },
@@ -1357,8 +3013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95578136709106,
-                42.37059870273964
+                -82.95578366190767,
+                42.37059871085618
               ]
             }
           },
@@ -1378,8 +3034,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95923509588604,
-                42.36937118944997
+                -82.95923690470353,
+                42.36937140163916
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0033/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p33",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0033/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0033/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5192.7,0.0 5076.5,7199.2 1172.0,7106.5 1292.0,0.0 5192.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0033/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96095392433746,
+                42.3757034005724
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95742268834564,
+                42.37701706519408
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95527255137706,
+                42.37386323197399
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95880378736888,
+                42.37254956735231
               ]
             }
           }
@@ -1404,8 +3198,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1424,7 +3218,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4982.9,0.0 5082.4,7795.0 4236.2,7795.0 1203.0,6822.5 1100.0,0.0 4982.9,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5080.5,7795.0 4228.4,7795.0 1202.9,6824.0 1202.9,6823.4 649.3,6645.6 1200.4,6653.2 1101.8,0.0 4983.2,0.0 5080.5,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +3247,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95896380033408,
-                42.37285059885402
+                -82.9589661339957,
+                42.372851742463496
               ]
             }
           },
@@ -1474,8 +3268,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95537003839144,
-                42.37410853474057
+                -82.95537142997998,
+                42.37411093728337
               ]
             }
           },
@@ -1495,8 +3289,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95332579439912,
-                42.370875810309656
+                -82.95332514012276,
+                42.37087736542219
               ]
             }
           },
@@ -1516,8 +3310,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95691955634177,
-                42.36961787442311
+                -82.95691984413848,
+                42.369618170602315
               ]
             }
           }
@@ -1542,8 +3336,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1562,7 +3356,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1323.5,1670.2 5160.5,1661.0 5135.6,6167.3 1316.0,6202.3 1323.5,1670.2\" /></svg>"
+          "value": "<svg><polygon points=\"5163.9,1658.0 5137.4,6167.6 1315.1,6201.3 1324.1,1665.9 5163.9,1658.0\" /></svg>"
         }
       },
       "body": {
@@ -1591,8 +3385,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95950549766108,
-                42.377519672321654
+                -82.9595040568506,
+                42.37751721613756
               ]
             }
           },
@@ -1612,8 +3406,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95600146933764,
-                42.37880386100149
+                -82.95600314628244,
+                42.378801366596406
               ]
             }
           },
@@ -1633,8 +3427,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95391440638937,
-                42.375652091124515
+                -82.9539161454509,
+                42.37565240104813
               ]
             }
           },
@@ -1654,8 +3448,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95741843471282,
-                42.37436790244468
+                -82.95741705601907,
+                42.374368250589285
               ]
             }
           }
@@ -1680,8 +3474,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1700,7 +3494,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"445.3,1633.4 5810.2,1698.9 5731.8,6170.3 359.6,6141.0 445.3,1633.4\" /></svg>"
+          "value": "<svg><polygon points=\"445.0,1635.4 5807.6,1702.6 5727.7,6172.1 357.8,6141.0 445.0,1635.4\" /></svg>"
         }
       },
       "body": {
@@ -1729,8 +3523,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95694537052948,
-                42.37844063401917
+                -82.95694624818965,
+                42.37844154611616
               ]
             }
           },
@@ -1750,8 +3544,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95346641638268,
-                42.37975924700012
+                -82.95346644319827,
+                42.37976156245484
               ]
             }
           },
@@ -1771,8 +3565,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95132337424644,
-                42.37663007853693
+                -82.95132112029064,
+                42.376631628693815
               ]
             }
           },
@@ -1792,8 +3586,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95480232839324,
-                42.37531146555598
+                -82.95480092528203,
+                42.375311612355134
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0037/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p37",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0037/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0037/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6009.8,6082.9 291.5,6166.7 308.2,1695.6 6034.8,1628.3 6009.8,6082.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0037/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95396531360902,
+                42.379571640322105
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95045785538272,
+                42.38083791071939
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94837226778166,
+                42.37768588915605
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95187972600796,
+                42.37641961875876
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0038/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p38",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0038/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0038/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"192.6,1719.5 5843.1,1640.0 5834.9,6077.8 167.8,6146.8 192.6,1719.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0038/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95079495949341,
+                42.380767226819756
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94726582208705,
+                42.3820413129495
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94516737157971,
+                42.3788697942254
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94869650898607,
+                42.37759570809566
               ]
             }
           }
@@ -1818,8 +3888,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,7 +3908,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1120.3,6882.5 1156.9,322.0 4956.2,281.3 4944.6,7796.0 3075.1,7796.0 3078.9,6865.8 1120.3,6882.5\" /></svg>"
+          "value": "<svg><polygon points=\"1157.2,324.0 4956.0,283.2 4947.4,6093.5 1125.5,6062.4 1157.2,324.0\" /></svg>"
         }
       },
       "body": {
@@ -1867,8 +3937,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95784859433769,
-                42.37517402271705
+                -82.95784940361023,
+                42.375174816710654
               ]
             }
           },
@@ -1888,8 +3958,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95434515373307,
-                42.37645305622646
+                -82.9543454361236,
+                42.376453847575725
               ]
             }
           },
@@ -1909,8 +3979,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95225357084792,
-                42.37328202691032
+                -82.95225385756268,
+                42.37328234136887
               ]
             }
           },
@@ -1930,8 +4000,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95575701145253,
-                42.372002993400905
+                -82.9557578250493,
+                42.3720033105038
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0004/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p4",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0004/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0004/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3775.4,6811.1 65.5,6820.0 72.8,0.0 6447.0,0.0 6447.0,5615.1 5469.6,5653.6 5553.7,7795.0 3774.7,7795.0 3775.4,6811.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0004/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9787755805837,
+                42.37315298250064
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9752246816299,
+                42.37442225232056
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9731473360766,
+                42.37125066168918
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9766982350304,
+                42.36998139186927
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0040/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p40",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0040/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0040/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1494.4,6131.8 -0.0,5635.5 1113.6,5725.9 1115.7,0.0 4937.4,0.0 4955.2,7278.7 1686.0,6195.4 1634.9,7796.0 1444.2,7796.0 1494.4,6131.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0040/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95622002225541,
+                42.3727141865177
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.952701937052,
+                42.37397208921865
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95063039049145,
+                42.37081012203274
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95414847569486,
+                42.369552219331794
               ]
             }
           }
@@ -1956,8 +4302,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1976,7 +4322,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"523.1,335.6 5866.0,287.4 5851.2,7370.1 508.2,7415.1 523.1,335.6\" /></svg>"
+          "value": "<svg><polygon points=\"532.8,320.4 5878.9,287.4 5842.5,7796.0 495.8,7796.0 532.8,320.4\" /></svg>"
         }
       },
       "body": {
@@ -2005,8 +4351,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95543897124786,
-                42.37608091733765
+                -82.95544007198141,
+                42.37607196933884
               ]
             }
           },
@@ -2026,8 +4372,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95193751790956,
-                42.377360927893015
+                -82.95194553112867,
+                42.37735867301657
               ]
             }
           },
@@ -2047,8 +4393,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94984430578793,
-                42.37419174496451
+                -82.94984137368753,
+                42.37419574661289
               ]
             }
           },
@@ -2068,8 +4414,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95334575912624,
-                42.37291173440915
+                -82.95333591454028,
+                42.372909042935156
               ]
             }
           }
@@ -2094,8 +4440,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2114,7 +4460,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5771.4,0.0 5705.3,7528.7 4028.2,7448.6 258.2,6113.8 312.1,0.0 5771.4,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5704.7,7529.1 4028.6,7449.6 260.4,6116.7 308.4,406.8 5764.8,435.4 5704.7,7529.1\" /></svg>"
         }
       },
       "body": {
@@ -2143,8 +4489,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95333656640877,
-                42.3731060455915
+                -82.95333859087792,
+                42.3731085802407
               ]
             }
           },
@@ -2164,8 +4510,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94992383737141,
-                42.37438027725098
+                -82.94992330084919,
+                42.37438277053431
               ]
             }
           },
@@ -2185,8 +4531,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94784017491057,
-                42.37129125180249
+                -82.9478397060314,
+                42.371291427008664
               ]
             }
           },
@@ -2206,8 +4552,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95125290394792,
-                42.37001702014301
+                -82.95125499606013,
+                42.37001723671505
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0043/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p43",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0043/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0043/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"138.9,7796.0 272.0,410.0 6083.6,413.4 5943.3,7796.0 138.9,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0043/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95241268011594,
+                42.37724335610976
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9489872938265,
+                42.37852809386818
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94687128933862,
+                42.37544982809455
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95029667562805,
+                42.374165090336135
               ]
             }
           }
@@ -2232,8 +4716,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2252,7 +4736,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"141.9,212.0 5890.4,154.0 5822.6,7636.0 5002.6,7628.6 5002.7,7614.8 138.4,7484.0 141.9,212.0\" /></svg>"
+          "value": "<svg><polygon points=\"119.7,7462.7 150.0,189.6 5899.7,152.8 5810.1,7635.9 4984.2,7625.3 4984.3,7611.6 119.7,7462.7\" /></svg>"
         }
       },
       "body": {
@@ -2281,8 +4765,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95035590305258,
-                42.37425037772807
+                -82.95035456031346,
+                42.37423934784732
               ]
             }
           },
@@ -2302,8 +4786,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94687998128381,
-                42.375521474805446
+                -82.9468855410282,
+                42.37551977504398
               ]
             }
           },
@@ -2323,8 +4807,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94480139386673,
-                42.372375327343974
+                -82.94479169605506,
+                42.37237987563258
               ]
             }
           },
@@ -2344,8 +4828,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94827731563548,
-                42.37110423026659
+                -82.94826071534033,
+                42.37109944843592
               ]
             }
           }
@@ -2370,8 +4854,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2390,7 +4874,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"281.4,284.3 6020.0,283.9 5964.0,7796.0 204.6,7796.0 281.4,284.3\" /></svg>"
+          "value": "<svg><polygon points=\"287.3,282.6 6013.8,277.9 5963.4,7796.0 216.2,7796.0 287.3,282.6\" /></svg>"
         }
       },
       "body": {
@@ -2419,8 +4903,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94927703838061,
-                42.37835771776946
+                -82.94928025605581,
+                42.37835610113884
               ]
             }
           },
@@ -2440,8 +4924,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94581251225821,
-                42.379647060269825
+                -82.94580705994511,
+                42.379646241582144
               ]
             }
           },
@@ -2461,8 +4945,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94370396272333,
-                42.37651141456993
+                -82.9436972054782,
+                42.37650274892074
               ]
             }
           },
@@ -2482,8 +4966,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94716848884573,
-                42.37522207206956
+                -82.9471704015889,
+                42.37521260847744
               ]
             }
           }
@@ -2508,8 +4992,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2528,7 +5012,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"157.3,502.8 5918.8,534.1 5830.9,6977.9 4536.5,7024.8 4544.3,7796.0 -0.0,7753.4 157.3,502.8\" /></svg>"
+          "value": "<svg><polygon points=\"156.1,511.8 5920.9,551.4 5828.8,6976.9 4535.2,7022.9 4542.6,7796.0 -0.0,7749.1 156.1,511.8\" /></svg>"
         }
       },
       "body": {
@@ -2557,8 +5041,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94728002823557,
-                42.37543285670533
+                -82.94727720955316,
+                42.375429400042435
               ]
             }
           },
@@ -2578,8 +5062,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94382631546696,
-                42.376735724965535
+                -82.94382669164526,
+                42.37673324885312
               ]
             }
           },
@@ -2599,8 +5083,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9416957480353,
-                42.37360971692254
+                -82.94169452072921,
+                42.37361013252721
               ]
             }
           },
@@ -2620,8 +5104,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94514946080392,
-                42.37230684866233
+                -82.94514503863712,
+                42.372306283716526
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0047/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p47",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0047/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0047/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"633.5,7796.0 631.9,340.0 6407.0,321.3 6407.0,7796.0 633.5,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0047/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94638073580333,
+                42.37946793532511
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94288028028733,
+                42.38072787126817
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94080522884586,
+                42.37758198646324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94430568436186,
+                42.37632205052018
               ]
             }
           }
@@ -2646,8 +5268,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2666,7 +5288,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6407.0,7796.0 5625.1,7796.0 5611.1,6882.7 470.2,6999.9 525.4,534.4 6287.8,612.5 6292.7,0.0 6407.0,0.0 6407.0,7796.0\" /></svg>"
+          "value": "<svg><polygon points=\"6407.0,7796.0 5623.1,7796.0 5610.4,6887.6 479.1,7002.4 536.8,551.5 6286.3,631.8 6291.6,0.0 6407.0,0.0 6407.0,7796.0\" /></svg>"
         }
       },
       "body": {
@@ -2695,8 +5317,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94439068874081,
-                42.37655638852813
+                -82.94440261318594,
+                42.37656106202838
               ]
             }
           },
@@ -2716,8 +5338,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94090709690506,
-                42.37785385820364
+                -82.94091192861774,
+                42.3778625474868
               ]
             }
           },
@@ -2737,8 +5359,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9387853170737,
-                42.37470086657123
+                -82.938783581691,
+                42.37470313623707
               ]
             }
           },
@@ -2758,8 +5380,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94226890890944,
-                42.373403396895725
+                -82.9422742662592,
+                42.37340165077865
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0049/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p49",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0049/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0049/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"622.4,6123.8 630.0,1670.7 6407.0,1685.1 6367.0,6111.1 622.4,6123.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0049/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94792890746028,
+                42.381814554090184
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94441162519959,
+                42.383083895529474
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94232098006839,
+                42.37992304460643
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94583826232908,
+                42.37865370316714
               ]
             }
           }
@@ -2784,8 +5544,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2804,7 +5564,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5628.0,1110.9 5477.7,7796.0 556.2,7796.0 677.9,1468.5 5628.0,1110.9\" /></svg>"
+          "value": "<svg><polygon points=\"575.6,6826.9 561.0,7796.0 -0.0,7796.0 -0.0,3076.0 647.7,3076.0 678.6,1470.3 5628.4,1112.6 5493.6,6928.5 575.6,6826.9\" /></svg>"
         }
       },
       "body": {
@@ -2833,8 +5593,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97964280450846,
-                42.36352121466878
+                -82.97964376144732,
+                42.36352176107322
               ]
             }
           },
@@ -2854,8 +5614,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97621773122046,
-                42.36490837702489
+                -82.97621844414947,
+                42.36490903988347
               ]
             }
           },
@@ -2875,8 +5635,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97394974375504,
-                42.36180770973187
+                -82.97395026628357,
+                42.361808151691854
               ]
             }
           },
@@ -2896,8 +5656,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97737481704304,
-                42.36042054737576
+                -82.97737558358142,
+                42.360420872881605
               ]
             }
           }
@@ -2922,8 +5682,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2942,7 +5702,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5412.2,903.0 5297.8,7418.0 4662.8,7396.4 4651.7,7796.0 -0.0,7796.0 0.0,0.0 573.3,0.0 558.6,918.6 5412.2,903.0\" /></svg>"
+          "value": "<svg><polygon points=\"5319.9,7391.5 4685.7,7381.0 4679.0,7796.0 -0.0,7796.0 -0.0,969.5 517.2,958.7 517.4,0.0 5363.6,0.0 5319.9,7391.5\" /></svg>"
         }
       },
       "body": {
@@ -2971,8 +5731,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97764983879796,
-                42.360790037301896
+                -82.97763368523704,
+                42.36082160321523
               ]
             }
           },
@@ -2992,8 +5752,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97417267867628,
-                42.36218755026897
+                -82.97411852754477,
+                42.362175986388294
               ]
             }
           },
@@ -3013,8 +5773,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97188786295924,
-                42.35903959890673
+                -82.97188844776754,
+                42.35901614984595
               ]
             }
           },
@@ -3034,8 +5794,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9753650230809,
-                42.357642085939666
+                -82.9754036054598,
+                42.357661766672884
               ]
             }
           }
@@ -3060,8 +5820,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3080,7 +5840,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5523.0,716.9 5547.3,7208.2 739.6,7171.3 701.4,1192.8 5523.0,716.9\" /></svg>"
+          "value": "<svg><polygon points=\"5513.9,648.5 5593.4,7188.4 769.3,7218.7 681.4,1195.4 5513.9,648.5\" /></svg>"
         }
       },
       "body": {
@@ -3109,8 +5869,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9770261480509,
-                42.36463875903789
+                -82.97700934657722,
+                42.36464664950926
               ]
             }
           },
@@ -3130,8 +5890,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97351869596672,
-                42.36596262151446
+                -82.97348918263494,
+                42.36592978989387
               ]
             }
           },
@@ -3151,8 +5911,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97135416808688,
-                42.36278742879405
+                -82.97137636435849,
+                42.36276551960314
               ]
             }
           },
@@ -3172,8 +5932,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97486162017105,
-                42.361463566317475
+                -82.97489652830077,
+                42.36148237921853
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p54",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"575.9,0.0 5497.1,0.0 5465.3,5628.1 6407.0,5622.2 6407.0,7796.0 -0.0,7796.0 -0.0,7335.7 647.9,7336.0 575.9,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97494218377173,
+                42.361755269635275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97147252548022,
+                42.36304008973582
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96935697901989,
+                42.35992116341716
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9728266373114,
+                42.35863634331662
               ]
             }
           }
@@ -3198,8 +6096,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3218,7 +6116,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5976.0,6916.2 5645.2,7796.0 36.7,7796.0 -0.0,919.2 6191.1,337.6 5976.0,6916.2\" /></svg>"
+          "value": "<svg><polygon points=\"6108.8,5262.6 1784.3,5224.4 1748.9,7796.0 36.7,7796.0 -0.0,918.5 6192.0,337.7 6108.8,5262.6\" /></svg>"
         }
       },
       "body": {
@@ -3247,8 +6145,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97405733398301,
-                42.36585674563094
+                -82.97405774463076,
+                42.36585618288981
               ]
             }
           },
@@ -3268,8 +6166,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97060239552778,
-                42.3671728866144
+                -82.97060289966937,
+                42.36717276240244
               ]
             }
           },
@@ -3289,8 +6187,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96845045022397,
-                42.36404529417621
+                -82.9684502373521,
+                42.364045254599816
               ]
             }
           },
@@ -3310,8 +6208,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9719053886792,
-                42.36272915319275
+                -82.97190508231348,
+                42.36272867508718
               ]
             }
           }
@@ -3336,8 +6234,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3356,7 +6254,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"24.2,2555.3 5694.4,2561.5 5633.2,7796.0 -0.0,7796.0 24.2,2555.3\" /></svg>"
+          "value": "<svg><polygon points=\"30.9,2552.0 1726.4,2543.0 1747.8,0.0 6030.3,11.3 5907.5,1649.2 5727.1,2136.8 5641.5,7796.0 -0.0,7796.0 30.9,2552.0\" /></svg>"
         }
       },
       "body": {
@@ -3385,8 +6283,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97260323407649,
-                42.36376921454666
+                -82.97260628916786,
+                42.363766568764795
               ]
             }
           },
@@ -3406,8 +6304,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96910670363806,
-                42.36508366312421
+                -82.969108029655,
+                42.36508222407976
               ]
             }
           },
@@ -3427,8 +6325,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96695761844936,
-                42.36191828251405
+                -82.96695697379667,
+                42.36191527475023
               ]
             }
           },
@@ -3448,8 +6346,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97045414888778,
-                42.360603833936494
+                -82.97045523330952,
+                42.36059961943527
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0057/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p57",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0057/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0057/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"358.9,6893.4 427.9,452.2 3126.0,174.1 6407.0,122.0 6407.0,7348.8 189.4,7379.1 358.9,6893.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0057/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97098771946544,
+                42.36709515464231
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96739310088432,
+                42.368373079715305
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96528883814977,
+                42.36514193137539
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9688834567309,
+                42.36386400630239
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0058/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p58",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0058/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0058/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7552.6 24.5,0.0 6386.9,0.0 6384.7,457.6 5633.5,453.9 5607.1,7552.0 -0.0,7552.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0058/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96890306993512,
+                42.3640697523986
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96539854346008,
+                42.36533123651357
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96332147271816,
+                42.36218088874918
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9668259991932,
+                42.36091940463421
               ]
             }
           }
@@ -3474,8 +6648,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3494,7 +6668,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1203.9,273.2 5290.0,307.8 6346.0,539.3 6346.0,7795.0 1051.6,7795.0 1203.9,273.2\" /></svg>"
+          "value": "<svg><polygon points=\"6346.0,7795.0 1034.8,7795.0 1205.6,264.1 4284.9,296.5 4311.7,0.0 6346.0,0.0 6346.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -3523,8 +6697,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96810750213932,
-                42.368181598631566
+                -82.96810393562235,
+                42.36817643376224
               ]
             }
           },
@@ -3544,8 +6718,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96457669451407,
-                42.369520842269104
+                -82.96458462040016,
+                42.36951939594088
               ]
             }
           },
@@ -3565,8 +6739,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96236478881882,
-                42.36629246446278
+                -82.96236659197288,
+                42.366301498827006
               ]
             }
           },
@@ -3586,8 +6760,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96589559644407,
-                42.36495322082524
+                -82.96588590719507,
+                42.364958536648366
               ]
             }
           }
@@ -3612,8 +6786,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3632,7 +6806,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"147.5,660.3 6264.7,517.7 6257.8,0.0 6346.0,0.0 6346.0,7795.0 -0.0,7795.0 -0.0,7636.6 106.8,7637.4 147.5,660.3\" /></svg>"
+          "value": "<svg><polygon points=\"254.7,496.2 6346.0,343.0 6346.0,7795.0 -0.0,7795.0 -0.0,7565.5 168.1,7567.0 254.7,496.2\" /></svg>"
         }
       },
       "body": {
@@ -3661,8 +6835,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96596174853681,
-                42.36523683807308
+                -82.96597474530805,
+                42.36514474505548
               ]
             }
           },
@@ -3682,8 +6856,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96246085788312,
-                42.36652154496398
+                -82.96250977646292,
+                42.366421033781094
               ]
             }
           },
@@ -3703,8 +6877,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96033913735464,
-                42.363320352883726
+                -82.96038875868035,
+                42.36327240638802
               ]
             }
           },
@@ -3724,8 +6898,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96384002800833,
-                42.36203564599282
+                -82.96385372752547,
+                42.36199611766241
               ]
             }
           }
@@ -3750,8 +6924,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3770,7 +6944,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5317.4,6889.6 -0.0,6936.5 -0.0,1188.8 5450.6,2846.9 5150.3,2859.4 5317.4,6889.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6959.6 -0.0,0.0 2266.0,0.0 2240.5,1764.3 6346.0,3082.3 6346.0,7795.0 5874.2,7795.0 5876.5,6975.8 -0.0,6959.6\" /></svg>"
         }
       },
       "body": {
@@ -3799,8 +6973,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96135057960718,
-                42.37026801633568
+                -82.9612942,
+                42.3701932
               ]
             }
           },
@@ -3820,8 +6994,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95776631558205,
-                42.371533204885814
+                -82.9578211,
+                42.371456
               ]
             }
           },
@@ -3841,8 +7015,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95567667377048,
-                42.368256021767415
+                -82.9557206,
+                42.3683027
               ]
             }
           },
@@ -3862,8 +7036,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9592609377956,
-                42.36699083321728
+                -82.9591937,
+                42.3670399
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p64",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,183.9 92.6,0.0 6346.0,0.0 6346.0,7327.2 -0.0,7326.1 -0.0,183.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95966668229147,
+                42.36728833792255
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95619828872711,
+                42.36854064980375
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95411539281645,
+                42.36539151959807
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95758378638081,
+                42.364139207716875
               ]
             }
           }
@@ -3888,8 +7200,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3908,7 +7220,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 369.7,6744.4 371.5,5943.1 569.8,5948.9 2124.2,1757.6 3758.7,1857.6 3765.6,1669.4 2193.7,1570.4 2536.6,645.9 6325.7,779.1 6346.0,1025.3 5880.6,1377.7 5705.8,6765.6 6346.0,6786.6 6346.0,7311.5 4110.0,7251.0 4092.3,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"4927.8,6804.1 293.5,6691.9 2123.6,1758.3 3757.0,1858.1 3763.9,1670.0 2193.0,1571.2 2582.2,521.7 6325.6,620.9 6346.0,1023.3 5877.4,1378.5 5685.9,7290.4 4913.9,7269.5 4927.8,6804.1\" /></svg>"
         }
       },
       "body": {
@@ -3937,8 +7249,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95342066613294,
-                42.37175841859036
+                -82.95341974873523,
+                42.371759171497644
               ]
             }
           },
@@ -3958,8 +7270,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9515988287815,
-                42.369182536879734
+                -82.95159687785038,
+                42.36918141771191
               ]
             }
           },
@@ -3979,8 +7291,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95585330944624,
-                42.36751680048297
+                -82.95585445054618,
+                42.36751473633806
               ]
             }
           },
@@ -4000,8 +7312,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95767514679768,
-                42.37009268219359
+                -82.95767732143104,
+                42.370092490123795
               ]
             }
           }
@@ -4009,13 +7321,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0066/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p69",
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p66",
       "metadata": [
         {
           "label": "streets",
@@ -4024,26 +7336,10 @@
         {
           "label": "intersections",
           "value": "0"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6346.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "988.3"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4052,21 +7348,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0066/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0066/info.json",
           "type": "ImageService2",
           "height": 7795,
           "width": 6346
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1331.2 457.4,946.0 441.9,760.7 425.6,767.6 424.5,-0.0 5675.2,-0.0 5633.8,7247.1 -0.0,7246.0 -0.0,1331.2\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0066/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -4091,8 +7387,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94892576586595,
-                42.37132372428493
+                -82.95174529217594,
+                42.36934401525509
               ]
             }
           },
@@ -4112,8 +7408,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94552190402759,
-                42.37262845186845
+                -82.95002333505887,
+                42.3667419909878
               ]
             }
           },
@@ -4122,7 +7418,7 @@
             "properties": {
               "resourceCoords": [
                 6346.0,
-                988.3
+                7795.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4133,8 +7429,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94524879642114,
-                42.37223404405281
+                -82.95435132302073,
+                42.365178609581356
               ]
             }
           },
@@ -4143,7 +7439,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                988.3
+                7795.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4154,8 +7450,592 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9486526582595,
-                42.37092931646929
+                -82.9560732801378,
+                42.367780633848646
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p67",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2645.3,-0.0 2751.1,-0.0 2749.9,416.1 6301.0,496.1 6298.0,678.1 4416.1,593.6 4425.2,7795.0 578.7,7795.0 2564.5,1949.1 2645.3,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94888496089665,
+                42.372360574059854
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94720011273877,
+                42.36981651553374
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95143190955075,
+                42.368286906743585
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95311675770863,
+                42.3708309652697
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0068/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p68",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0068/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0068/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1862.3,540.8 1865.5,360.6 -0.0,336.7 -0.0,0.0 5323.5,-0.0 5313.9,7022.2 -0.0,7017.8 -0.0,456.1 1862.3,540.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0068/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94778486838364,
+                42.37056434939039
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94608045504131,
+                42.36799426986065
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95035157667374,
+                42.36644546443738
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95205599001606,
+                42.36901554396712
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p69",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "681.5"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6346.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7113.5"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"634.6,2313.0 685.5,681.5 5678.3,681.5 5661.8,7575.1 986.6,7578.8 967.9,2311.5 634.6,2313.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                681.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94876100462076,
+                42.371040137362584
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                681.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94524119760321,
+                42.37230267683627
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94332423470523,
+                42.36938595078249
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94684404172278,
+                42.3681234113088
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p70",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "532.7"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6346.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7262.3"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"305.6,7570.7 312.2,532.7 5700.5,532.7 5874.3,7449.1 6346.0,7434.6 6346.0,7570.5 305.6,7570.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                532.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94577734554177,
+                42.372103704694645
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                532.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94233378998621,
+                42.373334371361324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9404263778447,
+                42.370421453012575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94386993340026,
+                42.3691907863459
               ]
             }
           }
@@ -4180,8 +8060,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4200,7 +8080,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,253.0 6346.0,182.3 6346.0,7795.0 6258.5,7337.7 -0.0,7259.7 -0.0,253.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,251.7 6346.0,175.1 6346.0,7795.0 6292.0,7490.9 6.5,7312.8 -0.0,251.7\" /></svg>"
         }
       },
       "body": {
@@ -4229,8 +8109,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94298675515208,
-                42.373641493629684
+                -82.94298542867729,
+                42.37364135798967
               ]
             }
           },
@@ -4250,8 +8130,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93951847425433,
-                42.37498321448969
+                -82.93951527954526,
+                42.374980713249556
               ]
             }
           },
@@ -4271,8 +8151,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93730229338914,
-                42.371812270672116
+                -82.9373030060485,
+                42.37180806136217
               ]
             }
           },
@@ -4292,8 +8172,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94077057428689,
-                42.37047054981211
+                -82.94077315518052,
+                42.37046870610228
               ]
             }
           }
@@ -4318,8 +8198,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4338,7 +8218,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6346.0,0.0 6346.0,7795.0 4774.8,7795.0 4781.4,7566.6 -0.0,7518.2 -0.0,-0.0 6346.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"4.5,488.8 -0.0,0.0 6346.0,0.0 6346.0,7795.0 4830.1,7795.0 4835.8,7454.4 -0.0,7486.6 -0.0,605.0 469.4,609.6 469.7,475.6 4.5,488.8\" /></svg>"
         }
       },
       "body": {
@@ -4367,8 +8247,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94093501264446,
-                42.37068373353894
+                -82.94090643967618,
+                42.37066636340961
               ]
             }
           },
@@ -4388,8 +8268,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93748015837312,
-                42.371979805705756
+                -82.93741884704414,
+                42.371920425508314
               ]
             }
           },
@@ -4409,8 +8289,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93533948425409,
-                42.36882097994382
+                -82.93533290564473,
+                42.36875406760743
               ]
             }
           },
@@ -4430,8 +8310,300 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93879433852541,
-                42.367524907776996
+                -82.93882049827677,
+                42.36750000550873
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p73 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3939.9"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6346.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3855.1"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3939.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97318370013778,
+                42.358826648685756
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                3939.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96958598434829,
+                42.36015888868578
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96849006554028,
+                42.358543122025004
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97208778132978,
+                42.35721088202498
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0075/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p75",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0075/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0075/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 305.9,0.0 305.1,248.6 5729.8,248.0 5731.7,477.6 6346.0,472.0 6346.0,7795.0 -0.0,7795.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0075/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96712457342781,
+                42.36105830896648
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9636445187996,
+                42.36231098423203
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96156119583883,
+                42.35915099738083
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96504125046704,
+                42.357898322115275
               ]
             }
           }
@@ -4456,8 +8628,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4505,8 +8677,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96412245803894,
-                42.362268539432286
+                -82.96402359854417,
+                42.36219769034296
               ]
             }
           },
@@ -4526,8 +8698,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96050625195366,
-                42.36364415962523
+                -82.96055862969905,
+                42.36347397906857
               ]
             }
           },
@@ -4547,8 +8719,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95823449239518,
-                42.360337369263
+                -82.95843761191648,
+                42.3603253516755
               ]
             }
           },
@@ -4568,8 +8740,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96185069848048,
-                42.358961749070055
+                -82.9619025807616,
+                42.359049062949886
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0079/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p79",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0079/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0079/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"527.5,7277.4 522.0,6943.0 35.5,6945.8 -0.0,-0.0 902.0,0.0 902.6,428.9 6037.9,423.9 6016.9,7292.9 4422.1,7294.2 4422.7,7795.0 528.2,7795.0 531.7,7522.3 1055.7,7517.4 1031.5,7270.3 527.5,7277.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0079/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9583222070388,
+                42.36432462528705
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95482302406165,
+                42.365583942079475
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95272860782399,
+                42.362406658608165
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95622779080114,
+                42.36114734181574
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0080/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p80",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0080/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0080/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4891.1,7295.2 475.1,7313.3 478.6,446.3 4887.9,429.6 4891.1,7295.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0080/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95526260977837,
+                42.36543770789252
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95175799393684,
+                42.36669073841232
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94967399335478,
+                42.36350858183493
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95317860919631,
+                42.36225555131512
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0081/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p81",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0081/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0081/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5538.6,7345.6 -0.0,7351.3 -0.0,451.0 4910.0,474.5 5010.2,5372.9 5441.9,6290.6 5538.6,7345.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0081/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95256847099526,
+                42.36641058278647
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94908226843813,
+                42.36765850144743
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9470067643198,
+                42.36449307221311
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95049296687692,
+                42.36324515355215
               ]
             }
           }
@@ -4594,8 +9180,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4614,7 +9200,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,370.6 5050.9,434.7 5048.7,1346.1 6335.0,1366.7 6335.0,7795.0 416.1,7795.0 413.8,6669.8 -0.0,5440.8 -0.0,370.6\" /></svg>"
+          "value": "<svg><polygon points=\"470.5,7795.0 412.9,6262.2 -0.0,5335.5 -0.0,427.6 6335.0,545.9 6335.0,1458.6 5140.6,1431.9 5059.8,7421.8 5863.6,7437.5 6335.0,7249.2 6335.0,7795.0 470.5,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -4643,8 +9229,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94977182138749,
-                42.367363819005554
+                -82.94986569157238,
+                42.367358562815745
               ]
             }
           },
@@ -4664,8 +9250,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9463417227413,
-                42.36863873891627
+                -82.94642209187634,
+                42.368658172197556
               ]
             }
           },
@@ -4685,8 +9271,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94423343707378,
-                42.36549842270537
+                -82.94425959135722,
+                42.36552501199147
               ]
             }
           },
@@ -4706,8 +9292,560 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94766353571995,
-                42.36422350279466
+                -82.94770319105326,
+                42.36422540260966
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0083/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p83",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0083/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0083/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5711.1,439.9 5668.0,7795.0 780.7,7795.0 782.0,7624.3 1271.3,7617.4 1264.0,7075.2 993.0,7227.3 -0.0,7264.5 -0.0,1312.6 1186.4,1322.3 1174.2,415.6 5711.1,439.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0083/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9470308985057,
+                42.368372190058196
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94353864872902,
+                42.36964448686029
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94141986568438,
+                42.36646965617864
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94491211546107,
+                42.365197359376545
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0084/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p84",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0084/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0084/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5854.1,7340.5 394.3,7354.8 392.8,492.2 5847.9,496.9 5854.1,7340.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0084/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94411246508614,
+                42.369463205058175
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94060855386377,
+                42.37072033213087
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93851497267218,
+                42.3675349921776
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94201888389455,
+                42.366277865104905
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0085/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p85",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0085/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0085/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4414.4,880.8 4416.6,376.2 6023.0,384.0 6003.6,4378.9 6335.0,4395.1 6335.0,7795.0 -0.0,7795.0 0.0,0.0 490.1,0.0 493.7,337.0 1001.4,332.7 1024.4,581.8 496.5,583.8 491.5,858.6 4414.4,880.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0085/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95643640267363,
+                42.36150053677965
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95297826405978,
+                42.36276303182916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95087595920185,
+                42.359618979896574
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9543340978157,
+                42.358356484847064
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0086/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p86",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0086/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0086/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"459.9,352.0 4889.0,340.2 4918.7,7795.0 824.8,7795.0 801.4,4383.7 467.9,4369.7 459.9,352.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0086/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95338855695049,
+                42.36259776108127
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9499383716773,
+                42.363835613812874
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94787708237651,
+                42.36069882145558
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95132726764969,
+                42.35946096872397
               ]
             }
           }
@@ -4732,8 +9870,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4752,7 +9890,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5562.6,368.4 5645.9,7795.0 1788.0,7795.0 -0.0,6598.2 -0.0,319.9 5562.6,368.4\" /></svg>"
+          "value": "<svg><polygon points=\"5646.8,7795.0 -0.0,7795.0 -0.0,311.4 5568.7,363.1 5646.8,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -4781,8 +9919,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95072067760735,
-                42.36354737073262
+                -82.95072022788396,
+                42.363543133328996
               ]
             }
           },
@@ -4802,8 +9940,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94724600620256,
-                42.36482263473086
+                -82.94724830918653,
+                42.36481925296082
               ]
             }
           },
@@ -4823,8 +9961,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94513727892583,
-                42.36164131918618
+                -82.94513816854732,
+                42.36164045549106
               ]
             }
           },
@@ -4844,8 +9982,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94861195033062,
-                42.36036605518794
+                -82.94861008724475,
+                42.36036433585924
               ]
             }
           }
@@ -4870,8 +10008,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4890,7 +10028,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5594.0,3459.0 5609.7,7113.4 1170.7,7097.4 1034.1,851.0 6335.0,790.5 6335.0,3460.1 5594.0,3459.0\" /></svg>"
+          "value": "<svg><polygon points=\"6335.0,754.7 6335.0,3447.1 5493.6,3448.8 5527.5,7795.0 1186.6,7795.0 1065.0,866.2 6335.0,754.7\" /></svg>"
         }
       },
       "body": {
@@ -4919,8 +10057,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9482295475654,
-                42.36444928676921
+                -82.94827854610621,
+                42.36446682491342
               ]
             }
           },
@@ -4940,8 +10078,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94476526331331,
-                42.365700365634844
+                -82.94473210275646,
+                42.36573610570161
               ]
             }
           },
@@ -4961,8 +10099,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94269649986563,
-                42.36252860286682
+                -82.9426184396275,
+                42.362511858840776
               ]
             }
           },
@@ -4982,8 +10120,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94616078411772,
-                42.361277524001174
+                -82.94616488297724,
+                42.36124257805259
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0089/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p89",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0089/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0089/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3456.9 829.1,3457.1 835.0,885.4 5755.8,862.1 5743.7,7090.0 -0.0,7178.2 -0.0,3456.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0089/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94517665600523,
+                42.36554821347749
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94170020951894,
+                42.366799642825164
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9396162281,
+                42.36363910228463
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94309267458628,
+                42.362387672936954
               ]
             }
           }
@@ -5008,8 +10284,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5028,7 +10304,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4107.8,7230.5 4112.1,6348.3 293.7,6344.5 294.6,6161.1 -0.0,6162.3 -0.0,-0.0 6131.3,0.0 6093.3,7218.7 4107.8,7230.5\" /></svg>"
+          "value": "<svg><polygon points=\"4109.1,7227.8 4114.5,6345.0 294.6,6336.7 295.8,6153.8 -0.0,6154.3 -0.0,-0.0 6141.8,0.0 6095.5,7218.3 4109.1,7227.8\" /></svg>"
         }
       },
       "body": {
@@ -5057,8 +10333,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9643760462885,
-                42.37805232320114
+                -82.96437762473573,
+                42.378046480411506
               ]
             }
           },
@@ -5078,8 +10354,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96090477522223,
-                42.37932457350158
+                -82.96090969561045,
+                42.37932123134894
               ]
             }
           },
@@ -5099,8 +10375,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95883709564447,
-                42.376202296317366
+                -82.95883795196224,
+                42.376201960112965
               ]
             }
           },
@@ -5120,8 +10396,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96230836671074,
-                42.37493004601693
+                -82.96230588108752,
+                42.37492720917553
               ]
             }
           }
@@ -5146,8 +10422,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5166,7 +10442,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5282.7,6991.6 -0.0,6965.6 16.3,370.3 5287.1,426.4 5282.7,6991.6\" /></svg>"
+          "value": "<svg><polygon points=\"5277.9,6972.6 -0.0,6950.1 13.0,374.1 5275.0,424.3 5277.9,6972.6\" /></svg>"
         }
       },
       "body": {
@@ -5195,8 +10471,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94202966851252,
-                42.366684399030795
+                -82.94202883183829,
+                42.36668699255772
               ]
             }
           },
@@ -5216,8 +10492,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9385404736935,
-                42.36797899204795
+                -82.93853186055337,
+                42.367980859652405
               ]
             }
           },
@@ -5237,8 +10513,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93639967885879,
-                42.364784537195355
+                -82.93639226617726,
+                42.364779285166385
               ]
             }
           },
@@ -5258,8 +10534,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9398888736778,
-                42.36348994417819
+                -82.93988923746218,
+                42.3634854180717
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0091/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p91",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0091/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0091/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,369.6 4999.2,368.0 4991.4,707.7 6335.0,716.0 6335.0,7121.2 -0.0,6993.2 -0.0,369.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0091/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93910090251295,
+                42.367740150824176
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9356199472729,
+                42.36901143881707
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93350281271519,
+                42.36584692317519
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93698376795524,
+                42.3645756351823
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0092/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p92",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0092/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0092/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1001.7,7795.0 1022.7,0.0 6335.0,0.0 6335.0,7100.9 4999.1,7097.6 4812.7,7795.0 1001.7,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0092/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93707933944263,
+                42.36488737748259
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93361243965586,
+                42.366147147205396
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93151454669778,
+                42.36299531961343
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93498144648456,
+                42.361735549890625
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0094/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p94",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0094/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0094/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5513.8,7795.0 -0.0,7795.0 -0.0,723.1 1142.6,710.9 1143.6,764.0 5534.9,763.6 5513.8,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0094/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94633816481269,
+                42.36156628118325
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94283231865884,
+                42.36282074272172
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94074341975535,
+                42.35963327271824
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94424926590919,
+                42.35837881117977
               ]
             }
           }
@@ -5284,8 +10974,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5304,7 +10994,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"148.0,7795.0 260.1,612.1 2228.3,642.2 2235.7,0.0 6009.1,0.0 5935.6,7795.0 148.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"148.7,7795.0 266.8,0.0 6009.4,0.0 5921.8,7795.0 148.7,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -5333,8 +11023,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94340199475218,
-                42.362582800355966
+                -82.94340290239583,
+                42.362583413095805
               ]
             }
           },
@@ -5354,8 +11044,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93995112927257,
-                42.36387382433891
+                -82.93995183811184,
+                42.363874492525575
               ]
             }
           },
@@ -5375,8 +11065,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93781637553055,
-                42.36071425507472
+                -82.93781699268652,
+                42.36071474123859
               ]
             }
           },
@@ -5396,8 +11086,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94126724101015,
-                42.35942323109178
+                -82.94126805697051,
+                42.35942366180882
               ]
             }
           }
@@ -5422,8 +11112,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5442,7 +11132,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 9.4,0.0 6335.0,0.0 6335.0,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 9.2,0.0 6335.0,0.0 6335.0,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -5471,8 +11161,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94014361067984,
-                42.363819960294414
+                -82.9401457168208,
+                42.36382345555356
               ]
             }
           },
@@ -5492,8 +11182,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93654725014106,
-                42.365137928114784
+                -82.9365516042638,
+                42.36513905762336
               ]
             }
           },
@@ -5513,8 +11203,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93436790215985,
-                42.361845208327544
+                -82.93437616820944,
+                42.36184839602078
               ]
             }
           },
@@ -5534,8 +11224,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93796426269863,
-                42.36052724050718
+                -82.93797028076644,
+                42.36053279395098
               ]
             }
           }
@@ -5560,8 +11250,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5580,7 +11270,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5301.3,2234.0 5312.9,7795.0 1751.0,7795.0 2025.8,2228.5 967.0,2226.7 965.1,986.1 6335.0,1033.9 6335.0,2235.7 5301.3,2234.0\" /></svg>"
+          "value": "<svg><polygon points=\"6335.0,1056.4 6335.0,2259.1 5311.9,2252.8 5298.6,7795.0 -0.0,7795.0 -0.0,977.4 6335.0,1056.4\" /></svg>"
         }
       },
       "body": {
@@ -5609,8 +11299,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94439787808149,
-                42.35881582534178
+                -82.9444086340562,
+                42.35880968771754
               ]
             }
           },
@@ -5630,8 +11320,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94095361814075,
-                42.360061027329124
+                -82.94097106962865,
+                42.36006669247059
               ]
             }
           },
@@ -5651,8 +11341,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93889476299407,
-                42.356907306423224
+                -82.93889269639764,
+                42.35691910686894
               ]
             }
           },
@@ -5672,4346 +11362,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94233902293479,
-                42.35566210443588
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0100/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p100",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0100/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0100/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"750.5,898.7 1046.6,898.0 1086.5,673.0 6335.0,677.1 6335.0,7795.0 703.1,7795.0 750.5,898.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0100/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1079.8,
-                1943.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.934067,
-                42.361428
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4835.2,
-                1943.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.932007,
-                42.362178
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0012/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p12",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0012/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0012/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"290.4,7022.8 241.5,0.0 5960.8,6.7 5985.0,6902.6 290.4,7022.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0012/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                248.0,
-                1047.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.954943,
-                42.381379
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5943.1,
-                1047.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.951794,
-                42.382489
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0013/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p13",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0013/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0013/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6065.3,6845.7 381.4,6932.1 414.2,0.0 6095.7,0.0 6065.3,6845.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0013/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2527.6,
-                1063.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.950617,
-                42.382904
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4231.3,
-                6871.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.948133,
-                42.38089
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0014/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p14",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0014/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0014/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"632.3,6773.2 637.5,0.0 6447.0,0.0 6418.2,6760.5 632.3,6773.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0014/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3983.4,
-                1023.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9468188,
-                42.3842515
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                611.9,
-                1023.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.948671,
-                42.383591
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0015/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p15",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0015/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0015/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,374.4 6172.4,348.1 6140.5,7072.4 188.5,7135.0 186.1,7795.0 -0.0,7795.0 -0.0,374.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0015/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2231.7,
-                6263.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.983225,
-                42.3650064
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4111.4,
-                352.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.983923,
-                42.367779
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0017/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p17",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0017/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0017/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5378.6,6857.4 452.9,6908.7 415.9,959.9 5465.9,998.8 5378.6,6857.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0017/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2503.6,
-                6891.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9799988,
-                42.3662885
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                415.9,
-                959.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.982806,
-                42.368223
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0018/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p18",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0018/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0018/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5666.2,6761.6 -0.0,6907.5 -0.0,1015.3 5751.8,1097.7 5666.2,6761.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0018/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3791.4,
-                6807.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9764248,
-                42.3677084
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3791.4,
-                1075.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9779908,
-                42.370004
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0019/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p19",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0019/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0019/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3859.4,1091.9 3862.0,0.0 4663.9,0.0 4688.9,2010.0 5634.5,1997.6 5780.1,5914.6 3845.9,5933.8 3844.2,6563.5 139.3,6719.4 145.4,1092.5 3859.4,1091.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0019/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3859.4,
-                1091.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.974881,
-                42.371125
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1839.7,
-                1091.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.975991,
-                42.370726
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0002/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p2",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0002/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0002/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5197.1,6514.9 303.4,6526.9 235.6,56.9 -0.0,-0.0 5198.7,0.0 5197.1,6514.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0002/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4599.3,
-                6503.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.980466,
-                42.369118
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4599.3,
-                627.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.982105,
-                42.371489
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0020/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p20",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0020/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0020/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,2013.3 5359.5,2142.3 5412.5,0.0 6447.0,0.0 6447.0,6405.7 -0.0,6396.3 -0.0,2013.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0020/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3847.4,
-                6395.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9702461,
-                42.3701576
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                331.9,
-                6395.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.972189,
-                42.369392
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0021/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p21",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0021/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0021/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4658.0,6733.6 4398.3,6155.0 1327.4,6153.1 1280.4,0.0 6447.0,0.0 6447.0,7795.0 5173.2,7795.0 5210.3,7005.2 4658.0,6733.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0021/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9712679860766,
-                42.37289948690457
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6447.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96778397834527,
-                42.374249559163125
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6447.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96557653007127,
-                42.37113469443429
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96906053780262,
-                42.369784622175736
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                567.9,
-                6143.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9692214,
-                42.3705636
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0026/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p26",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0026/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0026/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5817.1,6207.2 3052.1,6254.8 546.5,6515.5 489.4,612.7 5807.7,382.5 5817.1,6207.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0026/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3899.4,
-                467.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9702461,
-                42.3701576
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5815.1,
-                6207.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9676821,
-                42.3682039
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0003/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p3",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0003/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0003/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6748.1 -0.0,-0.0 5991.4,0.0 5838.3,6861.5 -0.0,6748.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0003/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1807.7,
-                6783.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.979141,
-                42.369594
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1807.7,
-                895.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.980779,
-                42.371965
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0033/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p33",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0033/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0033/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5192.3,0.0 5143.2,3651.5 5076.7,7204.2 1172.3,7110.4 1291.6,0.0 5192.3,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0033/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1231.8,
-                3651.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.959272,
-                42.374477
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5143.2,
-                3651.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9571296,
-                42.375274
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0037/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p37",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0037/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0037/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6009.8,6082.9 291.5,6166.7 308.2,1695.6 6034.8,1628.3 6009.8,6082.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0037/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2087.7,
-                6132.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.951182,
-                42.377505
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2087.7,
-                1680.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.952373,
-                42.379305
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0038/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p38",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0038/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0038/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"192.6,1719.5 5843.1,1640.0 5834.9,6077.8 167.8,6146.8 192.6,1719.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0038/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4023.4,
-                6092.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.946939,
-                42.379089
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5843.1,
-                1640.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.947135,
-                42.381262
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0004/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p4",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0004/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0004/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"72.6,0.0 4493.8,0.0 4576.8,5718.7 3775.7,5720.4 3775.4,6811.1 65.3,6819.7 72.6,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0004/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3775.4,
-                6811.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.974881,
-                42.371125
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3775.4,
-                919.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.976451,
-                42.373522
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0040/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p40",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0040/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0040/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1113.3,824.9 3071.5,792.0 3070.3,1726.1 4939.3,1710.7 4955.2,7278.7 1686.0,6195.5 1634.9,7796.0 1444.2,7796.0 1494.4,6131.8 -0.0,5663.7 1113.6,5728.2 1113.3,824.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0040/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3071.5,
-                6656.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.952765,
-                42.3706179
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3071.5,
-                792.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.954323,
-                42.372996
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0043/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p43",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0043/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0043/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"138.9,7796.0 272.0,410.0 6083.6,413.4 5943.3,7796.0 138.9,7796.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0043/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3947.4,
-                408.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.950191,
-                42.377873
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                272.0,
-                408.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.952156,
-                42.377136
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0047/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p47",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0047/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0047/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"633.4,7796.0 631.9,340.0 6407.0,321.3 6407.0,7796.0 633.4,7796.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0047/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4003.4,
-                340.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.944103,
-                42.380118
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                631.9,
-                340.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.945945,
-                42.379455
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0049/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p49",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0049/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0049/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"622.4,6123.8 630.0,1670.7 6407.0,1685.1 6367.0,6111.1 622.4,6123.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0049/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2303.6,
-                6124.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.945022,
-                42.379788
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3975.4,
-                1680.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.945296,
-                42.381921
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0005/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p5",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0005/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0005/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6447.0,0.0 6447.0,7795.0 -0.0,7795.0 -0.0,-0.0 6447.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0005/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97631460523121,
-                42.374058439520354
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6447.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97279983170063,
-                42.37536417952531
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6447.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97066486929253,
-                42.372221808743014
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97417964282312,
-                42.370916068738055
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                463.9,
-                975.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9757944,
-                42.373759
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p54",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"576.1,0.0 5497.1,0.0 5471.1,5620.5 6407.0,5614.8 6407.0,7796.0 -0.0,7796.0 -0.0,7335.7 647.9,7336.0 576.1,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2239.7,
-                7336.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9717386,
-                42.3592695
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                647.9,
-                7336.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9726006,
-                42.3589503
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0057/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p57",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0057/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0057/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"44.0,7796.0 358.9,6893.4 442.5,6047.4 427.9,452.2 3126.0,174.1 6407.0,122.0 6407.0,7796.0 44.0,7796.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0057/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3759.4,
-                5248.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.967462,
-                42.3656699
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2027.7,
-                276.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9697756,
-                42.3673852
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0058/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p58",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0058/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0058/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5607.1,7552.0 -0.0,7552.6 -0.0,426.4 5633.5,453.9 5607.1,7552.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0058/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                320.0,
-                7552.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.966716,
-                42.361081
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5607.1,
-                7552.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.963824,
-                42.362122
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p64",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,183.9 92.6,0.0 6346.0,0.0 6346.0,7327.2 -0.0,7326.1 -0.0,183.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1944.6,
-                7327.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.956646,
-                42.364712
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5177.6,
-                7327.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.954879,
-                42.36535
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0066/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p66",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0066/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0066/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5633.8,7247.1 660.0,7246.1 642.9,6721.7 -0.0,6717.9 -0.0,1331.2 919.1,557.2 1738.8,174.8 5675.3,135.2 5633.8,7247.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0066/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5633.8,
-                3395.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9521019,
-                42.366353
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5633.8,
-                6751.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.953965,
-                42.36568
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p67",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4205.1,905.4 4272.7,7795.0 631.4,7795.0 2482.3,2188.3 2519.0,-0.0 2639.3,-0.0 2643.4,752.6 6346.0,800.1 6346.0,969.0 4205.1,905.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1896.6,
-                3919.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.950434,
-                42.3708449
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2480.8,
-                2235.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9492906,
-                42.3709414
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0068/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p68",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0068/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0068/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5313.7,7159.1 1328.8,7195.8 257.3,7795.0 -0.0,7795.0 -0.0,976.0 5322.2,994.9 5313.7,7159.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0068/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94778556517903,
-                42.370563351342575
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6346.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94608162773825,
-                42.3679939894233
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6346.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95035155679997,
-                42.36644561645317
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95205549424075,
-                42.36901497837245
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5313.7,
-                7159.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9502804,
-                42.3669899
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p69",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "681.5"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6346.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7113.5"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"685.5,681.5 5678.2,681.5 5661.8,7575.1 -0.0,7581.7 -0.0,2317.2 516.4,2315.0 437.4,4555.2 614.3,4556.1 685.5,681.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3837.2,
-                7575.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.944775,
-                42.368977
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5661.8,
-                7575.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.943763,
-                42.36934
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p70",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "532.7"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6346.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7262.3"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"312.2,532.7 5699.7,532.7 5852.0,7567.0 305.6,7570.7 312.2,532.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2564.8,
-                7571.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.942537,
-                42.369778
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4761.5,
-                7571.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.941345,
-                42.370204
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p73 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "3939.9"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6346.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "3855.1"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2460.8,
-                4115.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9717386,
-                42.3592695
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                940.3,
-                4115.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9726006,
-                42.3589503
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0075/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p75",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0075/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0075/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"305.1,248.6 5790.0,248.0 5790.3,408.7 6346.0,404.4 6346.0,7795.0 -0.0,7795.0 -0.0,-0.0 305.1,0.0 305.1,248.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0075/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                624.2,
-                248.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.966716,
-                42.361081
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5897.9,
-                248.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.963824,
-                42.362122
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0079/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p79",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0079/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0079/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6037.9,423.9 6017.3,7795.0 -0.0,7795.0 -0.0,-0.0 902.0,0.0 902.6,428.9 6037.9,423.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0079/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2808.9,
-                7311.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.954809,
-                42.361902
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6037.9,
-                423.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.954879,
-                42.36535
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0080/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p80",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0080/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0080/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4891.0,7295.1 475.1,7313.4 478.6,446.4 4887.8,429.6 4891.0,7295.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0080/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2136.7,
-                7311.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.952128,
-                42.362875
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2136.7,
-                439.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.953965,
-                42.36568
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0081/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p81",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0081/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0081/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5441.9,6290.6 5538.6,7345.6 -0.0,7351.3 -0.0,451.0 5048.1,474.0 5095.2,5517.6 5441.9,6290.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0081/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                632.2,
-                7343.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.950266,
-                42.363553
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                632.2,
-                447.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9521019,
-                42.366353
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0083/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p83",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0083/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0083/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5671.3,7304.8 3932.5,7277.3 3824.0,7376.0 3819.2,7795.0 1283.5,7688.7 1268.4,1322.9 -0.0,1312.6 -0.0,410.1 5711.1,439.9 5671.3,7304.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0083/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3863.4,
-                7307.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.942915,
-                42.366172
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5711.1,
-                439.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.943763,
-                42.36934
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0084/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p84",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0084/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0084/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"394.3,7354.8 392.8,492.2 5830.2,496.9 5913.3,7340.3 394.3,7354.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0084/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2607.6,
-                7343.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.940698,
-                42.36698
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2607.6,
-                495.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.942537,
-                42.369778
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0086/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p86",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0086/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0086/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3722.0,4506.9 -0.0,4366.9 -0.0,861.4 461.0,860.8 459.9,352.0 4892.3,340.2 4906.1,4380.8 3846.0,4386.0 3722.0,4506.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0086/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2143.7,
-                352.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.952128,
-                42.362875
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                459.9,
-                352.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.953045,
-                42.362546
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0089/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p89",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0089/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0089/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1968.7,7795.0 -0.0,7795.0 -0.0,3456.9 738.8,3457.1 750.3,783.6 1340.7,776.0 3894.3,870.9 3897.1,449.0 4005.9,349.1 5756.8,368.5 5783.2,7055.7 1969.9,7149.8 1968.7,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0089/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3731.4,
-                5831.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94157,
-                42.363921
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3731.4,
-                3463.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.942203,
-                42.364881
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0091/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p91",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0091/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0091/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1188.6,6997.5 -0.0,6999.1 -0.0,369.6 4999.2,368.0 4993.8,596.6 6335.0,582.2 6255.1,7795.0 4966.9,7795.0 4969.5,7118.4 1241.0,7110.9 1188.6,6997.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0091/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1247.8,
-                5807.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.936838,
-                42.365633
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4999.2,
-                368.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.936254,
-                42.368594
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0092/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p92",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0092/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0092/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6121.9,677.4 6123.7,0.0 6335.0,0.0 6335.0,7795.0 1010.7,7795.0 1028.0,0.0 4828.5,0.0 6121.9,677.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0092/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1071.8,
-                2919.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.935707,
-                42.36392
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4823.2,
-                2919.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.933654,
-                42.364666
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p93",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"992.8,0.0 1638.2,380.7 2626.0,366.8 2677.0,311.7 3135.4,285.8 3191.1,1296.6 4002.1,1775.0 5689.2,1672.5 5877.2,5324.1 6335.0,5299.9 6335.0,7795.0 -0.0,7795.0 -0.0,0.0 992.8,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2667.6,
-                328.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9501374,
-                42.3615651
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4107.4,
-                328.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.948284,
-                42.3621447
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0094/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p94",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0094/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0094/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1150.3,7795.0 1142.8,0.0 5536.8,0.0 5513.8,7795.0 1150.3,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0094/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3223.5,
-                2911.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.943774,
-                42.361014
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5511.1,
-                2911.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.942508,
-                42.361467
+                -82.9423302608252,
+                42.35566210211589
               ]
             }
           }
@@ -10029,15 +11381,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10056,34 +11408,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5910.9,888.5 5911.1,2175.7 5788.8,2175.7 5785.5,7795.0 -0.0,7795.0 -0.0,2178.7 1031.7,2176.9 1034.2,972.1 5910.9,888.5\" /></svg>"
+          "value": "<svg><polygon points=\"6335.0,2173.8 6335.0,7795.0 -0.0,7795.0 -0.0,2178.7 1021.4,2176.9 1018.5,970.9 5910.9,887.0 5911.1,2175.7 6335.0,2173.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0098/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                96.0,
-                2175.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.940874,
-                42.358974
+                -82.94150208511766,
+                42.359832425170005
               ]
             }
           },
@@ -10091,20 +11446,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5911.1,
-                2175.7
+                6335.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.937701,
-                42.360111
+                -82.9380453918577,
+                42.36107108266658
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93598278028622,
+                42.35792834629236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93943947354619,
+                42.35668968879579
               ]
             }
           }
@@ -10122,15 +11519,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:52:43Z",
-      "modified": "2026-08-07T15:52:43Z",
+      "created": "2026-08-15T01:08:00Z",
+      "modified": "2026-08-15T01:08:00Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10149,34 +11546,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6335.0,7749.3 -0.0,7795.0 -0.0,1991.9 120.0,1991.7 133.8,985.7 6335.0,925.7 6335.0,7749.3\" /></svg>"
+          "value": "<svg><polygon points=\"84.6,1981.0 99.3,968.1 6335.0,973.6 6335.0,2010.8 84.6,1981.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0099/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                120.0,
-                1991.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.937701,
-                42.360111
+                -82.93829061270033,
+                42.36091282193115
               ]
             }
           },
@@ -10184,20 +11584,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                120.0,
-                3855.5
+                6335.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.937199,
-                42.359345
+                -82.93477063696425,
+                42.36220415314657
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93263543355151,
+                42.35898121932487
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9361554092876,
+                42.35768988810945
               ]
             }
           }

--- a/gallery/fargo_nd_1958.iiif.json
+++ b/gallery/fargo_nd_1958.iiif.json
@@ -24,8 +24,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6351.4,6415.3 1455.2,7407.6 280.3,2185.6 -0.0,637.6 -0.0,-0.0 6337.7,0.0 6333.9,379.1 6660.0,371.6 6660.0,4785.6 6321.2,4785.4 6351.4,6415.3\" /></svg>"
+          "value": "<svg><polygon points=\"6307.4,4781.9 6353.0,6983.9 4147.8,7062.5 3243.2,7258.7 1500.4,7653.7 259.8,2194.6 -0.0,765.5 0.0,0.0 6313.6,0.0 6310.6,374.6 6660.0,365.9 6660.0,4781.2 6307.4,4781.9\" /></svg>"
         }
       },
       "body": {
@@ -73,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.79389176203452,
-                46.88309935888797
+                -96.79387358975711,
+                46.883100952213
               ]
             }
           },
@@ -94,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78946638297528,
-                46.88242332427808
+                -96.78945117929949,
+                46.88241847503555
               ]
             }
           },
@@ -115,8 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.79065672916639,
-                46.87873133893401
+                -96.79065286976241,
+                46.87872896738856
               ]
             }
           },
@@ -136,8 +136,730 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.79508210822563,
-                46.87940737354389
+                -96.79507528022003,
+                46.87941144456601
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0010/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p10 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0010/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0010/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4018.9,8070.0 -0.0,8070.0 -0.0,-0.0 5105.4,0.0 5514.5,2951.8 6660.0,2808.0 6660.0,7060.4 6092.0,7134.5 5841.6,5312.1 3702.3,5570.2 4018.9,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0010/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7895386455514,
+                46.88096363596044
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7871710812043,
+                46.88076069780815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7875308897732,
+                46.87879910961213
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78989845412029,
+                46.87900204776442
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0011/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p11",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0011/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0011/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3308.1,7172.6 3257.0,0.0 6563.7,0.0 6660.0,4963.8 5514.8,4976.6 5532.0,7178.2 6660.0,7181.0 6660.0,8070.0 3849.1,8070.0 3851.3,7174.0 3308.1,7172.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0011/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78687124663334,
+                46.87929165623356
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.782310216295,
+                46.87927562342215
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78233864240839,
+                46.87549669201345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78689967274673,
+                46.87551272482486
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0012__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p12 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0012__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0012/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1499.4,4959.9 1608.6,1524.7 4825.0,1709.9 4923.5,0.0 6660.0,0.0 6660.0,7096.6 2556.0,6963.3 2556.0,7206.2 2173.2,7193.2 2144.7,8070.0 1401.1,8053.0 1429.2,7167.7 306.1,7129.3 358.7,4936.4 1499.4,4959.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0012__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78344881925078,
+                46.87926290509663
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.77887225731097,
+                46.87934622054808
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.77872453680737,
+                46.87555448565598
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78330109874719,
+                46.875471170204534
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0012__3/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p12 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "4141.6"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2518.4"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "4408.5"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0012__3/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0012/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,8070 0,0 6660,0 6660,8070 0,8070\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0012__3/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4141.6,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78432555880735,
+                46.86911214958591
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78431554895151,
+                46.86852823116236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                4408.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7857990723679,
+                46.868516176149285
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4141.6,
+                4408.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78580908222374,
+                46.86910009457284
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0013/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p13",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0013/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0013/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5497.3,478.5 5569.6,7432.8 1072.7,7386.4 1149.1,2980.4 -0.0,2966.3 -0.0,818.3 5497.3,478.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0013/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7977908564436,
+                46.87636668755179
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7932183166494,
+                46.87613088760464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79363637161715,
+                46.87234226228995
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79820891141135,
+                46.872578062237096
               ]
             }
           }
@@ -162,8 +884,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -182,7 +904,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5508.5,7443.4 1029.1,7387.8 1038.1,6880.0 -0.0,6871.9 -0.0,515.1 4229.4,227.2 4262.7,0.0 5540.7,137.9 5508.5,7443.4\" /></svg>"
+          "value": "<svg><polygon points=\"5547.3,146.0 5505.4,7445.7 1029.6,7384.2 935.5,465.5 5547.3,146.0\" /></svg>"
         }
       },
       "body": {
@@ -211,8 +933,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.79464953785224,
-                46.87620112102849
+                -96.79465707845773,
+                46.87620191867945
               ]
             }
           },
@@ -232,8 +954,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.79009087016334,
-                46.875948672497564
+                -96.79009435258547,
+                46.875953439644796
               ]
             }
           },
@@ -253,8 +975,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.79053531920982,
-                46.87214500406876
+                -96.79053181312294,
+                46.87214638514247
               ]
             }
           },
@@ -274,8 +996,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.79509398689872,
-                46.872397452599685
+                -96.7950945389952,
+                46.872394864177124
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0015/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p15",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0015/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0015/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3105.4,7460.3 1056.0,7458.2 1090.2,452.1 2369.6,371.3 2288.2,3235.5 2638.1,3239.0 2918.1,3241.8 3142.1,3244.0 3131.7,5338.8 5365.6,5352.2 5380.2,3548.7 6660.0,3616.8 6660.0,8070.0 3113.7,8070.0 3105.4,7460.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0015/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7916224528927,
+                46.876190848532374
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78683517217769,
+                46.87593110316209
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78729569972711,
+                46.87196471747416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79208298044212,
+                46.87222446284444
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0016/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p16",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0016/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0016/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,4999.6 2084.6,4981.5 2110.2,2763.5 6660.0,2761.8 6660.0,4999.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0016/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78808476128616,
+                46.87572313118243
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78810250737943,
+                46.87888061345386
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78250430337216,
+                46.87889531655038
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78248655727889,
+                46.87573783427895
               ]
             }
           }
@@ -300,8 +1298,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +1318,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4144.1 -0.0,2928.3 1669.1,1393.9 1592.7,504.4 2744.5,405.3 3185.4,0.0 5380.8,0.0 5409.2,175.8 900.2,4138.9 -0.0,4144.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,2785.9 1720.5,2727.5 1671.9,1295.5 3048.7,1305.7 5150.1,1162.2 5352.9,6834.7 6660.0,6788.0 6660.0,8070.0 -0.0,8070.0\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +1347,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78534287573949,
-                46.87623874605258
+                -96.7853952,
+                46.8761562
               ]
             }
           },
@@ -370,8 +1368,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78067165393537,
-                46.87593726620715
+                -96.7807375,
+                46.8760237
               ]
             }
           },
@@ -391,8 +1389,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7812024248381,
-                46.87203968192723
+                -96.78097240000001,
+                46.8721647
               ]
             }
           },
@@ -412,3875 +1410,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78587364664222,
-                46.87234116177265
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0020/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p20 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0020/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0020/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7819.3 -0.0,-0.0 6660.0,0.0 6660.0,5109.8 5992.9,5065.5 5821.3,7832.0 5102.6,7789.5 5084.0,8070.0 1864.8,8070.0 1859.8,7801.7 -0.0,7819.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0020/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80147721838685,
-                46.87558537439417
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79686325925425,
-                46.875516090086705
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79698523670571,
-                46.87166624799233
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.8015991958383,
-                46.8717355322998
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0021/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p21",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0021/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0021/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,2802.8 726.6,2797.7 714.6,0.0 5224.5,0.0 5219.5,508.0 6660.0,513.4 6660.0,7216.5 2896.9,7225.8 2916.7,6397.8 -0.0,6624.6 -0.0,2802.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0021/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7978906396948,
-                46.873136184774864
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79333622150072,
-                46.87285933492742
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79382360259991,
-                46.86905899574562
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79837802079399,
-                46.86933584559306
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0025/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p25",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0025/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0025/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,8070.0 -0.0,8070.0 0.0,-0.0 6204.9,-0.0 6203.6,205.2 5980.7,203.9 5706.0,202.4 5697.5,7941.6 6660.0,7942.7 6660.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0025/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80384748380418,
-                46.87581286010732
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80385686279412,
-                46.872734859219854
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80927586351673,
-                46.872742684852376
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80926648452679,
-                46.87582068573984
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0026/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p26",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0026/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0026/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5829.3,1592.1 5821.8,7980.7 6660.0,7981.6 6660.0,8070.0 -0.0,8070.0 -0.0,322.9 498.1,325.1 499.0,144.6 499.7,-0.0 2488.9,-0.0 2460.6,1591.6 2798.8,1591.6 2802.6,338.7 5146.1,355.0 5146.0,1592.0 5829.3,1592.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0026/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80377483126674,
-                46.87317550142961
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80378906904906,
-                46.87010047881275
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80920255740672,
-                46.87011235910993
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.8091883196244,
-                46.87318738172679
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0027/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p27",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0027/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0027/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,646.3 1550.4,653.0 1543.2,1845.1 3552.1,1843.1 3650.1,4049.5 6660.0,4059.3 6660.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0027/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80358365257827,
-                46.87048253744157
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80360364968044,
-                46.867325732281856
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80916082952517,
-                46.86734241912714
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.809140832423,
-                46.87049922428686
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0028/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p28",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0028/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0028/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,8070.0 3147.7,8070.0 3143.7,7705.1 123.0,7729.0 122.8,8070.0 -0.0,8070.0 -0.0,5515.9 1110.1,5502.4 1097.4,4460.3 1754.9,4458.6 1746.7,1490.6 4167.5,1494.0 4150.5,109.1 6165.8,94.7 6260.7,6418.8 6660.0,6412.8 6660.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0028/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80107921646913,
-                46.86876219235551
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80115017387617,
-                46.86561698271364
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80668676837915,
-                46.865676195904676
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80661581097213,
-                46.86882140554655
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0029/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p29",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0029/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0029/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7130.2 1411.4,7099.6 1392.3,4886.5 -0.0,4905.5 -0.0,2473.0 1382.5,2467.3 1376.2,804.9 1674.7,799.6 1671.5,0.0 5276.4,0.0 5281.0,706.4 5542.2,696.4 5549.3,2581.6 6660.0,2643.8 6660.0,8070.0 -0.0,8070.0 -0.0,7130.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0029/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.8020919014274,
-                46.869110393297305
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79754720544118,
-                46.869057387546086
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79764051338935,
-                46.865264909815416
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80218520937558,
-                46.865317915566635
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0031/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p31",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0031/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0031/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1376.1,4705.9 257.9,4636.0 263.2,2737.5 -0.0,2745.8 -0.0,-0.0 3238.3,0.0 3153.3,834.6 6075.4,1053.8 6075.3,8070.0 1354.2,8070.0 1376.1,4705.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0031/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79847695585687,
-                46.87001785233322
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79396370299459,
-                46.86998539096588
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7940208465859,
-                46.866219196051794
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79853409944818,
-                46.866251657419134
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0032/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p32",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0032/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0032/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6125.8,8070.0 -0.0,8070.0 -0.0,903.6 897.2,977.4 979.2,0.0 1826.7,0.0 1744.3,1045.8 6660.0,1492.8 6660.0,2667.4 6258.1,2675.4 6267.2,5513.4 6125.8,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0032/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7943647151384,
-                46.86990945376219
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78994443706323,
-                46.86989627463915
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78996763691156,
-                46.866207647082966
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79438791498673,
-                46.86622082620601
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0041/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p41",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0041/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0041/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,4971.4 6660.0,7118.3 5844.6,7119.1 5846.4,8041.2 243.2,8070.0 240.3,7156.5 -0.0,7156.2 -0.0,-0.0 5831.4,0.0 5836.8,2882.0 2137.5,2887.7 2141.1,4690.6 2795.7,4700.5 3163.7,4978.6 6660.0,4971.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0041/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79861486326489,
-                46.86096380651295
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79412003366392,
-                46.860950170683225
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7941440335381,
-                46.857198716173414
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79863886313908,
-                46.85721235200314
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0042/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p42",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0042/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0042/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,-0.0 1848.0,0.0 6262.3,1494.1 6660.0,7152.8 6660.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0042/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79467921924386,
-                46.86095909701437
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79019175057604,
-                46.86095122425706
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79020560710087,
-                46.857205913850855
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79469307576869,
-                46.85721378660818
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0044/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p44",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0044/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0044/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,-0.0 6378.4,0.0 6377.0,188.6 4961.0,196.0 4945.5,1138.5 6660.0,1166.6 6660.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0044/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80554967969259,
-                46.86585266647079
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80101827483652,
-                46.86585100286849
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80102120312816,
-                46.86206934791689
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80555260798423,
-                46.8620710115192
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0046/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p46",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0046/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0046/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6370.1,7158.1 295.4,7132.4 296.8,6768.4 -0.0,6769.8 -0.0,-0.0 6415.6,0.0 6352.9,1651.8 6370.1,7158.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0046/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79842304796252,
-                46.88285868971082
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79381511237922,
-                46.882857848967575
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7938165927393,
-                46.87901355786308
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79842452832261,
-                46.87901439860633
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0047/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p47",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0047/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0047/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2075.4,8070.0 767.3,6352.3 127.0,913.3 131.4,0.0 6660.0,0.0 6660.0,8070.0 2075.4,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0047/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79821148268049,
-                46.889005977830756
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79368967419894,
-                46.88899538191459
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79370833348636,
-                46.8852234011337
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7982301419679,
-                46.885233997049866
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0049/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p49",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0049/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0049/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5443.5,12.1 5413.1,6892.8 405.7,7022.4 405.7,7023.3 -0.0,7022.7 -0.0,2604.0 581.2,2751.4 1503.7,2751.1 1518.8,1479.6 4264.2,1478.1 4256.1,632.8 535.2,638.4 354.1,571.1 362.3,-0.0 5443.5,12.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0049/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78901332533307,
-                46.8905461579063
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78903271266972,
-                46.88744451623389
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79449483206315,
-                46.88746068818553
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7944754447265,
-                46.890562329857936
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0051/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p51",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0051/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0051/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,1408.8 6660.0,2428.9 5956.6,6589.9 4130.1,8070.0 -0.0,8070.0 -0.0,2388.5 -0.0,1078.2 230.0,-0.0 2033.3,-0.0 4120.0,-0.0 6660.0,194.1 6660.0,1408.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0051/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78456441131611,
-                46.890468778481264
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78458132820751,
-                46.88737328432022
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79003263404365,
-                46.887387395517074
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79001571715226,
-                46.89048288967812
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0052/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p52",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0052/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0052/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2004.5,6646.0 1994.6,7222.2 -0.0,7207.0 -0.0,2466.1 756.5,2474.1 788.0,256.8 -0.0,248.9 -0.0,-0.0 5676.5,-0.0 5627.8,4802.0 6533.5,4797.1 6530.7,7254.0 5860.4,7257.0 5870.7,6720.5 2004.5,6646.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0052/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78454320318085,
-                46.88774400249372
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78449585168268,
-                46.88462423755788
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78998958542644,
-                46.88458473712657
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79003693692462,
-                46.88770450206241
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0053/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p53",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0053/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0053/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6257.9,1704.8 6419.0,5620.9 6013.4,7792.3 5489.6,7670.7 5403.7,8070.0 252.5,8070.0 259.0,7351.5 933.1,7341.6 910.9,4870.4 -0.0,4884.6 -0.0,0.0 5743.2,-0.0 5763.9,1705.9 6257.9,1704.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0053/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7844660971553,
-                46.885084936109926
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7844647160829,
-                46.88198297396388
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78992684042599,
-                46.881981821824
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78992822149841,
-                46.885083783970046
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0055/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p55",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0055/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0055/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,-0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0055/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.82290057703557,
-                46.88520710640938
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.81857124179514,
-                46.88527084718513
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.81845899744086,
-                46.881659344821536
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.82278833268127,
-                46.881595604045785
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0056/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p56 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0056/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0056/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3959.9,0.0 6660.0,2560.2 6660.0,4639.7 6046.2,5518.1 6660.0,5816.7 6660.0,8070.0 1795.3,8070.0 1941.7,5505.9 -0.0,5487.6 0.0,0.0 3959.9,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0056/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78127564626637,
-                46.884724033238214
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7768069914434,
-                46.8847709134392
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.77672444292531,
-                46.881042956896074
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.78119309774829,
-                46.88099607669509
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0006/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p6",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0006/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0006/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6373.9,0.0 6286.0,8070.0 -0.0,8070.0 -0.0,301.4 2399.5,327.3 2401.2,0.0 6373.9,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0006/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80257964279106,
-                46.87962124568789
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79802317118668,
-                46.879635003504546
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79799894820377,
-                46.875833421084195
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80255541980814,
-                46.87581966326754
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0065/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p65",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0065/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0065/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,-0.0 6660.0,8070.0 -0.0,8070.0 0.0,0.0 6660.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0065/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.81967581505236,
-                46.87746411347943
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.81969879282397,
-                46.87134967648969
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.83046363736098,
-                46.871368848624236
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.83044065958937,
-                46.87748328561397
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0067/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p67",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0067/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0067/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,-0.0 6660.0,6725.7 5044.4,6733.6 5044.2,6686.4 4876.8,6734.4 3356.0,6741.7 3362.4,8070.0 -0.0,8070.0 -0.0,5612.3 453.1,5609.1 448.5,4869.7 -0.0,4872.5 -0.0,0.0 6660.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0067/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.81064629938076,
-                46.880500163360345
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.81071225764177,
-                46.874383844561486
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.8214810264503,
-                46.87443887552358
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.8214150681893,
-                46.88055519432245
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0069/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p69 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0069/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0069/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4278.2,8070.0 -0.0,8070.0 0.0,-0.0 4920.9,0.0 4921.3,212.6 5214.2,213.4 6110.6,185.6 6113.2,0.0 6660.0,0.0 6660.0,7472.2 6571.6,7473.5 6574.6,7787.3 4274.2,7796.0 4278.2,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0069/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80557230227137,
-                46.88333131258956
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80081933413328,
-                46.88329792728529
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80087811859453,
-                46.87933266839444
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.80563108673262,
-                46.87936605369871
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0007/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p7 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0007/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0007/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6510.7,7560.8 5586.9,7557.9 5556.9,8070.0 -0.0,8070.0 -0.0,7946.7 403.7,7936.1 287.0,290.6 6383.0,184.8 6510.7,7560.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0007/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79841339031196,
-                46.879601850671214
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79382462717939,
-                46.87953278999968
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79394622008812,
-                46.87570426014689
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79853498322069,
-                46.875773320818425
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0008/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p8",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0008/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0008/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1103.0,7543.7 998.6,0.0 5884.4,0.0 5334.2,2689.3 4709.0,2574.3 4681.4,4990.1 4892.9,5028.7 4695.9,5965.8 4690.8,7307.4 4417.5,7290.4 4370.1,7515.6 1103.0,7543.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0008/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79471238088026,
-                46.87957150273571
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79007803645628,
-                46.87951285156078
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79018130158808,
-                46.87564628787061
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.79481564601207,
-                46.875704939045534
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0010/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p10 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0010/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0010/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4018.9,8070.0 -0.0,8070.0 0.0,0.0 5105.4,0.0 5514.5,2951.8 6660.0,2808.0 6660.0,6326.7 5992.1,6407.7 5841.6,5312.1 3702.3,5570.3 4018.9,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0010/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3408.0,
-                3243.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7884718,
-                46.8800717
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6092.0,
-                7134.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7876911,
-                46.8790438
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0011/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p11",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0011/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0011/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3269.7,7178.2 3227.5,2649.1 910.4,2658.1 914.4,398.6 3213.4,416.8 3202.2,0.0 6565.0,0.0 6660.0,1490.4 6660.0,6890.6 5528.0,6792.5 5532.0,7178.2 3269.7,7178.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0011/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5532.0,
-                7178.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.783108,
-                46.875917
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1000.0,
-                7178.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.786159,
-                46.875933
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0015/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Fargo, N.D. | 1958 p15",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0015/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0015/info.json",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1056.0,7458.2 1090.2,452.1 2369.3,371.3 2287.9,3235.5 2638.2,3239.0 2918.2,3241.8 3142.2,3244.0 3105.5,7460.3 1056.0,7458.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0015/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1068.0,
-                3223.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.7910387,
-                46.874565
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1056.0,
-                7458.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.791289,
-                46.872484
+                -96.7856301,
+                46.8722972
               ]
             }
           }
@@ -4298,15 +1429,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4325,7 +1456,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"448.0,283.9 444.2,22.4 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,257.5 448.0,283.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,283.2 448.0,283.9 427.5,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,283.2\" /></svg>"
         }
       },
       "body": {
@@ -4354,8 +1485,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78187812958338,
-                46.87603146957798
+                -96.7818227953147,
+                46.87602414268289
               ]
             }
           },
@@ -4375,8 +1506,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.77730577049019,
-                46.876192772538666
+                -96.77790897800702,
+                46.87600848883674
               ]
             }
           },
@@ -4396,8 +1527,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7770198545025,
-                46.87240348050387
+                -96.77793673204894,
+                46.872765770564676
               ]
             }
           },
@@ -4417,8 +1548,83 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78159221359569,
-                46.872242177543185
+                -96.78185054935662,
+                46.872781424410825
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0019/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p19",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0019/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0019/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7674.3 -0.0,5400.4 1228.0,5402.7 1227.8,4906.3 -0.0,4910.6 -0.0,3141.0 1213.0,3139.5 1242.1,322.2 -0.0,221.9 0.0,0.0 4848.0,0.0 4746.1,7702.3 -0.0,7674.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0019/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80480594186263,
+                46.875483809165175
               ]
             }
           },
@@ -4426,20 +1632,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                448.0,
-                283.9
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7815605,
-                46.875909
+                -96.80023908471978,
+                46.8754584377366
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80028406816574,
+                46.87167467866989
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80485092530859,
+                46.87170005009847
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0020/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p20 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0020/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0020/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"659.7,7809.5 -0.0,7814.5 -0.0,-0.0 5185.7,0.0 5122.1,1169.1 6260.7,1243.6 5816.1,7827.5 2430.1,7778.2 2434.2,8070.0 662.7,8070.0 659.7,7809.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0020/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80147783967766,
+                46.87558471967741
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7968609611441,
+                46.8755163625566
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79698130625096,
+                46.8716640845428
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80159818478451,
+                46.87173244166361
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0021/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p21",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0021/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0021/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2851.8,7282.3 2892.6,6425.3 -0.0,6583.4 -0.0,2736.1 778.6,2749.9 816.0,447.9 5900.2,566.9 5851.1,2830.9 6660.0,2851.5 6660.0,7367.9 2851.8,7282.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0021/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79797402962949,
+                46.87309416149872
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79343182464505,
+                46.87289604830638
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79378304282501,
+                46.869132331088856
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79832524780944,
+                46.869330444281196
               ]
             }
           }
@@ -4457,15 +1981,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4484,34 +2008,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1722.6,6212.7 891.8,6321.9 903.9,425.4 6188.0,439.9 6191.5,600.2 6660.0,602.9 6581.7,7343.7 1725.9,7293.6 1722.6,6212.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,2716.8 -0.0,422.9 6188.0,439.9 6200.9,1091.3 6660.0,1088.5 6660.0,8065.0 61.4,8070.0 -0.0,7292.1 918.9,7293.5 819.6,2719.8 -0.0,2716.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0022/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3964.0,
-                7302.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.791706,
-                46.869336
+                -96.79395034515935,
+                46.87284866065667
               ]
             }
           },
@@ -4519,20 +2046,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6188.0,
-                439.9
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.789816,
-                46.872403
+                -96.78947339446152,
+                46.87258664184293
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78993790400654,
+                46.86887698281494
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79441485470436,
+                46.86913900162868
               ]
             }
           }
@@ -4550,15 +2119,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4577,34 +2146,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 4777.3,0.0 6660.0,401.5 6660.0,6307.9 1048.6,8070.0 -0.0,8070.0 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,3316.1 -0.0,327.7 -0.0,0.0 4719.7,384.6 6660.0,686.1 6660.0,2871.5 6660.0,4923.5 6660.0,5868.0 6660.0,6310.4 5420.3,7097.8 1641.7,8070.0 -0.0,8070.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0023/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5428.0,
-                2655.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.801152,
-                46.870795
+                -96.80485459610476,
+                46.87203858067159
               ]
             }
           },
@@ -4612,20 +2184,890 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5428.0,
-                7102.2
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.8011621,
-                46.8687212
+                -96.80030807706133,
+                46.872033634713944
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80031684558037,
+                46.86826644920605
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.8048633646238,
+                46.868271395163696
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0024/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p24",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0024/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0024/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1920.9,6412.2 1923.8,5030.4 -0.0,5025.8 -0.0,504.0 724.0,516.1 701.0,2767.9 1928.5,2775.1 1932.6,808.4 2513.6,821.3 2516.0,523.9 5166.6,586.4 4920.3,4416.1 4825.5,4415.2 4827.4,5071.3 4575.7,5057.7 4562.4,6447.6 1920.9,6412.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0024/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80163320264151,
+                46.87209165315115
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79707014116347,
+                46.87209321213269
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7970673773278,
+                46.86831227963449
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80163043880584,
+                46.86831072065295
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0025/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p25",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0025/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0025/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 0.0,0.0 710.6,-0.0 703.3,1430.4 928.6,1431.6 1036.9,162.9 3896.7,207.5 3892.0,1446.9 5688.4,1456.3 5690.4,201.6 6194.3,204.0 6174.6,4474.8 6660.0,4476.2 6660.0,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0025/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.8038445969924,
+                46.87580668279016
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80385801101653,
+                46.87273060863328
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80927361960154,
+                46.87274180101373
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80926020557742,
+                46.87581787517061
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0026/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p26",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0026/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0026/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5793.9,7959.8 6660.0,7961.4 6660.0,8070.0 978.5,8070.0 973.0,4597.5 489.3,4596.9 498.4,1591.2 2802.1,1608.7 2801.9,-0.0 5808.8,-0.0 5808.1,367.9 5132.6,364.0 5134.2,1601.8 5805.8,1599.8 5793.9,7959.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0026/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80376307203584,
+                46.87317802119093
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80378360470196,
+                46.87009130005476
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80921768796449,
+                46.8701084329319
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80919715529836,
+                46.87319515406807
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0027/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p27",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0027/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0027/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,8070.0 -0.0,8070.0 -0.0,0.0 1552.4,-0.0 1547.2,1849.6 3557.2,1839.8 3659.9,4045.9 6660.0,4049.4 6660.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0027/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80357812920784,
+                46.8704849064198
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80360771518032,
+                46.867324986919314
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80917037793559,
+                46.86734967532159
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.8091407919631,
+                46.870509594822074
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0028/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p28",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0028/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0028/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,8070.0 3140.2,8070.0 3136.9,7703.0 122.9,7726.2 122.6,8070.0 -0.0,8070.0 -0.0,5510.8 1125.1,5495.4 1102.6,3862.0 166.7,3870.0 90.1,115.9 1882.4,111.7 1883.7,138.8 4152.4,114.6 4152.3,106.4 6165.9,92.4 6263.0,6423.2 6660.0,6417.1 6660.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0028/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80108165960587,
+                46.868762902788106
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80115166402274,
+                46.865617972798724
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80668776578302,
+                46.86567639073464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80661776136616,
+                46.868821320724024
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0029/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p29",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0029/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0029/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1371.4,0.0 5273.8,0.0 5296.4,5966.6 5560.5,5965.6 5566.9,6993.0 1430.2,7086.7 1371.4,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0029/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80213155387284,
+                46.869103862818804
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79755184932625,
+                46.86906352179243
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79762336441394,
+                46.86526861968717
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80220306896052,
+                46.86530896071355
               ]
             }
           }
@@ -4643,11 +3085,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -4666,8 +3108,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4686,34 +3128,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1101.1,7412.4 -0.0,146.7 -0.0,-0.0 1110.1,0.0 3992.6,213.9 4622.4,2972.6 2329.7,7175.1 1101.1,7412.4\" /></svg>"
+          "value": "<svg><polygon points=\"1101.1,7412.3 1072.6,4911.4 1448.1,525.7 3992.6,213.9 4622.5,2972.5 2329.6,7175.0 1101.1,7412.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0002__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3272.0,
-                4882.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7889117,
-                46.8800626
+                -96.79040455665566,
+                46.88263751057353
               ]
             }
           },
@@ -4721,20 +3166,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3272.0,
-                471.9
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7882692,
-                46.8820944
+                -96.78591823263123,
+                46.88197446878402
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78709372220513,
+                46.87825717739691
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79158004622956,
+                46.87892021918642
               ]
             }
           }
@@ -4752,15 +3239,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4779,34 +3266,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5552.0,515.9 5545.3,7239.9 1357.4,7172.5 1663.7,4956.0 1056.3,4948.5 1058.7,516.1 4183.8,494.2 4188.8,0.0 6660.0,0.0 6660.0,510.9 5552.0,515.9\" /></svg>"
+          "value": "<svg><polygon points=\"5649.3,516.1 5533.1,7557.5 3775.6,7542.1 3782.8,7211.5 1357.4,7172.5 1663.7,4956.0 1056.3,4948.5 1058.7,516.1 4183.8,494.2 4188.8,0.0 5555.7,0.0 5552.0,515.9 5649.3,516.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0003/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1056.0,
-                7170.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7876911,
-                46.8790438
+                -96.78847141294818,
+                46.88237558880116
               ]
             }
           },
@@ -4814,20 +3304,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5552.0,
-                515.9
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.784687,
-                46.8821679
+                -96.78393704816615,
+                46.88241453381995
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7838679987966,
+                46.87865769551319
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78840236357863,
+                46.878618750494404
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0030/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p30",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0030/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0030/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,296.9 5273.5,222.0 6660.0,2481.3 6660.0,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0030/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80196652681109,
+                46.86589896129153
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7974176858364,
+                46.865881849744895
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79744801828556,
+                46.86211224001897
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80199685926026,
+                46.862129351565606
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0031/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p31",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0031/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0031/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6058.9,1079.5 6092.7,6824.6 5308.0,6830.3 5313.4,6409.3 262.7,6429.0 266.6,8070.0 -0.0,8070.0 -0.0,2767.1 -0.0,648.6 253.2,659.8 245.0,0.0 3246.6,0.0 3158.8,856.2 6058.9,1079.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0031/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79849241636786,
+                46.870025225282866
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79395574971187,
+                46.86999703787066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79400571923568,
+                46.866237792156404
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79854238589168,
+                46.86626597956861
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0032/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p32",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0032/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0032/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6119.4,8070.0 531.6,8070.0 534.3,6752.9 -0.0,6752.7 -0.0,1689.7 6256.4,2201.0 6263.4,5515.6 6119.4,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0032/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79436992390305,
+                46.86990958188526
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78994568991912,
+                46.869899717517725
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78996305468415,
+                46.86620779762134
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79438728866808,
+                46.86621766198888
               ]
             }
           }
@@ -4845,15 +3791,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4872,34 +3818,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"165.5,8070.0 222.7,6348.8 -0.0,6344.5 -0.0,5673.2 237.1,5677.9 438.8,2988.7 468.8,0.0 6660.0,0.0 6660.0,2604.1 5931.9,2580.7 5840.5,6458.7 4169.4,6426.0 4155.1,6711.2 4148.7,7420.9 2564.0,6762.3 2500.2,8070.0 165.5,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"342.2,8070.0 346.9,6493.3 -0.0,6493.2 -0.0,5812.1 340.6,5808.1 331.0,4772.6 329.0,4561.1 452.9,3268.6 385.6,0.0 6660.0,0.0 6660.0,2727.2 5616.0,2725.6 5642.6,6483.7 4064.8,6494.1 4075.9,7337.0 2564.0,6762.3 2540.3,8070.0 342.2,8070.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0033/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2564.0,
-                6762.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.788835,
-                46.865754
+                -96.79049297400144,
+                46.86888495485819
               ]
             }
           },
@@ -4907,20 +3856,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2564.0,
-                4482.9
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7888577,
-                46.8667431
+                -96.78600947382654,
+                46.8688391055821
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78609075023373,
+                46.865123761634734
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79057425040862,
+                46.865169610910826
               ]
             }
           }
@@ -4938,15 +3929,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4965,34 +3956,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"705.5,8070.0 -0.0,6477.7 -0.0,2718.9 658.7,1731.7 624.7,286.6 -0.0,301.4 0.0,0.0 6660.0,0.0 6660.0,6440.9 2945.8,6461.4 1481.9,8070.0 705.5,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6453.2 -0.0,2718.9 1048.5,1147.6 1056.5,18.0 6660.0,0.0 6657.5,6470.8 2946.2,6461.0 1481.9,8070.0 815.4,8070.0 -0.0,6453.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0034/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1452.0,
-                4978.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.785768,
-                46.866539
+                -96.78672522397721,
+                46.868851315445475
               ]
             }
           },
@@ -5000,20 +3994,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1452.0,
-                2731.3
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.785756,
-                46.8675804
+                -96.7822127180107,
+                46.86882700813686
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78225580697868,
+                46.865087603866414
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7867683129452,
+                46.86511191117503
               ]
             }
           }
@@ -5031,15 +4067,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5058,34 +4094,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,7066.1 6372.9,8070.0 -0.0,8070.0 0.0,-0.0 365.0,-0.0 365.0,-0.0 6660.0,478.4 6660.0,7066.1\" /></svg>"
+          "value": "<svg><polygon points=\"5303.3,6446.3 1728.4,6455.5 1728.8,4911.6 335.0,4908.4 352.5,0.0 5369.9,0.0 5362.9,418.2 6660.0,414.8 6660.0,2691.8 6126.6,2691.9 6116.6,4916.9 6506.3,4916.2 6660.0,4915.1 6660.0,7153.0 5298.7,7146.7 5303.3,6446.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0035/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                360.0,
-                4914.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.795006,
-                46.861599
+                -96.79859500045873,
+                46.86703017521526
               ]
             }
           },
@@ -5093,20 +4132,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                360.0,
-                427.9
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.791923,
-                46.861594
+                -96.79402805577149,
+                46.867013942815554
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79405683295509,
+                46.863229743172084
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79862377764233,
+                46.86324597557179
               ]
             }
           }
@@ -5124,15 +4205,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5151,34 +4232,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,8070.0 3683.6,8070.0 1470.8,7216.7 -0.0,6455.5 -0.0,445.0 3797.2,1737.4 5779.0,1741.7 5790.1,2365.7 5519.1,2365.3 5518.5,2732.4 6660.0,3954.7 6660.0,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"3720.9,8070.0 1489.9,7245.3 555.6,6517.1 -0.0,4994.7 -0.0,4750.8 -0.0,2747.8 -0.0,2747.8 534.2,1743.5 5663.2,1710.6 6660.0,3954.8 6660.0,4338.9 6660.0,8070.0 3720.9,8070.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0036/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1484.0,
-                4962.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.793409,
-                46.86471
+                -96.79438536589187,
+                46.86702883672477
               ]
             }
           },
@@ -5186,20 +4270,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5996.0,
-                2731.3
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.790326,
-                46.865747
+                -96.78986346801913,
+                46.86699892883238
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78991648534084,
+                46.86325176550992
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79443838321357,
+                46.86328167340231
               ]
             }
           }
@@ -5217,15 +4343,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5244,34 +4370,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"450.4,4310.9 -0.0,4307.8 -0.0,0.0 497.9,0.0 465.2,2725.1 1192.7,2739.5 1190.9,1653.1 2735.0,1622.9 2772.0,355.9 4318.4,963.4 4319.6,0.0 5937.8,0.0 5855.1,919.1 6660.0,924.0 6660.0,3223.6 5858.6,3220.7 5866.0,8070.0 1085.5,8070.0 1196.6,5043.0 443.6,5040.8 450.4,4310.9\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,-0.0 5812.5,0.0 6660.0,771.0 6660.0,2988.7 5841.8,6562.8 5848.4,8053.5 -0.0,8070.0 0.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0037/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2772.0,
-                355.9
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.788835,
-                46.865754
+                -96.79069343996979,
+                46.865896937723846
               ]
             }
           },
@@ -5279,20 +4408,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4296.0,
-                7406.2
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.787854,
-                46.862591
+                -96.78619961531315,
+                46.86585034986928
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78628162020061,
+                46.862100076335174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79077544485725,
+                46.862146664189744
               ]
             }
           }
@@ -5310,11 +4481,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -5333,8 +4504,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5353,7 +4524,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 1522.2,0.0 1531.4,1577.3 2983.0,0.0 6660.0,0.0 6660.0,6558.2 1529.3,6546.7 1528.6,8070.0 -0.0,8070.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,-0.0 1477.7,0.0 1500.1,1609.2 2957.0,0.0 6660.0,0.0 6660.0,6607.4 1532.9,6585.0 1542.7,8070.0 -0.0,8070.0 0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -5382,8 +4553,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78681444533844,
-                46.86584980455926
+                -96.78677140369754,
+                46.86586115723852
               ]
             }
           },
@@ -5403,8 +4574,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78223601741425,
-                46.86584246726218
+                -96.7822489803398,
+                46.865828630948634
               ]
             }
           },
@@ -5424,8 +4595,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78224902306852,
-                46.86204814575081
+                -96.78230663748268,
+                46.86208091666294
               ]
             }
           },
@@ -5445,8 +4616,99 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78682745099272,
-                46.86205548304789
+                -96.78682906084042,
+                46.862113442952825
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0038__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p38 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "4237.2"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "5125.1"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2422.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "1146.5"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0038__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0038/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,6271.6 4237.2,6271.6 4237.2,5125.1 6660.0,5125.1 6660.0,6271.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0038__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4237.2,
+                5125.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.82269612793176,
+                46.88692362835932
               ]
             }
           },
@@ -5454,20 +4716,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1524.0,
-                763.8
+                6660.0,
+                5125.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.785768,
-                46.865489
+                -96.82095523329959,
+                46.88691037587422
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                6271.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.82096441466923,
+                46.8863467630286
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4237.2,
+                6271.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.82270530930141,
+                46.886360015513695
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0039/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p39",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0039/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0039/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1683.5,4100.9 1686.7,2971.2 -0.0,2972.7 -0.0,0.0 5338.8,0.0 5332.3,714.0 6143.4,720.4 6112.1,6574.9 -0.0,6592.0 -0.0,4096.1 1683.5,4100.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0039/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79857343735868,
+                46.86400090299574
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79409244141266,
+                46.86399285927618
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79410670289671,
+                46.86028023842813
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79858769884274,
+                46.86028828214769
               ]
             }
           }
@@ -5485,15 +4927,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5512,34 +4954,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"270.9,6769.0 -0.0,2782.6 -0.0,724.3 1013.1,664.9 986.6,175.9 244.6,216.1 235.6,0.0 4800.6,0.0 4827.9,481.1 6660.0,394.4 6660.0,8070.0 3530.8,8070.0 3455.9,6661.3 270.9,6769.0\" /></svg>"
+          "value": "<svg><polygon points=\"157.3,6680.7 -0.0,679.6 2060.8,596.2 2043.3,0.0 4626.6,0.0 4643.5,493.1 6660.0,420.6 6660.0,8070.0 3444.3,8070.0 3377.7,6597.6 157.3,6680.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0004/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1204.0,
-                4954.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7839236,
-                46.8800911
+                -96.78460600607202,
+                46.88249509306001
               ]
             }
           },
@@ -5547,20 +4992,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4196.0,
-                507.9
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7816688,
-                46.8821888
+                -96.77992646740663,
+                46.882396138537025
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78010195100022,
+                46.87851985070123
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78478148966562,
+                46.878618805224214
               ]
             }
           }
@@ -5578,15 +5065,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5605,34 +5092,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3778.0,8070.0 -0.0,6616.9 -0.0,0.0 1492.3,0.0 3767.1,0.0 4144.0,0.0 6018.9,0.0 6660.0,706.7 6660.0,2595.8 6660.0,8070.0 3778.0,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,738.2 575.3,738.6 573.3,0.0 1504.3,0.0 1513.2,735.2 3772.0,727.8 3765.4,1569.8 5481.8,1572.7 5465.0,3982.2 6026.9,3984.7 6030.4,2979.1 6660.0,2979.0 6660.0,8070.0 3772.6,8070.0 3780.5,6533.2 -0.0,6581.3 -0.0,738.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0040/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1544.0,
-                5194.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.793426,
-                46.861608
+                -96.79443733976237,
+                46.86400233984116
               ]
             }
           },
@@ -5640,20 +5130,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6016.0,
-                5194.7
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.790406,
-                46.861586
+                -96.78994863706421,
+                46.86397787914144
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78999199606153,
+                46.860258038496845
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79448069875968,
+                46.860282499196565
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0041/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p41",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0041/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0041/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"263.3,8070.0 262.0,7167.9 -0.0,7167.1 -0.0,0.0 5739.9,0.0 5799.6,8070.0 263.3,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0041/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79863925501283,
+                46.86096835436179
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79411328720151,
+                46.860960229421146
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79412768913362,
+                46.85720942217242
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79865365694494,
+                46.85721754711306
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0042/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p42",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0042/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0042/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,-0.0 4122.9,0.0 4095.7,1517.3 6257.7,1544.8 6210.6,7174.6 6660.0,7178.4 6660.0,8070.0 -0.0,8070.0 0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0042/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79473860926645,
+                46.86096784372548
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79019269205622,
+                46.860982660908675
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79016642799495,
+                46.85721528342808
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79471234520517,
+                46.85720046624489
               ]
             }
           }
@@ -5671,15 +5479,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5698,34 +5506,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"300.5,5543.0 297.7,2717.9 643.9,2720.0 657.3,520.9 2962.7,519.2 2963.3,772.2 3736.5,770.5 3735.1,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,6001.8 501.7,6000.8 500.7,5542.8 300.5,5543.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6042.6 541.5,6031.9 532.8,5585.6 307.8,5588.1 275.9,2769.6 620.9,2767.2 606.9,750.6 3679.4,739.6 3671.3,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,6042.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0043/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4516.0,
-                6134.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7847506,
-                46.8570645
+                -96.790782126937,
+                46.86284658273104
               ]
             }
           },
@@ -5733,20 +5544,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4516.0,
-                4274.9
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.784739,
-                46.858793
+                -96.78170332266919,
+                46.8627541012766
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78186725058714,
+                46.855230180231075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79094605485496,
+                46.85532266168551
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0044/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p44",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0044/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0044/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 0.0,-0.0 6382.1,0.0 6380.5,190.4 5268.8,195.6 5225.8,7940.8 6660.0,7948.7 6660.0,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0044/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80555389541027,
+                46.86585192571077
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80102067342327,
+                46.865851953256566
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80102062493663,
+                46.86206879945231
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80555384692363,
+                46.862068771906515
               ]
             }
           }
@@ -5764,11 +5755,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -5787,8 +5778,8 @@
           "value": "3956.6"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5807,34 +5798,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"897.6,2230.7 303.4,1784.0 1222.2,1691.4 1051.9,0.0 6660.0,0.0 6660.0,3956.6 760.0,3836.6 1027.9,3332.8 897.6,2230.7\" /></svg>"
+          "value": "<svg><polygon points=\"1120.3,2054.3 620.6,1641.4 1365.7,1607.6 1292.7,0.0 6660.0,0.0 6660.0,3956.6 -0.0,3956.6 -0.0,3652.3 834.5,3597.4 1176.9,3112.8 1120.3,2054.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0045__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3812.0,
-                2152.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7730996,
-                46.8833976
+                -96.77803412408922,
+                46.885531210723684
               ]
             }
           },
@@ -5842,20 +5836,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                760.0,
-                3836.6
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7771624,
-                46.8822175
+                -96.76916021340512,
+                46.88522729730991
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                3956.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.76942433056166,
+                46.8816245614979
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3956.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.77829824124576,
+                46.881928474911675
               ]
             }
           }
@@ -5873,11 +5909,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -5896,8 +5932,8 @@
           "value": "4193.4"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5916,34 +5952,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5969.8,3876.6 5937.8,7825.0 2989.5,7819.5 2989.0,8013.0 2989.0,8070.0 -0.0,8070.0 -0.0,3876.6 5969.8,3876.6\" /></svg>"
+          "value": "<svg><polygon points=\"5948.3,4974.8 3019.2,4977.6 3020.8,5245.4 2372.3,5244.2 2375.0,8070.0 -0.0,8070.0 -0.0,3876.6 5949.4,3876.6 5948.3,4974.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0045__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4800.0,
-                4132.5
+                0.0,
+                3876.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.812239,
-                46.881569
+                -96.81188127566676,
+                46.885991096095154
               ]
             }
           },
@@ -5951,20 +5990,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                880.0,
-                5243.8
+                6660.0,
+                3876.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.81372,
-                46.885129
+                -96.81189880091296,
+                46.87985479891421
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.81755509947406,
+                46.87986234567679
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.81753757422787,
+                46.885998642857736
               ]
             }
           }
@@ -5982,11 +6063,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -6005,8 +6086,8 @@
           "value": "2547.8"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6025,34 +6106,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,5522.2 6660.0,6255.5 6207.1,6255.9 6195.8,8070.0 5023.5,8070.0 4987.6,6497.9 3138.8,6539.5 3138.8,5770.1 3297.3,5769.8 3297.3,5522.2 6660.0,5522.2\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,5522.2 6660.0,6255.5 6517.0,6255.6 6224.8,6255.9 6221.6,8070.0 3138.8,8070.0 3138.8,5984.3 3297.9,5984.2 3297.3,5522.2 6660.0,5522.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0045__3/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5081.3,
-                6257.0
+                3138.8,
+                5522.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.818135,
-                46.881573
+                -96.81714303773042,
+                46.88335705988967
               ]
             }
           },
@@ -6060,20 +6144,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3298.7,
-                6257.0
+                6660.0,
+                5522.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.818132,
-                46.883211
+                -96.81714896373936,
+                46.880121458992804
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.8205771499829,
+                46.88012439219757
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3138.8,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.82057122397396,
+                46.88335999309444
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0046/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p46",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0046/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0046/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6419.1,0.0 6389.9,7195.2 309.8,7182.7 329.0,0.0 6419.1,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0046/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79842189818604,
+                46.882855932604
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79381802099148,
+                46.882848168656786
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79383178831644,
+                46.879034257346206
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.798435665511,
+                46.87904202129342
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0047/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p47",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0047/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0047/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4170.7,8070.0 2063.0,8070.0 815.7,6349.9 126.8,899.4 132.9,0.0 6660.0,0.0 6660.0,7565.2 4193.5,8070.0 4170.7,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0047/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79821254074055,
+                46.88899908056571
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7936938352399,
+                46.88899439060514
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79370209416165,
+                46.88522497758168
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79822079966229,
+                46.88522966754225
               ]
             }
           }
@@ -6091,15 +6493,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6118,34 +6520,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6841.6 0.0,-0.0 6389.7,0.0 6391.5,352.0 5567.4,359.5 5555.1,2233.1 6660.0,2240.4 6660.0,6358.2 6438.0,6309.1 6303.1,6829.3 -0.0,6841.6\" /></svg>"
+          "value": "<svg><polygon points=\"97.3,6101.4 -0.0,6095.9 -0.0,0.0 6419.8,0.0 6420.6,360.0 5525.8,364.7 5512.1,1479.6 5761.2,1429.1 5749.2,2933.1 6387.1,2932.7 6321.9,6153.5 5723.4,6157.1 5717.9,6843.6 84.8,6826.8 97.3,6101.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0048/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1876.0,
-                6154.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7969911,
-                46.8831759
+                -96.79825426475743,
+                46.8860323335683
               ]
             }
           },
@@ -6153,20 +6558,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2112.0,
-                355.9
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.796822,
-                46.885869
+                -96.79375270978618,
+                46.88603398801438
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79374979650174,
+                46.88227867504905
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.798251351473,
+                46.88227702060297
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0049/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p49",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0049/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0049/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5328.0,21.6 5365.5,6866.3 432.0,7057.2 432.0,7058.3 -0.0,7063.3 -0.0,2669.2 552.4,2808.2 1537.8,2794.9 1520.3,1534.6 4223.9,1495.1 4204.8,653.3 478.9,707.7 296.7,643.2 297.6,-0.0 5328.0,21.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0049/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78895970059754,
+                46.89051515480064
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78903839823722,
+                46.88741843922902
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79453032485809,
+                46.88748362490105
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79445162721841,
+                46.89058034047267
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0005/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p5",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0005/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0005/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,338.3 6660.0,8070.0 -0.0,8070.0 -0.0,353.3 104.0,351.7 117.1,0.0 4267.4,0.0 4268.0,339.9 6660.0,338.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0005/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80657395383021,
+                46.879657520513234
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80201179742552,
+                46.87963525566296
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80205126276843,
+                46.87585441899344
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80661341917312,
+                46.875876683843714
               ]
             }
           }
@@ -6184,15 +6907,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6211,34 +6934,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4759.6,8070.0 4746.6,7234.8 -0.0,7070.1 0.0,-0.0 653.8,-0.0 665.6,609.0 2705.8,585.4 2704.6,-0.0 6660.0,-0.0 6660.0,8070.0 4759.6,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"5633.1,6847.9 4752.6,6857.0 4763.0,7173.7 3252.5,7165.0 2222.9,7018.3 -0.0,7025.0 -0.0,566.9 691.4,-0.0 726.6,602.3 2729.1,573.0 2726.2,-0.0 4737.4,-0.0 4756.3,1385.2 5608.8,1366.5 5633.1,6847.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0050/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4756.0,
-                4970.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.792397,
-                46.885853
+                -96.78903732940844,
+                46.88803794025154
               ]
             }
           },
@@ -6246,20 +6972,890 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4756.0,
-                2731.3
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.790896,
-                46.885844
+                -96.78909036442721,
+                46.88494656337906
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7945341527669,
+                46.88499080461972
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79448111774813,
+                46.8880821814922
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0051/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p51",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0051/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0051/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,352.5 6660.0,2432.9 6660.0,2432.9 5955.0,6591.2 4117.6,8070.0 -0.0,8070.0 -0.0,1056.8 227.3,-0.0 4115.3,-0.0 4115.3,-0.0 6660.0,199.2 6660.0,352.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0051/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7845652452577,
+                46.89046759327161
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78457776792447,
+                46.88737050835985
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79003185887116,
+                46.88738095415271
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79001933620438,
+                46.89047803906447
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0052/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p52",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0052/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0052/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6530.5,7250.4 4841.6,7258.1 4827.4,8070.0 3981.1,8070.0 3997.5,7261.6 3992.6,6695.2 1997.1,6651.5 1987.5,7220.1 -0.0,7205.5 -0.0,2457.5 754.2,2465.1 782.9,244.5 -0.0,236.8 0.0,-0.0 5697.0,-0.0 5638.0,4794.9 6532.6,4789.8 6530.5,7250.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0052/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78455164330857,
+                46.88773808573116
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78450582559643,
+                46.88462308314117
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78999117889325,
+                46.88458486222835
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7900369966054,
+                46.88769986481834
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0053/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p53",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0053/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0053/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5727.4,1705.8 6220.0,1703.6 6390.4,5580.7 5991.3,7731.8 3738.9,7247.1 924.0,7298.2 895.7,4851.4 -0.0,4867.4 0.0,-0.0 858.1,-0.0 861.7,381.4 5707.3,344.5 5727.4,1705.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0053/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78444487368348,
+                46.88507338075116
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78445486514387,
+                46.881962745405765
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78997118160954,
+                46.88197102183008
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78996119014916,
+                46.885081657175476
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0054/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p54",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0054/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0054/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6404.3,1167.8 5062.4,7321.6 5814.2,7483.1 5605.1,7480.2 5608.0,8070.0 4922.9,8070.0 4914.6,7477.2 1700.0,7438.2 1705.4,8070.0 -0.0,8070.0 -0.0,879.1 4513.0,776.0 6404.3,1167.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0054/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78885196333485,
+                46.88543617894588
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78888563241962,
+                46.882330710069745
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79439232310392,
+                46.882358602198266
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79435865401915,
+                46.8854640710744
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0055/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p55",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0055/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0055/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5492.5,6027.8 2799.8,5932.3 2796.0,6554.4 546.6,6566.3 541.8,1132.9 928.6,1131.8 934.5,262.0 834.2,261.3 832.8,0.0 6660.0,0.0 6660.0,843.9 5498.5,842.5 5492.5,6027.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0055/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78507549464429,
+                46.88519212305963
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7805867630124,
+                46.885206033735074
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.780562093745,
+                46.88148786191783
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7850508253769,
+                46.88147395124239
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0056/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p56 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0056/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0056/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 3909.0,0.0 6660.0,2531.4 6660.0,4542.1 5962.1,5425.3 4375.4,5444.9 4344.5,6021.2 6660.0,6145.0 6660.0,8070.0 1928.0,8070.0 2017.5,5460.7 -0.0,5464.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0056/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78136699496243,
+                46.884815435015774
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.77668454412857,
+                46.884826200520905
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.77666545280722,
+                46.88094750669758
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78134790364108,
+                46.88093674119245
               ]
             }
           }
@@ -6277,15 +7873,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6304,34 +7900,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"435.1,4062.6 431.3,3185.8 535.0,3185.5 538.1,1230.6 -0.0,1227.3 -0.0,-0.0 6660.0,0.0 6660.0,8070.0 5795.5,8070.0 4946.0,7286.5 2982.4,7321.0 2995.4,8070.0 626.4,8070.0 560.4,4061.0 435.1,4062.6\" /></svg>"
+          "value": "<svg><polygon points=\"592.8,6811.6 552.3,4058.0 433.2,4059.8 427.1,3175.8 532.4,3175.2 528.6,1218.2 -0.0,1216.3 -0.0,-0.0 6660.0,0.0 6660.0,8070.0 5923.8,8070.0 4956.5,7194.0 3502.3,7205.7 3498.5,6784.9 592.8,6811.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0057/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1560.0,
-                1231.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7831823,
-                46.8903588
+                -96.78527250147087,
+                46.8914896763029
               ]
             }
           },
@@ -6339,20 +7938,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4940.0,
-                1231.7
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.778609,
-                46.890352
+                -96.77627085493447,
+                46.89146098980202
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.77632173107682,
+                46.8840051046924
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78532337761322,
+                46.88403379119328
               ]
             }
           }
@@ -6370,11 +8011,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -6393,8 +8034,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6413,34 +8054,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1865.6,7041.9 818.0,7027.0 819.9,6908.6 823.3,6616.8 413.0,6607.0 396.0,7315.2 -0.0,7310.8 -0.0,-0.0 6660.0,0.0 6660.0,6153.9 6244.4,6142.7 6191.2,8070.0 3995.7,8070.0 4025.4,7049.6 2977.9,7057.8 2980.6,6668.7 1872.2,6642.0 1865.6,7041.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6807.1 -0.0,0.0 6660.0,0.0 6660.0,6139.5 6283.0,6139.2 6255.4,8070.0 4055.7,8070.0 4072.1,7037.1 3022.6,7059.3 3020.4,6703.5 1909.2,6687.2 1908.0,7058.3 858.1,7057.3 858.5,6938.7 858.0,6671.7 490.2,6666.3 469.6,8070.0 -0.0,8070.0 -0.0,6807.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0058__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1908.0,
-                4474.9
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7966094,
-                46.8975759
+                -96.79920770478014,
+                46.90176580995046
               ]
             }
           },
@@ -6448,20 +8092,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5232.0,
-                2511.4
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7920919,
-                46.899444
+                -96.79011755888627,
+                46.90174853422564
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79014819953358,
+                46.89421978132484
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79923834542745,
+                46.894237057049665
               ]
             }
           }
@@ -6469,41 +8155,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0059__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0006/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Fargo, N.D. | 1958 p59 [2]",
+      "label": "Fargo, N.D. | 1958 p6",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6660.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8070.0"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6512,44 +8182,47 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0059__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0006/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0059/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0006/info.json",
           "type": "ImageService2",
           "height": 8070,
           "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 5602.3,0.0 5507.7,7414.8 2538.4,7392.2 2537.9,8070.0 -0.0,8070.0 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"831.1,318.1 6367.7,366.1 6296.6,8070.0 755.6,7996.3 831.1,318.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0059__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0006/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2492.0,
-                6154.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.8019932,
-                46.8903739
+                -96.80258345747335,
+                46.87962577809358
               ]
             }
           },
@@ -6557,20 +8230,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4688.0,
-                6154.5
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7996265,
-                46.8903727
+                -96.79802038814111,
+                46.879634078237
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79800577432263,
+                46.875826991216634
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80256884365487,
+                46.87581869107322
               ]
             }
           }
@@ -6588,11 +8303,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -6611,8 +8326,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6631,34 +8346,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1463.2,6960.5 787.5,6967.3 785.1,6507.1 -0.0,6511.2 0.0,0.0 407.9,0.0 412.4,407.7 1453.6,397.4 1450.6,0.0 2552.4,0.0 2559.0,386.7 3599.5,353.5 3594.3,1367.8 5775.7,1315.4 5788.0,2899.3 4836.2,2911.1 4829.6,5264.4 3600.5,5275.6 3621.9,7395.4 1468.3,7419.8 1463.2,6960.5\" /></svg>"
+          "value": "<svg><polygon points=\"1460.0,7418.2 1453.1,6962.5 798.3,6973.0 791.9,6389.7 -0.0,6398.3 0.0,0.0 366.2,0.0 371.9,383.8 1417.1,369.4 1412.8,0.0 2519.1,0.0 2526.6,354.1 3570.9,316.7 3569.8,1345.0 4818.3,1326.6 4873.2,5244.5 3591.5,5244.6 3621.7,7385.1 1460.0,7418.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0060__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5788.0,
-                2899.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7907123,
-                46.8927677
+                -96.79856394075489,
+                46.89554532799834
               ]
             }
           },
@@ -6666,20 +8384,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5788.0,
-                331.9
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7906646,
-                46.8951826
+                -96.78943437501557,
+                46.89543618538943
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78962794583818,
+                46.88787450349466
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79875751157749,
+                46.88798364610357
               ]
             }
           }
@@ -6697,11 +8457,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -6720,8 +8480,8 @@
           "value": "3709.5"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6740,34 +8500,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4360.5 6660.0,4360.5 6660.0,8070.0 -0.0,8070.0 -0.0,4360.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8070.0 0.0,4360.5 6660.0,4360.5 6660.0,8070.0 -0.0,8070.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0061__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5304.0,
-                7174.6
+                0.0,
+                4360.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.8107064,
-                46.888234
+                -96.81782338148675,
+                46.890552129759186
               ]
             }
           },
@@ -6775,20 +8538,216 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5304.0,
-                4536.4
+                6660.0,
+                4360.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.8107161,
-                46.8904026
+                -96.80889978780583,
+                46.89056670366296
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80888790020254,
+                46.88716819126627
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.81781149388345,
+                46.88715361736249
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0062__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p62 [6]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2004.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2738.5"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0062__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0062/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2004.0,2738.5 0.0,2738.5 -0.0,-0.0 2004.0,-0.0 2004.0,2738.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0062__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78822344934764,
+                46.903387052052075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2004.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78563216717856,
+                46.90334925287566
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2004.0,
+                2738.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78570778064008,
+                46.90092764614487
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                2738.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78829906280916,
+                46.90096544532129
               ]
             }
           }
@@ -6806,11 +8765,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -6829,8 +8788,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6849,34 +8808,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6323.2,472.3 6403.8,1597.0 6660.0,1598.3 6660.0,3698.6 6250.6,3701.1 6271.7,7155.8 6155.6,7156.8 6163.0,8070.0 4369.2,8070.0 4371.6,6694.1 4081.7,6693.6 4080.1,6792.7 3449.6,6805.9 3480.0,0.0 6660.0,0.0 6660.0,470.6 6323.2,472.3\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,581.5 6307.2,583.3 6390.3,1672.1 6660.0,1675.0 6660.0,3736.2 6232.2,3739.3 6252.7,6607.9 4160.9,6607.2 4101.8,6756.0 3449.6,6767.6 3449.6,0.0 6660.0,0.0 6660.0,581.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0062__3/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5208.7,
-                3875.0
+                3449.6,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7996608,
-                46.8858845
+                -96.80204859297675,
+                46.88956511197788
               ]
             }
           },
@@ -6884,20 +8846,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5208.7,
-                5182.7
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7996755,
-                46.8846817
+                -96.79763163234797,
+                46.8895451402755
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79770506422665,
+                46.88195822546604
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3449.6,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80212202485542,
+                46.88197819716842
               ]
             }
           }
@@ -6915,15 +8919,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6942,34 +8946,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,1544.0 6660.0,6551.4 6660.0,7182.0 5919.5,8070.0 3545.4,8070.0 -0.0,7125.9 -0.0,-0.0 6660.0,-0.0 6660.0,1544.0\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,-0.0 6660.0,7238.2 5880.2,8070.0 1935.7,8070.0 1935.4,7635.2 -0.0,7096.7 -0.0,0.0 6660.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0064/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                904.0,
-                4890.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.787625,
-                46.8951829
+                -96.78098555040725,
+                46.89599899128553
               ]
             }
           },
@@ -6977,20 +8984,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6064.0,
-                4890.8
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7877398,
-                46.8903722
+                -96.78101719149909,
+                46.889799185173885
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79201329885997,
+                46.88982539139771
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79198165776813,
+                46.89602519750935
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0065/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p65",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0065/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0065/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,3613.2 1300.5,3769.9 1310.5,3014.5 1267.6,1611.2 -0.0,1458.4 0.0,0.0 6660.0,-0.0 6660.0,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0065/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.8196479545217,
+                46.87725245671086
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.8196370412287,
+                46.87111597971124
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.83051697931424,
+                46.87110693775606
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.83052789260724,
+                46.87724341475568
               ]
             }
           }
@@ -7008,11 +9195,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -7031,8 +9218,8 @@
           "value": "4826.8"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7051,34 +9238,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,8070.0 -0.0,8070.0 -0.0,3243.2 351.1,3243.2 338.2,3560.5 472.1,3560.9 472.8,4026.4 6165.6,4017.1 6161.3,6124.3 6660.0,6125.3 6660.0,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,8070.0 -0.0,8070.0 -0.0,3243.2 338.6,3243.2 338.2,3560.5 472.1,3560.9 472.8,4020.5 6152.5,4010.8 6126.9,6082.7 6660.0,6089.3 6660.0,8070.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0066__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4216.0,
-                5740.5
+                0.0,
+                3243.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7934917,
-                46.8556393
+                -96.79910216213517,
+                46.857927476526044
               ]
             }
           },
@@ -7086,20 +9276,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5336.0,
-                5740.5
+                6660.0,
+                3243.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.791999,
-                46.8556367
+                -96.79022592820662,
+                46.85791201581174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79024233217116,
+                46.85350834481194
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79911856609971,
+                46.853523805526244
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0067/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p67",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0067/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0067/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,6699.8 3565.0,6712.8 3570.7,8070.0 -0.0,8070.0 -0.0,5597.6 435.6,5596.4 434.4,4862.0 -0.0,4862.7 -0.0,2316.4 373.3,2310.7 372.8,2055.7 -0.0,2056.4 -0.0,-0.0 6660.0,-0.0 6660.0,6699.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0067/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.81061567139716,
+                46.88050692468385
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.8106423407107,
+                46.87439265519108
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.82148356698802,
+                46.874414750081556
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.82145689767448,
+                46.880529019574325
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0069/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p69 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0069/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0069/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7486.5 -0.0,-0.0 4861.5,0.0 4862.1,217.5 5222.8,218.8 6119.0,191.6 6121.8,0.0 6232.4,0.0 6241.5,3552.0 6566.9,3550.3 6577.7,7792.0 2774.3,7803.8 2773.0,7479.8 -0.0,7486.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0069/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80557931916609,
+                46.883332269222066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80082530783153,
+                46.88330112603415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80088014439998,
+                46.879334996835745
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.80563415573454,
+                46.87936614002366
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0007/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p7 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0007/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0007/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1009.7,7611.8 984.8,8070.0 -0.0,8070.0 -0.0,7953.1 405.4,7948.7 400.4,7617.3 395.1,7617.3 291.0,287.1 6391.4,183.3 6514.7,7562.5 1009.7,7611.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0007/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79841616039549,
+                46.87960009615556
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79382929678512,
+                46.8795321872618
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79394886179453,
+                46.875705242195004
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7985357254049,
+                46.875773151088765
               ]
             }
           }
@@ -7117,11 +9763,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -7140,8 +9786,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7160,34 +9806,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"277.0,-0.0 4324.8,-0.0 4324.8,1572.1 4170.5,1573.8 4224.1,8070.0 942.8,8070.0 945.4,7768.2 0.0,7765.7 0.0,1555.6 276.7,1551.9 277.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"316.1,7710.1 316.1,3563.1 -0.0,3563.9 0.0,-0.0 3915.5,0.0 3917.5,277.9 4007.1,282.4 4013.2,459.2 4012.6,7706.4 316.1,7710.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0070__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                316.1,
-                5670.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.801152,
-                46.870795
+                -96.80113007601747,
+                46.883348992452554
               ]
             }
           },
@@ -7195,20 +9844,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                316.1,
-                3563.1
+                4324.8,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.801172,
-                46.869734
+                -96.7979513157037,
+                46.883333955420866
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4324.8,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79799237626302,
+                46.879277133241516
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.8011711365768,
+                46.8792921702732
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0071/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p71",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0071/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0071/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,8070.0 6140.3,8070.0 6130.2,7309.5 941.5,7299.2 943.0,1328.4 552.7,1327.9 -0.0,1329.3 -0.0,0.0 6115.8,0.0 6112.0,1325.7 6660.0,1322.9 6660.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0071/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.81776409948525,
+                46.88381054809105
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.81337346606209,
+                46.883807556177295
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.81337877140066,
+                46.88017027401772
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.81776940482382,
+                46.880173265931475
               ]
             }
           }
@@ -7226,11 +10055,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -7249,8 +10078,8 @@
           "value": "2755.3"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7269,7 +10098,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4166.7,5314.7 4351.6,5314.7 4353.5,5810.2 5276.0,5802.6 5824.0,5314.7 6660.0,5314.7 6660.0,8070.0 4182.0,8070.0 4166.7,5314.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,5835.1 2110.3,5314.7 2911.9,5314.7 3698.9,5314.7 5276.0,5802.6 5295.0,8070.0 -0.0,8070.0\" /></svg>"
         }
       },
       "body": {
@@ -7298,8 +10127,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78856140388449,
-                46.87466664347615
+                -96.78676623495149,
+                46.874431996041025
               ]
             }
           },
@@ -7319,8 +10148,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78400433109123,
-                46.874364539635174
+                -96.78449574477324,
+                46.874281477531696
               ]
             }
           },
@@ -7340,8 +10169,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78418716233293,
-                46.8730750977534
+                -96.7845868375772,
+                46.873639033300314
               ]
             }
           },
@@ -7361,8 +10190,83 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78874423512619,
-                46.873377201594366
+                -96.78685732775544,
+                46.873789551809644
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0008/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p8",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0008/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0008/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4693.8,5963.3 4692.2,7407.1 6546.0,7408.5 6550.5,7494.6 1105.8,7551.2 986.4,248.6 3637.8,194.6 5766.0,546.1 5322.8,2686.1 4697.4,2572.9 4676.5,4988.2 4888.1,5026.3 4693.8,5963.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0008/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79469982192114,
+                46.879577129103154
               ]
             }
           },
@@ -7370,20 +10274,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5276.0,
-                5802.6
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7849837,
-                46.874199
+                -96.79006480322575,
+                46.8795096367229
               ]
             }
           },
@@ -7391,20 +10295,41 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5276.0,
-                5802.6
+                6660.0,
+                8070.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7849837,
-                46.874199
+                -96.79018363476753,
+                46.87564251046959
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79481865346293,
+                46.87571000284984
               ]
             }
           }
@@ -7422,11 +10347,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -7445,8 +10370,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7465,34 +10390,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2310.4,7339.4 2264.3,8070.0 -0.0,8070.0 -0.0,6284.1 236.1,5141.7 -0.0,5099.1 -0.0,2124.1 764.0,2262.8 1227.3,0.0 2740.5,0.0 2714.4,253.3 3788.7,363.9 2588.8,6848.2 2468.9,7284.1 2310.4,7339.4\" /></svg>"
+          "value": "<svg><polygon points=\"2310.4,7338.9 2264.3,8070.0 -0.0,8070.0 -0.0,6283.3 236.1,5141.5 -0.0,5098.9 -0.0,2124.1 764.0,2262.8 1227.4,0.0 2740.5,0.0 2714.4,253.5 3788.8,364.1 2588.7,6847.8 2468.8,7283.7 2310.4,7338.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                764.0,
-                2263.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.791035,
-                46.878236
+                -96.79144183992479,
+                46.87912412643776
               ]
             }
           },
@@ -7500,20 +10428,216 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3312.0,
-                2751.3
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.789589,
-                46.878024
+                -96.7876472056949,
+                46.87906687581816
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78774870831322,
+                46.875922845581954
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79154334254311,
+                46.87598009620155
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Fargo, N.D. | 1958 p9 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "2536.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "2485.4"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "4124.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5584.6"
+        }
+      ],
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009/info.json",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2536.0,2485.4 6620.6,2485.4 6660.0,7021.4 2536.0,7585.0 2536.0,2485.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2536.0,
+                2485.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.82430282752416,
+                46.878488922475135
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                2485.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.82143944857886,
+                46.87825212358302
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.82190554392218,
+                46.87558121384775
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2536.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.82476892286749,
+                46.87581801273987
               ]
             }
           }
@@ -7531,15 +10655,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7558,34 +10682,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5908.0,6150.5 490.3,6150.5 1330.7,2290.1 3661.8,2571.4 3655.8,1521.6 3646.8,0.0 5845.8,0.0 5908.0,6150.5\" /></svg>"
+          "value": "<svg><polygon points=\"490.3,6150.5 1330.7,2290.2 3661.8,2571.5 3646.8,0.0 5845.8,0.0 5908.0,6150.5 490.3,6150.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009a/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                492.0,
-                6150.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.789589,
-                46.878024
+                -96.78975116942797,
+                46.87950090037141
               ]
             }
           },
@@ -7593,20 +10720,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5908.0,
-                6150.5
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.787687,
-                46.878018
+                -96.7874130261774,
+                46.879493524525195
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78742610415229,
+                46.877556405448914
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78976424740286,
+                46.87756378129513
               ]
             }
           }
@@ -7624,15 +10793,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7651,34 +10820,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1172.0,859.8 5632.0,859.8 5627.7,7116.4 1143.5,6217.5 1172.0,859.8\" /></svg>"
+          "value": "<svg><polygon points=\"1172.0,859.8 5632.0,859.8 5627.6,7117.2 1143.5,6218.2 1172.0,859.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009b/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1172.0,
-                859.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.787687,
-                46.878018
+                -96.78738210352637,
+                46.87830247325618
               ]
             }
           },
@@ -7686,20 +10858,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5632.0,
-                859.8
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7876859,
-                46.876936
+                -96.78738046092546,
+                46.8766867512831
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79024494652283,
+                46.87668539025876
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79024658912374,
+                46.87830111223183
               ]
             }
           }
@@ -7717,15 +10931,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7744,34 +10958,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4129.9,8070.0 3122.9,7427.4 1004.0,6938.7 1200.7,492.8 5512.0,635.8 5301.4,8070.0 4129.9,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"4129.4,8070.0 3122.7,7427.5 1004.0,6938.7 1201.0,492.5 5512.0,635.8 5301.0,8070.0 4129.4,8070.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009c/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1004.0,
-                6938.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.789907,
-                46.876936
+                -96.78752899054018,
+                46.87722212119581
               ]
             }
           },
@@ -7779,20 +10996,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5512.0,
-                635.8
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7876899,
-                46.8759207
+                -96.78745894383168,
+                46.87565517467159
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79023695627767,
+                46.875597135451365
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79030700298617,
+                46.87716408197558
               ]
             }
           }
@@ -7810,15 +11069,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7837,34 +11096,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5646.8,7003.6 1120.1,7074.5 1069.3,0.0 1798.1,0.0 1702.6,786.0 5645.5,731.2 5646.8,7003.6\" /></svg>"
+          "value": "<svg><polygon points=\"1183.2,7206.0 1112.0,871.8 6660.0,824.4 6660.0,1508.4 5613.3,1521.9 5687.6,7102.1 1183.2,7206.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009d/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1112.0,
-                5330.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.787687,
-                46.878018
+                -96.78806059509682,
+                46.879245622249755
               ]
             }
           },
@@ -7872,20 +11134,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5620.0,
-                5330.7
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.786196,
-                46.878014
+                -96.78583170512604,
+                46.879231754800415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78585629048762,
+                46.87738494374176
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7880851804584,
+                46.8773988111911
               ]
             }
           }
@@ -7903,15 +11207,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7930,34 +11234,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1068.0,7372.2 1164.4,0.0 5597.0,0.0 5600.0,7372.2 1068.0,7372.2\" /></svg>"
+          "value": "<svg><polygon points=\"1106.4,0.0 5643.5,0.0 5600.0,7372.2 993.6,7362.0 1106.4,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009e/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5600.0,
-                7374.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.786159,
-                46.875933
+                -96.7880542663567,
+                46.877590566705585
               ]
             }
           },
@@ -7965,20 +11272,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1068.0,
-                7374.2
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7876899,
-                46.8759207
+                -96.78584094443453,
+                46.87761169250559
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78580349086835,
+                46.87577778080254
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78801681279052,
+                46.87575665500253
               ]
             }
           }
@@ -7996,15 +11345,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8023,34 +11372,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5592.0,871.8 5616.4,6331.7 1162.0,6314.3 1076.0,871.8 5592.0,871.8\" /></svg>"
+          "value": "<svg><polygon points=\"0,8070 0,0 6660,0 6660,8070 0,8070\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009f/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1076.0,
-                871.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.786196,
-                46.878014
+                -96.78656656197809,
+                46.878220880420784
               ]
             }
           },
@@ -8058,20 +11410,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5592.0,
-                871.8
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.784636,
-                46.87801
+                -96.78426594196036,
+                46.8782149813951
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78427640024117,
+                46.8763087363376
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7865770202589,
+                46.876314635363286
               ]
             }
           }
@@ -8089,15 +11483,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8116,34 +11510,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1756.1,8070.0 2344.3,3377.7 1144.0,3377.2 1076.5,0.0 5543.6,0.0 5587.5,3377.2 6660.0,3377.2 6660.0,5216.0 5557.9,6073.1 5158.9,8070.0 1756.1,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"1755.7,8070.0 2344.0,3377.7 1144.0,3377.2 1076.5,0.0 5543.6,0.0 5587.5,3377.2 6660.0,3377.2 6660.0,8070.0 1755.7,8070.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009g/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1144.0,
-                3375.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.786159,
-                46.875933
+                -96.78654414480899,
+                46.87673052317203
               ]
             }
           },
@@ -8151,20 +11548,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5580.0,
-                3375.2
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.784631,
-                46.875925
+                -96.78425007808222,
+                46.876718512351474
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78427137185867,
+                46.87481769721218
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78656543858543,
+                46.874829708032735
               ]
             }
           }
@@ -8182,15 +11621,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8209,34 +11648,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6188.0,7242.2 -0.0,7411.4 -0.0,1681.0 6204.0,991.8 6188.0,7242.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1681.1 6204.0,991.8 6188.0,7242.2 -0.0,7411.6 -0.0,1681.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009h/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6188.0,
-                7242.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7879377,
-                46.8743891
+                -96.78987526926991,
+                46.87632799951576
               ]
             }
           },
@@ -8244,20 +11686,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6204.0,
-                991.8
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7876899,
-                46.8759207
+                -96.78748804194804,
+                46.876151715056785
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78780057362253,
+                46.874173709019985
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.79018780094441,
+                46.87434999347896
               ]
             }
           }
@@ -8275,15 +11759,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8302,34 +11786,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1042.0,843.8 6660.0,53.0 6660.0,7225.0 1188.0,7418.2 1042.0,843.8\" /></svg>"
+          "value": "<svg><polygon points=\"1042.0,843.8 6660.0,53.0 6660.0,7224.9 4570.8,7305.6 4598.2,8070.0 1216.1,8070.0 1042.0,843.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd417m:g4174m:g4174fm:g065361958:06536_1958-0009i/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1188.0,
-                7418.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7879377,
-                46.8743891
+                -96.78800570363755,
+                46.87614890843726
               ]
             }
           },
@@ -8337,20 +11824,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1040.0,
-                843.8
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7876899,
-                46.8759207
+                -96.78574326453086,
+                46.87594301232251
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.7861083175559,
+                46.87406852310268
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -96.78837075666259,
+                46.87427441921743
               ]
             }
           }
@@ -8368,11 +11897,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -8391,8 +11920,8 @@
           "value": "5224.7"
         }
       ],
-      "created": "2026-08-07T16:19:50Z",
-      "modified": "2026-08-07T16:19:50Z",
+      "created": "2026-08-15T01:13:50Z",
+      "modified": "2026-08-15T01:13:50Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8411,7 +11940,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1100.0,647.6 6180.2,630.2 6206.3,0.0 6660.0,0.0 6660.0,5224.7 1118.3,5224.7 1100.0,647.6\" /></svg>"
+          "value": "<svg><polygon points=\"1100.0,647.6 5613.8,614.5 5599.3,4869.6 1100.0,4864.9 1100.0,647.6\" /></svg>"
         }
       },
       "body": {
@@ -8440,8 +11969,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.79026154096366,
-                46.874824272238726
+                -96.78992192567262,
+                46.87465456935833
               ]
             }
           },
@@ -8461,8 +11990,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.7857020827678,
-                46.874539492921265
+                -96.78754595799188,
+                46.87451754854973
               ]
             }
           },
@@ -8482,8 +12011,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.78602901592787,
-                46.8720922030648
+                -96.7877032935369,
+                46.873242511203756
               ]
             }
           },
@@ -8503,29 +12032,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -96.79058847412372,
-                46.872376982382264
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1100.0,
-                647.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -96.789549,
-                46.8744739
+                -96.79007926121763,
+                46.87337953201235
               ]
             }
           }

--- a/gallery/grand_rapids_mi_1953_vol7.iiif.json
+++ b/gallery/grand_rapids_mi_1953_vol7.iiif.json
@@ -7,282 +7,6 @@
   "label": "Mosaic of main content, Grand Rapids, Mich. | 1953 | Vol. 7",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p703",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4125.2,8070.0 723.8,8070.0 687.0,6847.0 -0.0,6861.2 -0.0,0.0 6660.0,0.0 6660.0,7462.9 6486.6,7470.7 6471.4,6726.9 4097.7,6776.2 4125.2,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.664461,
-                42.9277148
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6602139,
-                42.9277333
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6601833,
-                42.923964
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6644304,
-                42.9239455
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p711",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "13"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"960.1,6371.3 -0.0,6332.0 0.0,404.7 64.9,407.1 59.6,73.8 0.0,75.0 0.0,0.0 6660.0,-0.0 6660.0,8070.0 -0.0,8070.0 -0.0,6703.5 969.4,6672.7 960.1,6371.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6415186,
-                42.9276131
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6331786,
-                42.9277496
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6329526,
-                42.9203478
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6412927,
-                42.9202113
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0701/georef",
       "type": "Annotation",
       "@context": [
@@ -300,8 +24,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,157.5 5229.4,479.9 5280.6,8070.0 -0.0,8070.0 -0.0,157.5\" /></svg>"
+          "value": "<svg><polygon points=\"4396.6,0.0 4823.3,6805.5 1363.5,6983.8 990.1,264.5 1960.6,331.9 1949.5,33.1 4396.6,0.0\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66432807861206,
-                42.8986392758195
+                -85.6672673466573,
+                42.92768931426844
               ]
             }
           },
@@ -370,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66031038274697,
-                42.89872508496465
+                -85.66310731698371,
+                42.92761355759189
               ]
             }
           },
@@ -391,8 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66016941260105,
-                42.89513258036894
+                -85.66323264073212,
+                42.92391954973818
               ]
             }
           },
@@ -412,8 +136,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66418710846614,
-                42.89504677122378
+                -85.6673926704057,
+                42.92399530641473
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p702",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1178.3,6149.6 1202.0,0.0 4488.5,34.7 4476.5,1285.2 6660.0,6399.7 6660.0,8070.0 2202.1,8070.0 1178.3,6149.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66727338713461,
+                42.924456540844815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66312187137564,
+                42.92456983441654
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66293566910659,
+                42.92085926262484
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66708718486557,
+                42.920745969053115
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p703",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,7659.9 4195.3,7679.5 4198.4,8070.0 -0.0,8070.0 -0.0,-0.0 6660.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66454422751507,
+                42.927638563544015
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66039116236014,
+                42.92777173222901
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66017228331953,
+                42.92405996675762
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66432534847445,
+                42.92392679807262
               ]
             }
           }
@@ -438,8 +438,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +458,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2289.4,8065.0 2278.0,6322.6 819.9,6248.4 835.8,8070.0 -0.0,8070.0 -0.0,-0.0 750.3,0.0 762.4,1241.0 4236.0,1312.5 4227.3,0.0 6660.0,0.0 6660.0,754.5 4382.1,809.1 4556.1,8070.0 2289.4,8065.0\" /></svg>"
+          "value": "<svg><polygon points=\"4554.5,8070.0 -0.0,8070.0 0.0,0.0 182.8,0.0 203.4,1284.4 4389.8,1217.2 4554.5,8070.0\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +487,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66446519687149,
-                42.92450948783377
+                -85.66447466415113,
+                42.92451695943792
               ]
             }
           },
@@ -508,8 +508,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66030864313349,
-                42.92459079008437
+                -85.66030774579183,
+                42.924601176072265
               ]
             }
           },
@@ -529,8 +529,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66017501969182,
-                42.920875718707194
+                -85.66016933245828,
+                42.920876840607995
               ]
             }
           },
@@ -550,8 +550,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66433157342982,
-                42.92079441645659
+                -85.66433625081758,
+                42.920792623973654
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p705",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,2239.6 430.3,2257.8 426.6,354.4 1444.9,378.2 1453.5,2251.7 6660.0,2292.4 6660.0,8070.0 -0.0,8070.0 -0.0,2239.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66667293087029,
+                42.921807653691296
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66246190606562,
+                42.92189302021133
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66232061719505,
+                42.918155519603275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66653164199973,
+                42.91807015308324
               ]
             }
           }
@@ -576,8 +714,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +734,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 6360.4,0.0 6366.2,1235.8 6660.0,1235.7 6660.0,6784.8 6384.9,6786.6 6400.3,8070.0 -0.0,8070.0 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 6359.2,0.0 6374.5,4087.2 6092.0,4069.2 6081.6,7001.3 5783.2,6980.9 5790.6,8070.0 -0.0,8070.0 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +763,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66171689218734,
-                42.924190524337234
+                -85.66171981321875,
+                42.92419027248619
               ]
             }
           },
@@ -646,8 +784,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65754064968026,
-                42.92434610245528
+                -85.65753991641841,
+                42.92434895966801
               ]
             }
           },
@@ -667,8 +805,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65728495208913,
-                42.92061341665477
+                -85.65727910915724,
+                42.9206130051845
               ]
             }
           },
@@ -688,8 +826,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66146119459621,
-                42.92045783853672
+                -85.66145900595758,
+                42.92045431800268
               ]
             }
           }
@@ -714,8 +852,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +872,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"595.2,6824.2 -0.0,6824.0 -0.0,0.0 6660.0,0.0 6660.0,520.5 6517.5,523.3 6523.2,6102.9 5530.7,6091.3 5507.5,8070.0 597.9,8070.0 595.2,6824.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6827.4 -0.0,-0.0 6660.0,0.0 6660.0,553.9 6532.3,555.8 6513.0,6129.7 5507.9,6115.1 5479.4,8070.0 573.7,8064.1 576.5,6829.6 -0.0,6827.4\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +901,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65831455050471,
-                42.92745611985883
+                -85.65832181725641,
+                42.92745706357136
               ]
             }
           },
@@ -784,8 +922,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65417189750852,
-                42.92761138850183
+                -85.65418380186192,
+                42.9276259443772
               ]
             }
           },
@@ -805,8 +943,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65391669502513,
-                42.92390892090756
+                -85.65390622616981,
+                42.9239276216073
               ]
             }
           },
@@ -826,8 +964,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65805934802134,
-                42.92375365226456
+                -85.6580442415643,
+                42.92375874080146
               ]
             }
           }
@@ -852,8 +990,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +1010,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4255.5,8070.0 4252.6,6998.8 2546.2,6911.0 2286.1,6820.9 2285.3,6637.2 563.6,6645.4 574.9,1023.8 5208.3,1031.7 5204.5,1320.0 6660.0,1417.3 6660.0,8070.0 4255.5,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"299.4,6734.1 300.5,6895.8 -0.0,6875.8 -0.0,3901.4 286.7,3918.9 262.8,1012.9 6660.0,1396.5 6660.0,8070.0 4277.5,8070.0 4269.7,6990.5 2562.3,6910.4 2301.7,6821.5 2285.9,6608.5 299.4,6734.1\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +1039,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65789060106816,
-                42.924228177027075
+                -85.657880655223,
+                42.92423262116996
               ]
             }
           },
@@ -922,8 +1060,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65376865537368,
-                42.924387861701966
+                -85.65375912805403,
+                42.924378290735056
               ]
             }
           },
@@ -943,8 +1081,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65350620843816,
-                42.92070370710337
+                -85.65351971540544,
+                42.920694510210375
               ]
             }
           },
@@ -964,8 +1102,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65762815413264,
-                42.92054402242848
+                -85.6576412425744,
+                42.92054884064528
               ]
             }
           }
@@ -990,8 +1128,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1010,7 +1148,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6539.3,4376.9 6381.9,7272.2 260.3,7301.9 272.9,7011.0 -0.0,7014.9 0.0,0.0 2583.3,-0.0 2554.2,468.2 4441.9,462.8 4397.7,1183.9 5437.6,1182.9 5465.9,4394.5 6539.3,4376.9\" /></svg>"
+          "value": "<svg><polygon points=\"5434.8,1156.1 5460.6,4388.9 6542.5,4372.3 6381.9,7270.1 254.5,7293.5 267.6,6998.5 -0.0,7001.9 -0.0,0.0 2586.5,-0.0 2557.7,455.8 4447.1,452.4 4403.1,1159.7 5434.8,1156.1\" /></svg>"
         }
       },
       "body": {
@@ -1039,8 +1177,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64528407720016,
-                42.92759940082743
+                -85.64529376951073,
+                42.92759981394211
               ]
             }
           },
@@ -1060,8 +1198,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64511240437359,
-                42.924539782271204
+                -85.64511796922945,
+                42.92454319814545
               ]
             }
           },
@@ -1081,8 +1219,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65014127851013,
-                42.92438635169149
+                -85.65014190822129,
+                42.92438607870998
               ]
             }
           },
@@ -1102,8 +1240,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65031295133672,
-                42.92744597024772
+                -85.65031770850257,
+                42.92744269450664
               ]
             }
           }
@@ -1128,8 +1266,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1148,7 +1286,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6466.3,2695.8 6106.5,2684.7 6105.0,3047.8 6441.8,3049.2 6273.3,5501.3 5667.4,5483.1 5637.2,7317.8 108.3,7297.2 -0.0,-0.0 573.0,-0.0 556.4,288.3 6116.5,340.7 6113.1,1140.7 6572.5,1144.2 6660.0,1730.8 6532.5,1728.7 6466.3,2695.8\" /></svg>"
+          "value": "<svg><polygon points=\"6469.9,2699.7 6083.5,2688.0 6082.4,3103.2 6442.0,3103.9 6277.7,5507.7 5657.7,5489.3 5631.1,7325.9 108.2,7307.2 0.0,-0.0 570.9,-0.0 554.2,292.4 6089.6,342.6 6087.5,1143.3 6575.6,1146.8 6660.0,1718.9 6536.8,1717.2 6469.9,2699.7\" /></svg>"
         }
       },
       "body": {
@@ -1177,8 +1315,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64966598561675,
-                42.92760599566512
+                -85.64966338135095,
+                42.927604809198805
               ]
             }
           },
@@ -1198,8 +1336,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64943351050304,
-                42.92452315359095
+                -85.64943256999993,
+                42.92452447040119
               ]
             }
           },
@@ -1219,8 +1357,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65450055716813,
-                42.92431538174871
+                -85.65449550222473,
+                42.92431818552755
               ]
             }
           },
@@ -1240,8 +1378,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65473303228184,
-                42.927398223822884
+                -85.65472631357575,
+                42.92739852432516
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p711",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"812.1,6294.7 -0.0,6231.4 -0.0,253.3 359.1,281.2 496.9,291.4 500.9,0.0 6660.0,0.0 6660.0,753.9 6267.8,724.0 6276.9,2554.4 6660.0,2588.4 6660.0,8070.0 -0.0,8070.0 -0.0,6594.8 810.1,6599.5 812.1,6294.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64161289174552,
+                42.9274734797777
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.63333811038012,
+                42.9278330078086
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.63274302536199,
+                42.920489152435806
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64101780672739,
+                42.92012962440491
               ]
             }
           }
@@ -1266,8 +1542,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1286,7 +1562,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5068.4,8070.0 4027.0,8070.0 -0.0,6880.3 -0.0,3937.7 -0.0,720.9 2634.4,-0.0 3503.1,-0.0 4524.8,-0.0 6660.0,972.9 6660.0,8070.0 5068.4,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"4016.1,8070.0 -0.0,6895.6 0.0,0.0 3933.4,-0.0 4542.1,-0.0 6660.0,911.3 6660.0,8070.0 4016.1,8070.0\" /></svg>"
         }
       },
       "body": {
@@ -1315,8 +1591,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.6409933662752,
-                42.92756068628813
+                -85.64099466145012,
+                42.92756771236953
               ]
             }
           },
@@ -1336,8 +1612,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.6408178070742,
-                42.92450568187076
+                -85.64080471191646,
+                42.924513871665816
               ]
             }
           },
@@ -1357,8 +1633,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64583909055831,
-                42.92434877767922
+                -85.64582408269077,
+                42.924344106265636
               ]
             }
           },
@@ -1378,8 +1654,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64601464975931,
-                42.92740378209659
+                -85.64601403222443,
+                42.92739794696935
               ]
             }
           }
@@ -1404,8 +1680,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1424,7 +1700,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5359.0,6951.5 1514.9,7047.0 1451.8,2346.6 -0.0,2269.1 0.0,0.0 2849.6,0.0 2841.3,612.6 6660.0,811.6 6660.0,2606.8 5345.3,2533.9 5359.0,6951.5\" /></svg>"
+          "value": "<svg><polygon points=\"5326.6,6939.3 1495.6,7039.4 1462.0,2349.4 -0.0,2269.0 0.0,0.0 2850.8,0.0 2841.4,624.0 6660.0,829.4 6660.0,2617.9 5285.4,2539.4 5326.6,6939.3\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +1729,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.6546817005224,
-                42.92479040929421
+                -85.65468931719438,
+                42.92479432143385
               ]
             }
           },
@@ -1474,8 +1750,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65054310244396,
-                42.92490968727169
+                -85.6505352314711,
+                42.924919147273265
               ]
             }
           },
@@ -1495,8 +1771,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65034706334467,
-                42.9212106844049
+                -85.65033007423246,
+                42.921206301130916
               ]
             }
           },
@@ -1516,8 +1792,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65448566142312,
-                42.921091406427415
+                -85.65448415995574,
+                42.9210814752915
               ]
             }
           }
@@ -1542,8 +1818,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1562,7 +1838,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6124.9 0.0,0.0 6660.0,80.6 6594.0,3930.8 6281.9,4598.4 6660.0,4680.2 6660.0,5504.6 5883.9,5449.7 5504.2,6261.7 -0.0,6124.9\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,0.0 1930.6,0.0 2655.5,0.0 2719.3,0.0 5542.1,32.8 6660.0,112.8 6615.7,3977.7 5524.9,6314.9 -0.0,6175.4 0.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -1591,8 +1867,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65136654083344,
-                42.92470159496442
+                -85.65139944139813,
+                42.92471231349788
               ]
             }
           },
@@ -1612,8 +1888,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64713732623648,
-                42.92486176751352
+                -85.64715702412666,
+                42.92487693079397
               ]
             }
           },
@@ -1633,8 +1909,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64687407540762,
-                42.92108176654907
+                -85.6468846988672,
+                42.92110976470402
               ]
             }
           },
@@ -1654,8 +1930,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65110329000457,
-                42.92092159399997
+                -85.65112711613867,
+                42.92094514740793
               ]
             }
           }
@@ -1680,8 +1956,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1700,7 +1976,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1901.1,5112.7 -0.0,4704.2 -0.0,1022.4 607.1,0.0 6660.0,0.0 6660.0,783.7 5877.9,5358.4 1901.1,5112.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,4701.8 -0.0,1026.8 622.5,0.0 6660.0,0.0 6660.0,790.4 5876.4,5356.4 5881.1,7053.5 626.4,6677.0 1407.3,5002.7 -0.0,4701.8\" /></svg>"
         }
       },
       "body": {
@@ -1729,8 +2005,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64826394663909,
-                42.92499062950138
+                -85.64827462751431,
+                42.924993637429836
               ]
             }
           },
@@ -1750,8 +2026,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64406976205764,
-                42.92514595801938
+                -85.64407267896549,
+                42.92514982503198
               ]
             }
           },
@@ -1771,8 +2047,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64381447105083,
-                42.92139728923298
+                -85.64381597634707,
+                42.921394212000074
               ]
             }
           },
@@ -1792,8 +2068,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64800865563228,
-                42.92124196071497
+                -85.6480179248959,
+                42.92123802439793
               ]
             }
           }
@@ -1818,8 +2094,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,7 +2114,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7005.7 -0.0,3594.1 -0.0,636.2 2521.1,819.0 6660.0,1450.2 6660.0,8070.0 2332.4,8070.0 -0.0,7005.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7007.8 -0.0,3474.2 -0.0,643.3 2522.5,824.5 6660.0,1452.6 6660.0,4441.8 6660.0,8070.0 2338.7,8070.0 -0.0,7007.8\" /></svg>"
         }
       },
       "body": {
@@ -1867,8 +2143,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64457123825498,
-                42.92508338512917
+                -85.6445732203156,
+                42.92508690548672
               ]
             }
           },
@@ -1888,8 +2164,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64039060389237,
-                42.92524936495354
+                -85.64038935788852,
+                42.92525099174169
               ]
             }
           },
@@ -1909,8 +2185,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64011780685391,
-                42.921512807335624
+                -85.64011967315541,
+                42.92151154730008
               ]
             }
           },
@@ -1930,8 +2206,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64429844121652,
-                42.92134682751126
+                -85.6443035355825,
+                42.92134746104511
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p717",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5435.9,7670.8 6660.0,7659.1 6660.0,8070.0 -0.0,8070.0 -0.0,190.6 590.3,235.3 591.2,0.0 2534.1,0.0 2550.6,180.8 2804.9,270.9 4476.0,365.9 4472.8,1430.4 5382.4,1439.2 5435.9,7670.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6578715440367,
+                42.92118447107697
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65366490454377,
+                42.921362754151644
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65336983288746,
+                42.91762911997129
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65757647238038,
+                42.91745083689661
               ]
             }
           }
@@ -1956,8 +2370,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1976,7 +2390,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1880.1 1434.9,1896.5 1456.6,0.0 5237.0,0.0 5073.6,7785.9 6660.0,7819.0 6660.0,8070.0 -0.0,8070.0 -0.0,1880.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1880.4 1423.5,1907.4 1459.7,0.0 5241.7,0.0 5070.1,7790.7 6660.0,7827.1 6660.0,8070.0 -0.0,8070.0 -0.0,1880.4\" /></svg>"
         }
       },
       "body": {
@@ -2005,8 +2419,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65448865501584,
-                42.921544080655714
+                -85.65449874466921,
+                42.92153815307827
               ]
             }
           },
@@ -2026,8 +2440,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65028436725152,
-                42.92174245957097
+                -85.65029535469074,
+                42.921745722245056
               ]
             }
           },
@@ -2047,8 +2461,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64995833907965,
-                42.91798454706487
+                -85.64995422269106,
+                42.91798861220955
               ]
             }
           },
@@ -2068,8 +2482,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65416262684397,
-                42.91778616814961
+                -85.65415761266954,
+                42.91778104304276
               ]
             }
           }
@@ -2094,8 +2508,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2114,7 +2528,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 0.0,-0.0 5571.9,91.7 5615.3,8070.0 -0.0,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,-0.0 5579.0,91.8 5615.3,8070.0 -0.0,8070.0\" /></svg>"
         }
       },
       "body": {
@@ -2143,8 +2557,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65119100532952,
-                42.92183188982301
+                -85.65119378412973,
+                42.92182946870813
               ]
             }
           },
@@ -2164,8 +2578,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64698177982297,
-                42.92196560552971
+                -85.64698672076979,
+                42.92196594316315
               ]
             }
           },
@@ -2185,8 +2599,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.64676202219059,
-                42.91820329621286
+                -85.64676242921979,
+                42.91820556642597
               ]
             }
           },
@@ -2206,8 +2620,1378 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.65097124769714,
-                42.918069580506156
+                -85.65096949257973,
+                42.91806909197095
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0720/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p720",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0720/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0720",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,8070.0 -0.0,8070.0 -0.0,4540.5 661.9,4498.3 386.1,430.4 4238.6,437.4 4245.2,521.1 4274.6,898.0 5643.6,797.9 5759.6,2266.8 6660.0,2195.7 6660.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0720/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64813756482732,
+                42.92230062684761
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.63984095660417,
+                42.92218201020237
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64003727114034,
+                42.914818114827575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64833387936349,
+                42.914936731472814
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2766.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3893.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2766.8,0.0 2766.8,3893.0 430.3,3893.0 442.4,0.0 2766.8,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6483944617039,
+                42.91337770913036
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2766.8,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64663930190643,
+                42.91340957772606
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2766.8,
+                3893.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64657799853617,
+                42.91160198342749
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3893.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64833315833364,
+                42.91157011483179
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721__5/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "4707.6"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3222.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1952.4"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "4848.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721__5/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,7212.8 4900.9,7377.9 4896.1,6998.0 4707.6,7014.8 4707.6,3222.0 6660.0,3222.0 6660.0,7212.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721__5/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4707.6,
+                3222.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.62841253200222,
+                42.92722075471947
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                3222.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.62848619068218,
+                42.925377629823416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.63472962830164,
+                42.92551143065223
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4707.6,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.63465596962168,
+                42.927354555548284
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p722 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,6882.8 2349.3,6943.3 1849.9,6955.9 1542.9,6963.7 1539.5,8070.0 -0.0,8070.0 -0.0,127.4 234.4,137.1 240.0,-0.0 6660.0,-0.0 6660.0,6882.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64816642976798,
+                42.91515698679977
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64798317463567,
+                42.90897657051208
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65822065813357,
+                42.908814055116885
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65840391326589,
+                42.914994471404576
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p724 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3994.2"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5066.9,3994.2 -0.0,3994.2 0.0,0.0 561.7,-0.0 5213.4,525.5 5066.9,3994.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66133768372607,
+                42.913421980435096
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66104441514442,
+                42.907285356352304
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                3994.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66607136047892,
+                42.90715647401689
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3994.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66636462906058,
+                42.91329309809968
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p724 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3993.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "4077.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5479.3,7245.1 3894.5,7316.2 3909.0,7675.5 6660.0,7564.9 6660.0,8070.0 -0.0,8070.0 -0.0,4227.3 3193.0,4088.9 3196.6,3993.0 4373.9,3993.0 4442.7,4575.3 5417.0,4461.8 5361.6,3993.0 5578.3,3993.0 5479.3,7245.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3993.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66148013853913,
+                42.908599752088584
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                3993.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66153946310465,
+                42.902581406816516
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6665731526356,
+                42.90260802614577
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6665138280701,
+                42.90862637141784
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p725 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1063.3,3198.0 1001.8,2482.4 -0.0,1469.1 -0.0,541.1 2733.9,672.1 2724.7,111.8 -0.0,156.4 -0.0,0.0 6199.0,0.0 6296.5,5138.9 6660.0,5137.7 6660.0,8070.0 5332.8,8070.0 5292.8,6797.1 4904.3,6796.4 4903.5,7231.3 2317.2,7132.7 2294.5,5837.8 2291.6,5837.7 2232.3,3297.1 1063.3,3198.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66477696915774,
+                42.91347844150066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65637664230417,
+                42.91359290173615
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65618724042038,
+                42.90613562304546
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66458756727395,
+                42.906021162809964
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725__3/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p725 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3655.1"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1976.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2005.5"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725__3/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"844.9,5660.6 -0.0,5660.6 -0.0,3655.1 803.5,3655.1 844.9,5660.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725__3/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3655.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65843160906769,
+                42.90728237064806
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1976.0,
+                3655.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65717844013832,
+                42.90729781223356
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1976.0,
+                5660.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65715699458674,
+                42.90636602270714
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5660.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65841016351611,
+                42.90635058112164
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p726 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"668.0,7122.2 1158.5,1918.0 2314.4,1984.6 2363.8,1128.6 2895.0,1147.3 2961.9,-0.0 6660.0,-0.0 6660.0,5982.5 5612.0,6018.6 5655.3,7221.3 3338.8,7031.8 3316.3,7220.0 668.0,7122.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65728063750035,
+                42.90747458995076
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65697117283867,
+                42.904434525289105
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6620014450624,
+                42.90415978886324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66231090972408,
+                42.907199853524894
               ]
             }
           }
@@ -2248,8 +4032,8 @@
           "value": "2364.6"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2297,8 +4081,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66079645589477,
-                42.90538639289881
+                -85.66077142067442,
+                42.90470799303434
               ]
             }
           },
@@ -2318,8 +4102,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66069615357554,
-                42.90450627955542
+                -85.66063994539405,
+                42.90382680333094
               ]
             }
           },
@@ -2339,8 +4123,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66216157706273,
-                42.90441540636632
+                -85.66210716238838,
+                42.90370768776795
               ]
             }
           },
@@ -2360,8 +4144,730 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66226187938196,
-                42.90529551970971
+                -85.66223863766875,
+                42.904588877471355
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p727",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,-0.0 6660.0,8070.0 6270.9,8070.0 6163.6,6065.9 2437.5,6265.3 2441.2,4722.2 -0.0,4716.4 -0.0,0.0 6660.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65329422201758,
+                42.907287727368384
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65320778759131,
+                42.90426707163068
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65820596741787,
+                42.904190337256374
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65829240184414,
+                42.90721099299408
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p728 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3891.6"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7163.2 0.0,0.0 360.0,0.0 367.3,1586.3 3616.2,1816.1 3624.9,1599.7 3891.6,1579.0 3891.6,6670.9 3725.2,6669.7 3726.7,7428.5 -0.0,7163.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66606158719156,
+                42.90509143987852
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3891.6,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6612642311736,
+                42.905207510808985
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3891.6,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66093562613464,
+                42.89791851266583
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6657329821526,
+                42.897802441735365
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p728 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3814.8"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2845.2"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3814.8,8070.0 3814.8,7529.1 5621.9,7586.8 5745.9,3693.0 3814.8,3631.4 3814.8,591.2 5893.5,715.5 5887.2,0.0 6660.0,0.0 6660.0,8070.0 3814.8,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3814.8,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66387445604207,
+                42.89912701219965
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66019962788464,
+                42.899197428427776
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65992719698929,
+                42.8915672310504
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3814.8,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66360202514672,
+                42.891496814822275
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0729/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p729 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0729/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0729",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"606.7,7542.9 338.5,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,7538.5 606.7,7542.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0729/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6654049869927,
+                42.895700424884815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66125554775128,
+                42.89568303332689
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66128431848581,
+                42.891998429526204
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66543375772723,
+                42.89201582108413
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0809/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p809",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0809/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0809",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1684.1,8070.0 -0.0,8070.0 -0.0,-0.0 3949.1,0.0 3959.6,606.3 4775.1,632.8 4788.2,1572.6 5855.9,1578.1 5955.4,7574.3 6660.0,7562.6 6660.0,8070.0 5682.8,8070.0 5725.0,6363.3 3575.5,6309.8 1684.1,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0809/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.71101860163623,
+                42.933330496192575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70283165822514,
+                42.93354746556441
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70247501970483,
+                42.92623092442281
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.71066196311592,
+                42.926013955050976
               ]
             }
           }
@@ -2386,8 +4892,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2406,7 +4912,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1706.2,798.1 3661.3,826.0 3668.8,0.0 4464.2,0.0 4458.2,837.4 4748.2,841.5 4747.7,956.9 5490.9,960.8 5418.1,4345.9 6660.0,4372.6 6660.0,4467.7 5583.8,4397.8 5574.8,7868.2 6660.0,7871.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0 1717.6,0.0 1706.2,798.1\" /></svg>"
+          "value": "<svg><polygon points=\"1711.2,794.4 3664.6,824.7 3671.8,0.0 4467.3,0.0 4461.5,837.1 4751.6,841.6 4751.1,958.0 5497.1,961.7 5434.1,4347.9 5583.2,4350.7 5571.9,7873.2 6660.0,7876.7 6660.0,8070.0 -0.0,8070.0 -0.0,0.0 1723.5,0.0 1711.2,794.4\" /></svg>"
         }
       },
       "body": {
@@ -2435,8 +4941,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.70388657578502,
-                42.93405444460893
+                -85.70389058661634,
+                42.93405676065125
               ]
             }
           },
@@ -2456,8 +4962,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69560709419598,
-                42.93437739565796
+                -85.69561085934872,
+                42.934377694589365
               ]
             }
           },
@@ -2477,8 +4983,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69507624416582,
-                42.92697824541271
+                -85.69508332493992,
+                42.926978324787626
               ]
             }
           },
@@ -2498,8 +5004,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.70335572575486,
-                42.926655294363684
+                -85.70336305220754,
+                42.92665739084951
               ]
             }
           }
@@ -2524,8 +5030,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2544,7 +5050,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4886.6,0.0 5008.3,8070.0 -0.0,8070.0 -0.0,1363.0 1069.0,1345.6 1055.9,0.0 4886.6,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"4908.4,1887.5 4996.8,8070.0 -0.0,8070.0 -0.0,1345.4 1065.9,1330.8 1056.3,0.0 4896.0,0.0 4909.7,1600.7 6660.0,682.0 6660.0,1185.1 4908.4,1887.5\" /></svg>"
         }
       },
       "body": {
@@ -2573,8 +5079,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69702418067288,
-                42.934071217192574
+                -85.69702236517394,
+                42.93406164488534
               ]
             }
           },
@@ -2594,8 +5100,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69284056597517,
-                42.93416796494306
+                -85.69284891570383,
+                42.934166112134356
               ]
             }
           },
@@ -2615,8 +5121,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69268153266822,
-                42.930429284774846
+                -85.69267719313669,
+                42.930436516104514
               ]
             }
           },
@@ -2636,8 +5142,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69686514736594,
-                42.93033253702436
+                -85.69685064260679,
+                42.9303320488555
               ]
             }
           }
@@ -2662,8 +5168,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2682,7 +5188,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1243.9 2117.3,1375.8 2116.8,1188.8 3193.5,1209.2 3196.9,1449.1 6660.0,1671.4 6660.0,8070.0 -0.0,8070.0 -0.0,1243.9\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,1672.5 6660.0,8070.0 -0.0,8070.0 -0.0,1158.1 4060.9,1220.4 4052.2,1504.4 6660.0,1672.5\" /></svg>"
         }
       },
       "body": {
@@ -2711,8 +5217,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69669528761685,
-                42.93087288682988
+                -85.6967012969882,
+                42.930877930110704
               ]
             }
           },
@@ -2732,8 +5238,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69248553505915,
-                42.93102902606852
+                -85.69248104335797,
+                42.93103144087874
               ]
             }
           },
@@ -2753,8 +5259,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69222888770238,
-                42.92726679314924
+                -85.69222871644006,
+                42.92725982320818
               ]
             }
           },
@@ -2774,8 +5280,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69643864026008,
-                42.9271106539106
+                -85.69644897007028,
+                42.927106312440145
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0813/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p813",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0813/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0813",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1330.7,669.2 -0.0,624.4 -0.0,478.6 297.6,473.9 284.0,0.0 3233.6,0.0 3239.4,427.6 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,3994.4 1430.7,3949.9 1330.7,669.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0813/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69410088767316,
+                42.930837561404445
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.68580880619682,
+                42.93094975167822
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.68562310423269,
+                42.92359079714834
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69391518570903,
+                42.92347860687457
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0814/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p814",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0814/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0814",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1513.3,2799.3 654.7,3245.1 655.7,3086.5 866.4,3085.1 846.4,43.3 6660.0,0.0 6660.0,570.0 3582.7,550.7 3531.3,6033.7 670.1,5968.1 653.0,3386.3 1511.4,3046.9 1513.3,2799.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0814/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69492365884824,
+                42.93642096447509
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.68638327908663,
+                42.93667993917064
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.68595457103359,
+                42.929101378697005
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6944949507952,
+                42.92884240400146
               ]
             }
           }
@@ -2800,8 +5582,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2820,7 +5602,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6094.7 -0.0,-0.0 6660.0,0.0 6660.0,8070.0 6544.4,8070.0 6598.4,6298.8 -0.0,6094.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6273.7 0.0,-0.0 6660.0,0.0 6632.7,6286.4 -0.0,6273.7\" /></svg>"
         }
       },
       "body": {
@@ -2849,8 +5631,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69041241092874,
-                42.93599212413932
+                -85.69030012539802,
+                42.93604315291345
               ]
             }
           },
@@ -2870,8 +5652,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.68618308632263,
-                42.93619161732119
+                -85.68608866845194,
+                42.9361514826741
               ]
             }
           },
@@ -2891,8 +5673,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.6858551501846,
-                42.93241221046465
+                -85.68590933648052,
+                42.93241436929312
               ]
             }
           },
@@ -2912,8 +5694,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69008447479071,
-                42.93221271728277
+                -85.6901207934266,
+                42.93230603953247
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0816/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p816",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0816/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0816",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 6660.0,0.0 6660.0,8070.0 2196.7,8070.0 2180.5,6564.3 2089.1,6462.0 542.0,6319.9 537.0,8070.0 -0.0,8070.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0816/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69017774201905,
+                42.93313748085514
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.68596625215444,
+                42.93323986936319
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.68579676203699,
+                42.92950258243311
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69000825190159,
+                42.929400193925055
               ]
             }
           }
@@ -2938,8 +5858,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2958,7 +5878,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,8070.0 -0.0,8070.0 -0.0,-0.0 6660.0,0.0 6660.0,8070.0\" /></svg>"
         }
       },
       "body": {
@@ -2987,8 +5907,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.7019102094375,
-                42.937172305820255
+                -85.701900354211,
+                42.93717624846875
               ]
             }
           },
@@ -3008,8 +5928,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69769478928616,
-                42.93729230288023
+                -85.6976866197771,
+                42.937291243319166
               ]
             }
           },
@@ -3029,8 +5949,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.69749752876365,
-                42.93352539376669
+                -85.69749758227535,
+                42.93352584059249
               ]
             }
           },
@@ -3050,8 +5970,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.70171294891499,
-                42.93340539670672
+                -85.70171131670925,
+                42.933410845742074
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0818/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p818",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0818/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0818",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,8070.0 6239.1,8070.0 6243.6,6732.0 4937.1,6795.3 2486.7,8070.0 -0.0,8070.0 -0.0,37.6 6660.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0818/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69816991979361,
+                42.9371986219728
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69389727515224,
+                42.93734872633282
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69364878345999,
+                42.933557392246705
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69792142810137,
+                42.93340728788668
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0820/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p820 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0820/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0820",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2626.4,7140.0 1824.8,7117.8 1811.8,6517.8 -0.0,6527.1 -0.0,0.0 5170.6,0.0 5469.6,1470.7 6660.0,1225.0 6660.0,2562.2 5342.3,2570.4 5347.6,3503.4 6048.2,3527.9 6054.2,4452.1 5352.9,4427.2 5361.2,5885.1 3647.4,5922.5 3692.7,8070.0 2643.5,8070.0 2626.4,7140.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0820/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7086841,
+                42.9393793
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7003516,
+                42.9395687
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.700038,
+                42.93217490000001
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7083705,
+                42.9319855
               ]
             }
           }
@@ -3076,8 +6272,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3096,7 +6292,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4716.6,672.1 6660.0,762.0 6660.0,8070.0 -0.0,8070.0 0.0,0.0 4694.0,0.0 4716.6,672.1\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,763.8 6660.0,7062.7 5648.9,7055.5 5691.3,8070.0 -0.0,8070.0 -0.0,-0.0 4709.0,0.0 4730.3,671.1 6660.0,763.8\" /></svg>"
         }
       },
       "body": {
@@ -3125,8 +6321,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66868968334529,
-                42.89892925318181
+                -85.66870493829236,
+                42.8989254382796
               ]
             }
           },
@@ -3146,8 +6342,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66456668550818,
-                42.89892822580057
+                -85.66457343074202,
+                42.898930035039726
               ]
             }
           },
@@ -3167,8 +6363,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66456837334671,
-                42.895241611607915
+                -85.66456587893114,
+                42.89523581181334
               ]
             }
           },
@@ -3188,8 +6384,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66869137118383,
-                42.89524263898915
+                -85.66869738648148,
+                42.895231215053215
               ]
             }
           }
@@ -3214,8 +6410,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3234,7 +6430,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3096.8,952.6 6432.0,975.8 6438.8,0.0 6660.0,0.0 6660.0,8070.0 3013.9,8070.0 3096.8,952.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,5375.6 2847.9,5417.9 2807.4,961.4 5488.1,975.2 5624.3,7366.6 5026.3,7355.0 5019.8,7875.3 6660.0,7895.5 6660.0,8070.0 2872.0,8070.0 2865.1,7304.7 940.2,7261.5 957.0,8070.0 -0.0,8070.0\" /></svg>"
         }
       },
       "body": {
@@ -3263,8 +6459,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66863770864857,
-                42.89567689889152
+                -85.66863905615249,
+                42.89567293903226
               ]
             }
           },
@@ -3284,8 +6480,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66442837069441,
-                42.89569747019082
+                -85.66443031835412,
+                42.89569355907759
               ]
             }
           },
@@ -3305,8 +6501,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.6643945768045,
-                42.89193345661432
+                -85.66439644438573,
+                42.89193008216382
               ]
             }
           },
@@ -3326,8 +6522,438 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66860391475866,
-                42.89191288531502
+                -85.6686051821841,
+                42.891909462118484
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p824",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 0.0,0.0 3911.7,0.0 3897.8,979.4 6660.0,1018.6 6660.0,5255.1 3953.2,5190.3 3930.0,7751.5 4839.7,7759.8 4830.7,6991.1 6660.0,7048.8 6660.0,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67129853199096,
+                42.89568159133972
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66687152221316,
+                42.89573294041128
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66678716768553,
+                42.89177427745539
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67121417746333,
+                42.89172292838383
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0825/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p825",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0825/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0825",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0 6660.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0825/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.68326569967195,
+                42.927838605797454
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67903083954567,
+                42.92790015691707
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67892895773595,
+                42.92414185015749
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.68316381786222,
+                42.924080299037875
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0826__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p826 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "1639.2"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5020.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0826__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0826",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1639.2,1179.9 2434.1,776.3 2414.6,199.8 1639.2,226.0 1639.2,0.0 6660.0,0.0 6660.0,579.6 4879.9,7424.1 4882.3,8070.0 2680.3,8070.0 2658.3,7418.4 1639.2,3810.0 1639.2,1179.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0826__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1639.2,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67952066920793,
+                42.927997917370156
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67633772211113,
+                42.92796550446694
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67640880335074,
+                42.92421874852465
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1639.2,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67959175044754,
+                42.92425116142787
               ]
             }
           }
@@ -3352,8 +6978,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3372,7 +6998,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,0.0 5715.2,7242.4 5746.2,7242.7 5742.2,8070.0 -0.0,8070.0 0.0,-0.0 6660.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 6660.0,0.0 5740.5,8070.0 -0.0,8070.0 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -3401,8 +7027,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67748459951441,
-                42.92796840218501
+                -85.67748392359977,
+                42.927966456749296
               ]
             }
           },
@@ -3422,8 +7048,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67324846682206,
-                42.9279346352481
+                -85.67325206566657,
+                42.92793452652521
               ]
             }
           },
@@ -3443,8 +7069,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67330396713997,
-                42.92414864405727
+                -85.67330454709803,
+                42.9241523549874
               ]
             }
           },
@@ -3464,8 +7090,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67754009983233,
-                42.92418241099417
+                -85.67753640503122,
+                42.92418428521148
               ]
             }
           }
@@ -3490,8 +7116,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3510,7 +7136,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"54.6,282.7 2061.7,0.0 5385.0,0.0 5292.8,3981.0 131.2,3945.6 54.6,282.7\" /></svg>"
+          "value": "<svg><polygon points=\"26.5,203.1 2040.3,0.0 5130.9,0.0 5372.9,0.0 5365.1,356.6 2155.7,3917.9 112.1,3963.8 26.5,203.1\" /></svg>"
         }
       },
       "body": {
@@ -3539,8 +7165,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67702908802475,
-                42.926261705271344
+                -85.67701333883568,
+                42.92626534240952
               ]
             }
           },
@@ -3560,8 +7186,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67308812776996,
-                42.9262834542023
+                -85.6730825680447,
+                42.926281647509676
               ]
             }
           },
@@ -3581,8 +7207,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67305238194093,
-                42.9227611371626
+                -85.67305576951729,
+                42.92276843752001
               ]
             }
           },
@@ -3602,8 +7228,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67699334219573,
-                42.92273938823165
+                -85.67698654030826,
+                42.92275213241986
               ]
             }
           }
@@ -3628,8 +7254,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3648,7 +7274,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3957.4,8070.0 -0.0,8070.0 -0.0,1249.2 691.0,1263.4 644.5,310.2 -0.0,305.3 -0.0,-0.0 5653.3,108.0 5746.3,1351.1 5656.7,1351.3 5671.3,6659.6 3887.3,6648.9 3957.4,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,1253.6 687.9,1267.3 641.0,315.9 -0.0,311.4 -0.0,-0.0 5598.1,59.5 5529.1,6645.2 3880.9,6634.3 3952.5,8070.0 -0.0,8070.0\" /></svg>"
         }
       },
       "body": {
@@ -3677,8 +7303,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67381027212684,
-                42.92780194483419
+                -85.67380867408926,
+                42.92780503719805
               ]
             }
           },
@@ -3698,8 +7324,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66961118391485,
-                42.927753450595944
+                -85.66960182883545,
+                42.927754773776165
               ]
             }
           },
@@ -3719,8 +7345,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66969089020617,
-                42.92400055583693
+                -85.66968444299906,
+                42.92399494622113
               ]
             }
           },
@@ -3740,8 +7366,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67388997841816,
-                42.92404905007517
+                -85.67389128825286,
+                42.92404520964301
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0830/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p830",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0830/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0830",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8013.2 -0.0,0.0 6648.6,0.0 6660.0,291.9 5705.5,227.9 6148.3,7905.5 -0.0,8013.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0830/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67027320572004,
+                42.92773505530744
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6660428855665,
+                42.92765184119793
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66617965812115,
+                42.92387102908455
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67040997827469,
+                42.92395424319406
               ]
             }
           }
@@ -3766,8 +7530,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3786,7 +7550,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3673.1,0.0 5460.8,0.0 5736.6,3424.1 5771.2,8070.0 -0.0,8070.0 -0.0,1445.8 3749.0,1423.5 3673.1,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5313.3,0.0 5483.3,1470.6 5691.8,1467.7 5746.7,8070.0 -0.0,8070.0 -0.0,1459.6 3743.9,1434.6 3665.6,0.0 5313.3,0.0\" /></svg>"
         }
       },
       "body": {
@@ -3815,8 +7579,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67373586979198,
-                42.92471844902912
+                -85.67374119820725,
+                42.92472388566596
               ]
             }
           },
@@ -3836,8 +7600,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66954587553096,
-                42.924651626068936
+                -85.6695332903061,
+                42.92465293275351
               ]
             }
           },
@@ -3857,8 +7621,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66965570184573,
-                42.92090667130887
+                -85.66964990436925,
+                42.92089196704839
               ]
             }
           },
@@ -3878,8 +7642,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67384569610675,
-                42.920973494269056
+                -85.6738578122704,
+                42.92096291996084
               ]
             }
           }
@@ -3904,8 +7668,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3924,7 +7688,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5799.4,1230.1 6119.2,8070.0 -0.0,8070.0 -0.0,1258.9 5799.4,1230.1\" /></svg>"
+          "value": "<svg><polygon points=\"5801.6,1233.4 6123.7,8070.0 -0.0,8070.0 -0.0,1264.3 5801.6,1233.4\" /></svg>"
         }
       },
       "body": {
@@ -3953,8 +7717,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67014469148255,
-                42.92456435559299
+                -85.67015460576657,
+                42.92456837521657
               ]
             }
           },
@@ -3974,8 +7738,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.66594869595467,
-                42.9245204693992
+                -85.66594845981234,
+                42.92452326058215
               ]
             }
           },
@@ -3995,8 +7759,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.6660208245516,
-                42.92077014101198
+                -85.66602260738718,
+                42.92076385935929
               ]
             }
           },
@@ -4016,8 +7780,162 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.67021682007946,
-                42.92081402720577
+                -85.6702287533414,
+                42.920808973993715
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0834__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p834 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0834__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0834",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6902.5 -0.0,543.0 558.8,1043.4 762.1,1104.2 4579.6,1183.0 4650.4,-0.0 6660.0,-0.0 6660.0,6998.3 -0.0,6902.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0834__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70913406751421,
+                42.92518377282644
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70886870584613,
+                42.91906533785989
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.71899464451826,
+                42.91882980197011
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.71926000618635,
+                42.924948236936665
               ]
             }
           }
@@ -4042,8 +7960,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4062,7 +7980,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5924.1,461.8 6660.0,436.7 6660.0,760.9 6445.5,856.7 6563.1,3739.6 6579.2,3739.6 6660.0,8070.0 -0.0,8070.0 0.0,0.0 5908.0,0.0 5924.1,461.8\" /></svg>"
+          "value": "<svg><polygon points=\"5922.0,475.5 6660.0,449.2 6660.0,770.1 6438.6,869.3 6556.9,3742.4 6578.5,3742.2 6660.0,8070.0 -0.0,8070.0 0.0,-0.0 5904.7,0.0 5922.0,475.5\" /></svg>"
         }
       },
       "body": {
@@ -4091,8 +8009,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76959173642504,
-                42.90912150104043
+                -85.7696007149928,
+                42.90913245727892
               ]
             }
           },
@@ -4112,8 +8030,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76537341909152,
-                42.90919848027981
+                -85.76536951592189,
+                42.909205030024125
               ]
             }
           },
@@ -4133,8 +8051,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76524693225974,
-                42.905427264376016
+                -85.76525026952974,
+                42.905422297704824
               ]
             }
           },
@@ -4154,8 +8072,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76946524959327,
-                42.90535028513663
+                -85.76948146860066,
+                42.90534972495962
               ]
             }
           }
@@ -4180,8 +8098,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4200,7 +8118,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,1853.6 4831.7,0.0 6320.3,0.0 6318.8,428.7 6660.0,432.9 6660.0,3362.1 6360.2,3354.3 6356.5,3888.4 6362.0,4372.5 6660.0,4373.5 6660.0,5375.3 6389.1,5268.9 6366.9,4798.2 5663.0,4777.6 5577.3,8070.0 -0.0,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1860.9 222.6,1773.3 235.7,1456.5 1038.9,1461.0 4834.2,0.0 6313.9,0.0 6312.9,429.4 6660.0,433.3 6660.0,3887.5 6354.4,3885.4 6360.5,4370.2 6660.0,4370.9 6660.0,5370.6 6388.5,5264.4 6365.9,4794.2 5679.7,4774.9 5596.3,8070.0 -0.0,8070.0 -0.0,1860.9\" /></svg>"
         }
       },
       "body": {
@@ -4229,8 +8147,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76557393470121,
-                42.90967308612959
+                -85.76557444549267,
+                42.909677022284406
               ]
             }
           },
@@ -4250,8 +8168,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.7613040106937,
-                42.90987974902632
+                -85.7612996804338,
+                42.909880331780926
               ]
             }
           },
@@ -4271,8 +8189,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76096443408713,
-                42.906062427490944
+                -85.76096561394193,
+                42.90605868233443
               ]
             }
           },
@@ -4292,8 +8210,162 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76523435809462,
-                42.90585576459422
+                -85.76524037900082,
+                42.90585537283791
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0837__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p837 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0837__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0837",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,5708.2 6660.0,6573.5 5310.1,6581.1 1529.7,8070.0 -0.0,8070.0 -0.0,-0.0 6660.0,0.0 6660.0,2344.6 4328.0,2327.4 4340.5,1099.5 3647.5,1094.9 3616.9,5687.8 6660.0,5708.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0837__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76613932049622,
+                42.91277923083731
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76185417575681,
+                42.91296539481778
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76154620596574,
+                42.90916028774796
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76583135070516,
+                42.908974123767486
               ]
             }
           }
@@ -4318,8 +8390,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4338,7 +8410,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"623.8,4042.3 275.1,4039.2 275.1,3601.0 146.1,3601.5 148.4,2718.8 994.6,2727.3 3057.1,1923.5 3064.6,0.0 6660.0,0.0 6660.0,8070.0 6227.2,8070.0 6247.8,7163.9 633.6,7036.3 623.8,4042.3\" /></svg>"
+          "value": "<svg><polygon points=\"639.3,4046.0 284.5,4042.9 284.4,3604.1 154.7,3604.4 156.7,2724.2 1002.7,2732.4 3062.4,1928.7 3069.4,0.0 6660.0,0.0 6660.0,8070.0 6263.1,8070.0 6282.5,7220.8 646.9,7089.5 639.3,4046.0\" /></svg>"
         }
       },
       "body": {
@@ -4367,8 +8439,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76183531149164,
-                42.91152819088977
+                -85.76184087408394,
+                42.91153195655914
               ]
             }
           },
@@ -4388,8 +8460,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.7576566616526,
-                42.911720300779436
+                -85.75765711389828,
+                42.911723199972215
               ]
             }
           },
@@ -4409,8 +8481,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.75734098775149,
-                42.90798469642317
+                -85.75734286378666,
+                42.90798302709895
               ]
             }
           },
@@ -4430,8 +8502,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76151963759052,
-                42.9077925865335
+                -85.76152662397233,
+                42.90779178368587
               ]
             }
           }
@@ -4456,8 +8528,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4476,7 +8548,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1486.8 726.6,1489.1 762.1,1974.1 1045.8,2076.8 1017.5,1043.3 710.2,1050.2 680.9,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,1486.8\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1440.6 707.5,1442.2 743.1,1929.4 1026.2,2032.3 999.5,995.3 690.9,1002.5 672.0,499.9 986.9,493.8 974.5,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,1440.6\" /></svg>"
         }
       },
       "body": {
@@ -4505,8 +8577,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76177873288495,
-                42.90827140712883
+                -85.76176616946813,
+                42.908247502290344
               ]
             }
           },
@@ -4526,8 +8598,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.75763504885983,
-                42.90839222795778
+                -85.75761307236571,
+                42.90836576228105
               ]
             }
           },
@@ -4547,8 +8619,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.75743652739072,
-                42.90468768351016
+                -85.75741743567735,
+                42.904677910386404
               ]
             }
           },
@@ -4568,8 +8640,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.76158021141585,
-                42.904566862681214
+                -85.76157053277977,
+                42.9045596503957
               ]
             }
           }
@@ -4577,13 +8649,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0840/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p841 [2]",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p840 [1]",
       "metadata": [
         {
           "label": "streets",
@@ -4594,8 +8666,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4604,21 +8676,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0840/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0840",
           "type": "ImageService2",
           "height": 8070,
           "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3714.3,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,1044.3 4052.4,1165.5 4066.9,681.6 3717.2,668.0 3714.3,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"4007.3,4265.3 -0.0,4139.8 -0.0,0.0 6660.0,0.0 6660.0,8070.0 6495.8,8070.0 6491.4,6427.8 3564.0,6435.6 3560.3,5176.7 3829.8,5189.0 3838.6,4587.0 4002.5,4419.4 4007.3,4265.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0840/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -4643,8 +8715,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.72624201394605,
-                42.91995220912671
+                -85.72621567195931,
+                42.92591210269909
               ]
             }
           },
@@ -4664,8 +8736,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.71788472615779,
-                42.920051106066786
+                -85.71781962840866,
+                42.9260188632575
               ]
             }
           },
@@ -4685,8 +8757,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.71772220202489,
-                42.91258070011639
+                -85.71764292912333,
+                42.91856700519039
               ]
             }
           },
@@ -4706,8 +8778,162 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.72607948981313,
-                42.91248180317632
+                -85.72603897267398,
+                42.91846024463198
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p841 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1009.1,0.0 1016.5,886.1 1961.9,927.8 1959.9,1121.7 4060.0,1193.1 4076.4,707.8 3723.6,692.6 3723.4,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,0.0 1009.1,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.72626072106131,
+                42.91995793399906
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.71789145024525,
+                42.92008068815618
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.71768829588285,
+                42.912652010303816
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.72605756669891,
+                42.91252925614669
               ]
             }
           }
@@ -4732,8 +8958,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4752,7 +8978,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,0.0 297.3,-0.0 636.2,309.5 1831.0,289.8 1823.4,828.7 5690.5,695.9 5696.7,-0.0 6660.0,-0.0 6660.0,8062.4 -0.0,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"6258.0,6069.3 4508.8,6143.7 4573.8,8070.0 -0.0,8070.0 0.0,0.0 305.6,-0.0 647.8,316.3 1840.7,296.6 1833.2,834.7 5694.3,702.1 5700.6,-0.0 6660.0,-0.0 6660.0,4186.4 6277.0,4187.7 6258.0,6069.3\" /></svg>"
         }
       },
       "body": {
@@ -4781,8 +9007,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.72107510746122,
-                42.92203200782498
+                -85.72107042421474,
+                42.922037791727085
               ]
             }
           },
@@ -4802,8 +9028,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.72113336716374,
-                42.9189334514598
+                -85.72112872784223,
+                42.91893448336566
               ]
             }
           },
@@ -4823,8 +9049,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.72622578204569,
-                42.91898552507541
+                -85.72622895253379,
+                42.918986596242235
               ]
             }
           },
@@ -4844,2516 +9070,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.72616752234316,
-                42.9220840814406
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p702",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1206.2,6114.6 1211.5,0.0 4505.1,0.0 4404.0,8061.2 5227.7,8066.2 5223.7,6259.4 6660.0,6341.8 6660.0,8070.0 2221.6,8070.0 2222.7,6143.6 1206.2,6114.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3232.0,
-                2183.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.665196,
-                42.923505
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3232.0,
-                6174.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.665113,
-                42.921653
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p705",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,2226.3 430.3,2244.4 426.6,354.4 1444.9,378.2 1453.7,2308.6 6660.0,2291.4 6660.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2288.0,
-                5726.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.665126,
-                42.9191848
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2456.0,
-                399.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.665113,
-                42.921653
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p717",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1704.0,2284.3 599.6,2219.3 594.6,1379.4 595.5,1282.5 589.7,0.0 2550.1,0.0 2549.8,181.1 2804.2,271.2 4476.0,365.9 4473.0,1422.5 5394.0,1426.9 5430.5,7658.5 6660.0,7650.3 6660.0,8070.0 531.4,8070.0 552.6,5614.0 1477.5,5697.6 1704.0,2284.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2376.0,
-                4071.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.656222,
-                42.9193653
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4476.0,
-                367.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.655031,
-                42.921135
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0720/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p720",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "14"
-        },
-        {
-          "label": "intersections",
-          "value": "25"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0720/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0720",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,4541.8 662.4,4504.9 386.2,430.0 550.1,0.0 3029.2,0.0 3061.0,434.9 4238.7,437.1 4274.7,897.8 5479.8,808.9 5537.3,2181.4 6660.0,2134.4 6660.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0720/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2716.0,
-                6242.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.644906,
-                42.916556
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6192.0,
-                5386.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.640555,
-                42.917275
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721__3/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [3]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "3841.2"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "2818.8"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "3227.2"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721__3/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6113.9,2117.6 6123.4,3227.2 3841.2,3227.2 3841.2,0.0 6098.5,0.0 6108.2,419.9 6660.0,442.8 6660.0,3147.0 6601.4,3095.1 6576.3,2151.4 6113.9,2117.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0721__3/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3841.2,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.66030227245962,
-                42.92047805517356
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.65673399046072,
-                42.92058349756382
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                3227.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.65656903442067,
-                42.91759484779362
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3841.2,
-                3227.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.66013731641958,
-                42.917489405403366
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6108.2,
-                419.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.657411,
-                42.920174
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p722 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6660.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8070.0"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,6887.0 2349.2,6947.5 1848.9,6960.1 1541.4,6968.0 1538.0,8070.0 -0.0,8070.0 -0.0,120.0 230.5,129.5 235.9,-0.0 6660.0,-0.0 6660.0,6887.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.64817620602896,
-                42.915152959677854
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.64799326722539,
-                42.90898321181312
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.65821307912985,
-                42.90882097694643
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.65839601793343,
-                42.91499072481117
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2416.0,
-                4518.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.65383,
-                42.912824
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p724 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6660.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "3994.2"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5062.2,3994.2 -0.0,3994.2 -0.0,0.0 6660.0,-0.0 6660.0,526.8 5062.2,3994.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2128.0,
-                3710.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6659127,
-                42.9113354
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5732.0,
-                527.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6617495,
-                42.9081234
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p724 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "3993.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6660.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "4077.0"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3909.0,7675.6 6660.0,7564.6 6660.0,8070.0 -0.0,8070.0 -0.0,4227.6 1513.6,4161.8 1499.8,3993.0 3604.8,3993.0 3660.6,4599.6 4633.7,4511.2 4586.0,3993.0 5577.6,3993.0 5532.2,7243.0 3894.5,7316.2 3909.0,7675.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3952.0,
-                7314.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6656163,
-                42.905052
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1852.0,
-                4148.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6616891,
-                42.9069272
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p725 [3]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6660.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8070.0"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2291.6,5837.7 2251.5,3331.0 2082.6,3244.6 1063.3,3198.0 1001.8,2482.4 -0.0,1469.1 -0.0,541.1 2728.3,671.9 2718.7,117.0 -0.0,164.2 0.0,-0.0 6199.0,0.0 6296.3,5131.5 6660.0,5130.4 6660.0,6871.8 6323.1,6872.6 6336.1,8070.0 5332.8,8070.0 5305.6,6634.2 2833.8,6753.2 2818.2,5856.6 2291.6,5837.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0725__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3488.0,
-                703.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.660361,
-                42.912888
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2276.0,
-                4538.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6617997,
-                42.9093233
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p726 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6660.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8070.0"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3884.9,1182.2 3823.3,1836.7 6660.0,1988.5 6660.0,6814.6 6069.1,6790.1 6060.4,5931.2 4131.1,5948.3 4142.6,7098.0 -0.0,6758.6 -0.0,1040.6 3884.9,1182.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                668.0,
-                7122.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6616891,
-                42.9069272
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3328.0,
-                7122.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6615655,
-                42.905713
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p727",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5402.5 -0.0,0.0 6660.0,-0.0 6660.0,8070.0 3404.5,8070.0 3431.3,7407.1 2434.8,7424.0 2439.4,5460.6 -0.0,5402.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3500.0,
-                5394.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.65659,
-                42.905649
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                572.0,
-                5394.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.656628,
-                42.906977
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p728 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "3891.6"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8070.0"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7163.2 0.0,0.0 360.0,0.0 367.1,1639.6 3615.7,1816.1 3655.7,825.2 3891.6,813.1 3891.6,6670.9 3725.2,6669.7 3726.7,7428.5 1168.7,7259.7 1165.2,8070.0 945.7,8070.0 973.4,7241.1 -0.0,7163.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1739.8,
-                7314.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.663619,
-                42.898537
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3715.6,
-                1823.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.661407,
-                42.903557
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p728 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "3814.8"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "2845.2"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8070.0"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3814.8,4305.1 5926.8,4298.7 5887.2,0.0 6660.0,0.0 6660.0,8070.0 3814.8,8070.0 3814.8,4305.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4945.7,
-                675.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.662391,
-                42.898516
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5932.7,
-                5982.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6609396,
-                42.8935229
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0809/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p809",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0809/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0809",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,0.0 3961.2,0.0 3969.4,696.4 4772.6,726.7 4782.2,1767.1 5836.8,1757.4 5903.6,7620.4 6660.0,7611.3 6660.0,8070.0 5627.8,8070.0 5677.4,6415.6 3560.5,6352.1 1712.3,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0809/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3092.0,
-                3411.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.7070799,
-                42.9303961
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4800.0,
-                5150.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.7048594,
-                42.9288694
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0813/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p813",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "14"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0813/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0813",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"301.2,632.9 283.1,0.0 6660.0,0.0 6660.0,8070.0 6293.5,8070.0 6293.5,8070.0 -0.0,8070.0 -0.0,3987.2 1429.5,3941.6 1405.0,3160.0 301.2,632.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0813/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4772.0,
-                5326.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6880369,
-                42.9260606
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3792.0,
-                3243.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.689305,
-                42.927944
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0814/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p814",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0814/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0814",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 6660.0,0.0 6660.0,8070.0 2108.4,8070.0 -0.0,6431.5 -0.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0814/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1548.0,
-                1027.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.692884,
-                42.935516
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                668.0,
-                1867.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6939932,
-                42.9346772
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0816/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p816",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0816/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0816",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,1794.7 6660.0,8070.0 -0.0,8070.0 0.0,0.0 6660.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0816/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5800.0,
-                1163.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6864856,
-                42.9326869
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5800.0,
-                6574.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.686372,
-                42.930182
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0818/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p818",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "20"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0818/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0818",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,37.6 5545.2,0.0 6660.0,0.0 6660.0,1858.2 6238.5,5666.2 4865.7,6782.7 2486.7,8070.0 -0.0,8070.0 -0.0,37.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0818/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2508.0,
-                3775.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6964447,
-                42.9354816
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5288.0,
-                168.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.694771,
-                42.937238
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0820/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p820 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "12"
-        },
-        {
-          "label": "intersections",
-          "value": "20"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0820/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0820",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2604.5,7041.1 1810.6,7003.9 1808.8,6315.2 -0.0,6298.6 -0.0,0.0 6660.0,0.0 6660.0,2583.2 6078.9,2576.6 6078.5,2598.9 5375.0,2568.5 5364.0,3489.1 6064.3,3527.0 6052.6,4443.0 5353.0,4404.6 5335.7,5851.9 3642.5,5856.9 3647.4,8070.0 2604.5,8070.0 2604.5,7041.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0820/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4124.0,
-                4338.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.7033757,
-                42.9354789
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3372.0,
-                7082.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.70415,
-                42.93291
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p824",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 0.0,0.0 3741.2,0.0 3745.8,1001.9 6660.0,988.4 6660.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3680.0,
-                5098.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.668751,
-                42.893167
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1700.0,
-                5098.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.67012,
-                42.893172
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0825/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p825",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0825/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0825",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0 6660.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0825/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6464.0,
-                3623.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.679111,
-                42.926211
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6464.0,
-                7186.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.679066,
-                42.924551
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0830/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p830",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0830/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0830",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1243.0 89.0,1243.0 0.0,-0.0 6660.0,0.0 6660.0,6822.3 5958.0,6854.4 6012.4,8070.0 -0.0,8019.0 -0.0,1243.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0830/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                992.0,
-                2299.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.669636,
-                42.926635
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5908.0,
-                6054.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.666546,
-                42.9248589
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0837__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p837 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6660.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8070.0"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0837__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0837",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,5708.1 6660.0,6574.8 5302.5,6584.0 1530.8,8070.0 -0.0,8070.0 -0.0,-0.0 6660.0,0.0 6660.0,2344.5 4328.0,2327.4 4340.5,1099.5 3647.7,1094.9 3617.2,5687.8 6660.0,5708.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0837__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4328.0,
-                2327.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.7632658,
-                42.9118028
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4328.0,
-                6986.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.763088,
-                42.909606
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0840/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p840 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0840/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0840",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3998.8,4421.2 4003.5,4271.5 -0.0,4146.0 -0.0,0.0 6660.0,0.0 6660.0,8070.0 6493.8,8070.0 6496.1,6460.0 3564.1,6456.4 3560.3,5176.7 3829.8,5189.0 3838.6,4587.0 3998.8,4421.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0840/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3272.0,
-                2207.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.722045,
-                42.923928
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                868.0,
-                7326.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.724961,
-                42.919161
+                -85.7261706489063,
+                42.92208990460366
               ]
             }
           }
@@ -7371,15 +9089,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7398,34 +9116,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,-0.0 968.0,0.0 1022.8,1827.6 2738.0,1776.2 4537.6,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"2378.0,8070.0 2365.0,7442.8 2165.9,7434.6 1172.0,7396.2 1153.8,3616.9 1229.0,3344.9 1683.3,2809.4 4537.6,0.0 6660.0,0.0 6660.0,8070.0 2378.0,8070.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0843/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1172.0,
-                3491.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.71049,
-                42.924506
+                -85.71199868334102,
+                42.927680384377965
               ]
             }
           },
@@ -7433,20 +9154,216 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1172.0,
-                7398.2
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.710436,
-                42.920942
+                -85.70369978438482,
+                42.927747805342094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7035881899148,
+                42.92038257031905
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.711887088871,
+                42.92031514935492
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0844__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p844 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0844__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0844",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0 6660.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0844__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70296356407783,
+                42.941851126136264
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69886326298915,
+                42.942568730293274
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6976835156694,
+                42.938904982725404
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70178381675808,
+                42.93818737856839
               ]
             }
           }
@@ -7464,11 +9381,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -7487,8 +9404,8 @@
           "value": "5072.7"
         }
       ],
-      "created": "2026-08-07T14:29:02Z",
-      "modified": "2026-08-07T14:29:02Z",
+      "created": "2026-08-15T01:21:52Z",
+      "modified": "2026-08-15T01:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7507,34 +9424,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3334.4,1356.2 3325.4,0.0 6660.0,0.0 6660.0,2090.7 6470.5,2092.6 6481.7,4178.5 4270.0,5072.7 -0.0,5072.7 -0.0,-0.0 764.8,0.0 760.0,1356.2 3334.4,1356.2\" /></svg>"
+          "value": "<svg><polygon points=\"3333.5,1356.2 3324.5,0.0 6660.0,0.0 6660.0,2082.5 6470.6,2084.4 6481.7,4178.4 4269.9,5072.7 -0.0,5072.7 0.0,0.0 764.8,0.0 760.0,1356.2 3333.5,1356.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0845__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3484.0,
-                1356.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.761677,
-                42.911864
+                -85.76375067703981,
+                42.91236493723506
               ]
             }
           },
@@ -7542,20 +9462,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                760.0,
-                1356.2
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -85.7632658,
-                42.9118028
+                -85.7598661660266,
+                42.91251456719104
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                5072.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.75971056669155,
+                42.91034807464111
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5072.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76359507770476,
+                42.91019844468513
               ]
             }
           }

--- a/gallery/hudson_co_nj_1950_vol_9.iiif.json
+++ b/gallery/hudson_co_nj_1950_vol_9.iiif.json
@@ -7,6 +7,144 @@
   "label": "Mosaic of main content, Hudson Co., N.J. | 1950 | Vol. 9",
   "items": [
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p10",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5714
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5714.0,5367.9 5285.3,5334.7 5340.1,7236.4 2176.8,6397.4 2173.9,4997.6 969.9,4891.0 1344.0,1183.9 0.0,1058.0 -0.0,0.0 2152.1,0.0 2166.5,1410.0 5714.0,1422.4 5714.0,5367.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09466016873169,
+                40.71365561315818
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0926698657218,
+                40.715780331459534
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08866929678406,
+                40.71362729817199
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09065959979395,
+                40.71150257987064
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0011/georef",
       "type": "Annotation",
       "@context": [
@@ -24,8 +162,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +182,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3453.7,1891.1 3239.3,0.0 5696.0,0.0 5604.7,5070.5 1204.0,5174.1 1245.2,1523.1 3453.7,1891.1\" /></svg>"
+          "value": "<svg><polygon points=\"3455.3,1891.1 3241.2,0.0 5696.0,0.0 5611.8,5069.7 1203.1,5174.3 1244.9,1522.3 3455.3,1891.1\" /></svg>"
         }
       },
       "body": {
@@ -73,8 +211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09145340825361,
-                40.713073684137676
+                -74.09145187113084,
+                40.71307340013726
               ]
             }
           },
@@ -94,8 +232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08925194606476,
-                40.71507549601355
+                -74.08925285242486,
+                40.7150737025666
               ]
             }
           },
@@ -115,8 +253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08550058808416,
-                40.71267164215182
+                -74.08550432312344,
+                40.71267251682666
               ]
             }
           },
@@ -136,8 +274,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08770205027302,
-                40.71066983027594
+                -74.08770334182942,
+                40.71067221439732
               ]
             }
           }
@@ -162,8 +300,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -182,7 +320,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5714.0,8150.0 4633.8,8150.0 4649.2,6325.1 2016.6,6472.3 1025.2,6769.8 1236.2,0.0 5714.0,0.0 5714.0,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"5714.0,8150.0 4627.6,8150.0 4643.7,6322.2 2013.7,6468.2 1023.2,6765.0 1236.7,0.0 5714.0,0.0 5714.0,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -211,8 +349,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08906586120105,
-                40.71153203857805
+                -74.08906732247381,
+                40.71153194708084
               ]
             }
           },
@@ -232,8 +370,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08695302469197,
-                40.713547687810326
+                -74.08695333600433,
+                40.71355029480012
               ]
             }
           },
@@ -253,8 +391,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08318454365819,
-                40.71124589377265
+                -74.08317980969727,
+                40.71124724804961
               ]
             }
           },
@@ -274,8 +412,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08529738016729,
-                40.70923024454037
+                -74.08529379616675,
+                40.70922890033033
               ]
             }
           }
@@ -300,8 +438,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +458,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"304.3,618.9 2966.9,1153.4 2974.1,0.0 4201.1,0.0 4341.8,1420.7 5372.4,1636.3 5369.5,5971.4 2247.8,5986.1 2231.2,7003.8 293.3,7046.9 304.3,618.9\" /></svg>"
+          "value": "<svg><polygon points=\"300.0,618.7 2962.2,1157.2 2968.2,0.0 4203.9,0.0 4343.3,1427.8 5375.3,1645.3 5366.0,6004.4 2238.7,6014.1 2220.9,7017.4 279.6,7057.7 300.0,618.7\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +487,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09305677071515,
-                40.71171567292501
+                -74.09305456867958,
+                40.71171651344874
               ]
             }
           },
@@ -370,8 +508,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09087502047356,
-                40.71365026980198
+                -74.09088022757511,
+                40.71365024350564
               ]
             }
           },
@@ -391,8 +529,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08724970278458,
-                40.7112678871148
+                -74.08725653289856,
+                40.71127595218388
               ]
             }
           },
@@ -412,8 +550,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08943145302617,
-                40.70933329023782
+                -74.08943087400303,
+                40.709342222126985
               ]
             }
           }
@@ -438,8 +576,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +596,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4291.0,7068.9 3269.2,7298.3 434.1,7174.0 425.6,8150.0 280.0,8150.0 287.8,7180.8 -0.0,7155.0 -0.0,2580.6 1059.8,2589.0 1071.8,1077.7 2385.5,1054.7 2407.7,0.0 5645.8,0.0 5649.6,6464.2 4290.6,6940.4 4291.0,7068.9\" /></svg>"
+          "value": "<svg><polygon points=\"5655.6,6477.1 4290.8,7084.9 3264.2,7315.6 -0.0,7174.1 0.0,0.0 359.4,0.0 355.4,1078.7 2375.2,1043.0 2396.9,0.0 5650.4,0.0 5655.6,6477.1\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +625,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09041686364995,
-                40.70993747690706
+                -74.0904019806739,
+                40.70994004986643
               ]
             }
           },
@@ -508,8 +646,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08831850236409,
-                40.7118160581849
+                -74.08831290870768,
+                40.711809576610754
               ]
             }
           },
@@ -529,8 +667,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08480636850403,
-                40.709529979684945
+                -74.08481770338902,
+                40.70953361812884
               ]
             }
           },
@@ -550,8 +688,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0869047297899,
-                40.7076513984071
+                -74.08690677535525,
+                40.707664091384515
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p15",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5696
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1037.4,662.5 4178.8,494.5 4203.9,6359.7 1015.4,6364.0 1037.4,662.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09651786929096,
+                40.70860175172889
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0942360241297,
+                40.71053678398696
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09058451677974,
+                40.70806241604186
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.092866361941,
+                40.706127383783794
               ]
             }
           }
@@ -576,8 +852,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +872,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5053.4,6733.4 5714.0,6716.6 5714.0,8150.0 -0.0,8150.0 -0.0,473.8 1290.2,458.5 1284.9,0.0 1943.5,0.0 1944.1,423.0 5044.0,413.9 5053.4,6733.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,533.8 5026.7,399.8 5072.5,5641.6 4736.7,5649.1 4775.4,8150.0 -0.0,8150.0 -0.0,533.8\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +901,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09482268807939,
-                40.71002504053615
+                -74.09486418338436,
+                40.710033757519085
               ]
             }
           },
@@ -646,8 +922,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09258986561056,
-                40.71199229033091
+                -74.09257015504113,
+                40.711995847582024
               ]
             }
           },
@@ -667,8 +943,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08891199366728,
-                40.70955969962513
+                -74.08887605258577,
+                40.70951408218023
               ]
             }
           },
@@ -688,8 +964,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09114481613611,
-                40.707592449830365
+                -74.091170080929,
+                40.70755199211729
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p17",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5696
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1736.0,898.1 1740.7,0.0 4933.4,0.0 5030.4,6456.0 3495.4,7174.6 1509.6,7248.8 566.9,7832.7 246.7,7596.3 276.5,908.8 1736.0,898.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09395475188988,
+                40.70642304125498
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0916794142555,
+                40.7083578821152
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08802837327676,
+                40.7058904996591
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09030371091114,
+                40.703955658798876
               ]
             }
           }
@@ -714,8 +1128,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +1148,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6624.3 -0.0,1924.0 4657.7,1851.2 4759.5,6172.7 5031.9,6190.7 5199.1,8150.0 2728.4,8150.0 2695.7,6023.4 775.3,6254.2 -0.0,6624.3\" /></svg>"
+          "value": "<svg><polygon points=\"774.7,6248.0 -0.0,6598.5 -0.0,1951.8 4694.1,1962.3 4779.3,6179.5 5031.9,6196.9 5055.9,8150.0 2727.6,8150.0 2701.5,6022.7 774.7,6248.0\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +1177,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09199228230707,
-                40.708189790527044
+                -74.09200657855817,
+                40.70818053038615
               ]
             }
           },
@@ -784,8 +1198,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08969351266958,
-                40.71015234136319
+                -74.08971076530305,
+                40.71015305449039
               ]
             }
           },
@@ -805,8 +1219,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08605255117078,
-                40.7076669942512
+                -74.08605130203516,
+                40.707670903151914
               ]
             }
           },
@@ -826,8 +1240,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08835132080827,
-                40.70570444341505
+                -74.08834711529028,
+                40.705698379047675
               ]
             }
           }
@@ -852,8 +1266,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +1286,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5689.0,565.1 5689.0,5643.2 3478.7,5005.7 2751.3,4963.1 1878.5,8007.7 1530.2,7440.6 1324.9,8149.0 -0.0,8149.0 -0.0,1782.9 365.2,1776.4 332.3,512.5 5689.0,565.1\" /></svg>"
+          "value": "<svg><polygon points=\"4831.1,549.7 4816.0,5384.6 3478.0,5000.3 2750.6,4958.5 1881.1,8004.2 1534.4,7441.1 1329.2,8149.0 -0.0,8149.0 -0.0,1872.5 363.7,1873.3 326.5,510.5 4831.1,549.7\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +1315,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09575247688903,
-                40.70903001608309
+                -74.09575027073657,
+                40.70902748176354
               ]
             }
           },
@@ -922,8 +1336,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09318487243107,
-                40.70731088097903
+                -74.0931852805529,
+                40.70730622851213
               ]
             }
           },
@@ -943,8 +1357,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09641073278296,
-                40.70450302109561
+                -74.09641511683117,
+                40.70450122869088
               ]
             }
           },
@@ -964,8 +1378,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09897833724092,
-                40.70622215619968
+                -74.09898010701484,
+                40.70622248194229
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p20",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5755
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5396.6 -0.0,541.7 2087.6,567.9 2087.6,2027.5 5755.0,2070.8 5755.0,7125.5 -0.0,5396.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09357534009597,
+                40.70756178673934
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5755.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09098022307812,
+                40.70583373179768
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5755.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09420863842062,
+                40.70304753453739
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09680375543847,
+                40.70477558947905
               ]
             }
           }
@@ -990,8 +1542,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1010,7 +1562,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1056.0,6094.4 1041.2,1307.7 4609.4,1297.8 4386.6,857.3 5048.3,1714.2 5293.8,1711.7 5337.8,1307.1 5689.0,1299.6 5689.0,8149.0 5062.7,8149.0 5070.3,7269.5 1056.0,6094.4\" /></svg>"
+          "value": "<svg><polygon points=\"1061.7,6094.2 1045.8,1064.5 4062.6,1054.2 4300.0,733.9 5086.5,1785.4 5298.0,1712.4 5341.9,1308.0 5689.0,1300.7 5689.0,7365.1 5086.7,6666.6 5075.6,7269.0 1061.7,6094.2\" /></svg>"
         }
       },
       "body": {
@@ -1039,8 +1591,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09184861877453,
-                40.70579989618332
+                -74.09185045089521,
+                40.705802171201405
               ]
             }
           },
@@ -1060,8 +1612,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08930407761817,
-                40.7040706769185
+                -74.08930529518535,
+                40.70407233313297
               ]
             }
           },
@@ -1081,8 +1633,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09254870398806,
-                40.70128790433012
+                -74.09255108264972,
+                40.70128888845405
               ]
             }
           },
@@ -1102,8 +1654,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09509324514443,
-                40.70301712359495
+                -74.09509623835957,
+                40.70301872652249
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p22",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5755
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1274.8,704.5 3370.2,749.9 4914.7,6311.0 1317.3,6324.3 1274.8,704.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0931851034539,
+                40.70325934185459
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5755.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09132131679151,
+                40.701040756155976
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5755.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09546587194028,
+                40.69903959871889
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09732965860267,
+                40.701258184417505
               ]
             }
           }
@@ -1128,8 +1818,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1148,7 +1838,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"484.0,791.0 1195.4,629.3 5689.0,636.8 5689.0,7150.9 3352.4,7133.2 2853.0,8149.0 -0.0,8149.0 -0.0,3514.2 493.0,3962.6 484.0,791.0\" /></svg>"
+          "value": "<svg><polygon points=\"477.2,798.5 1188.2,636.0 4900.5,634.8 4926.3,7144.5 3352.2,7134.5 2855.0,8149.0 -0.0,8149.0 -0.0,3524.1 490.1,3968.8 477.2,798.5\" /></svg>"
         }
       },
       "body": {
@@ -1177,8 +1867,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0962320767348,
-                40.70687010964592
+                -74.09622539916968,
+                40.70686929809988
               ]
             }
           },
@@ -1198,8 +1888,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09439528480506,
-                40.70467628396935
+                -74.09439131308096,
+                40.70467285200864
               ]
             }
           },
@@ -1219,8 +1909,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09851175398349,
-                40.7026675608647
+                -74.09851269917522,
+                40.70266708802271
               ]
             }
           },
@@ -1240,8 +1930,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.10034854591322,
-                40.704861386541275
+                -74.10034678526394,
+                40.70486353411395
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p24",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5250.4,8150.0 3785.1,8150.0 3765.9,7195.6 -0.0,7132.8 -0.0,639.9 5747.0,731.1 5747.0,7238.5 5247.2,7233.0 5250.4,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09464292243703,
+                40.7049799066749
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09276071463952,
+                40.70277643712784
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.096882873315,
+                40.70075274361794
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0987650811125,
+                40.702956213165
               ]
             }
           }
@@ -1266,8 +2094,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1286,7 +2114,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4776.9,5906.2 1172.1,5716.5 -0.0,3498.2 -0.0,-0.0 4102.2,0.0 4027.2,1455.3 5007.8,2001.6 4776.9,5906.2\" /></svg>"
+          "value": "<svg><polygon points=\"4690.5,7295.2 3741.3,7266.8 3702.8,8149.0 676.1,8149.0 778.8,6425.4 1540.0,6424.2 -0.0,3498.8 -0.0,-0.0 4110.1,0.0 4031.2,1460.9 5009.9,2007.8 4690.5,7295.2\" /></svg>"
         }
       },
       "body": {
@@ -1315,8 +2143,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.1019201125673,
-                40.70322758132177
+                -74.1019213059983,
+                40.70322649718134
               ]
             }
           },
@@ -1336,8 +2164,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09912872795655,
-                40.70474967774962
+                -74.09913333439563,
+                40.7047507607746
               ]
             }
           },
@@ -1357,8 +2185,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0962647277332,
-                40.70168828960968
+                -74.09626525683731,
+                40.70169311530837
               ]
             }
           },
@@ -1378,8 +2206,698 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09905611234393,
-                40.70016619318183
+                -74.09905322843998,
+                40.70016885171511
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p26",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3311.5,5543.2 802.8,5519.5 838.8,2508.5 3921.1,2341.9 3923.4,2924.9 5747.0,2904.1 5747.0,7072.4 3297.6,7742.8 3311.5,5543.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0999454239119,
+                40.70109704106356
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0970727940263,
+                40.70249537680897
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09445695864937,
+                40.6994066780891
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09732958853498,
+                40.69800834234369
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p27",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5674
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4464.3 -0.0,620.2 -0.0,620.2 -0.0,-0.0 4474.2,0.0 5674.0,1220.9 5674.0,2831.0 4963.2,7592.4 693.0,7558.8 -0.0,4464.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10277729559857,
+                40.700895134549086
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5674.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0998947100078,
+                40.702301692474165
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5674.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09722947006705,
+                40.699162390328674
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10011205565782,
+                40.697755832403594
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p28",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"607.9,7414.2 607.9,697.8 2764.2,694.7 3578.7,2287.0 4409.6,4589.0 4693.6,4462.8 4597.7,5110.0 5430.1,7416.2 607.9,7414.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09634998258535,
+                40.700209298418656
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09449127713474,
+                40.69797651081361
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09866799401476,
+                40.69597794814615
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10052669946538,
+                40.698210735751196
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0003/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p3",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0003/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0003/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5711
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,8149 0,0 5711,0 5711,8149 0,8149\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0003/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09631411235743,
+                40.71732275829725
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5711.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09344167701393,
+                40.71548003045346
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5711.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09688529389547,
+                40.71235235072816
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09975772923897,
+                40.71419507857195
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p30",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3610.5,7531.0 131.0,8009.1 185.3,7794.9 -0.0,7813.5 0.0,0.0 5547.4,0.0 5747.0,380.4 5747.0,593.8 5276.0,828.7 3610.5,7531.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10314330401171,
+                40.697470915493945
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10075700621135,
+                40.69935100162114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0972401733406,
+                40.69678506763625
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09962647114095,
+                40.694904981509055
               ]
             }
           }
@@ -1404,8 +2922,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1424,7 +2942,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1467.7 5217.5,1558.5 4975.1,8051.4 -0.0,8149.0 -0.0,1467.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1459.2 2900.2,1490.6 5235.5,1568.3 4957.2,8046.5 -0.0,8149.0 -0.0,1459.2\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +2971,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0989127316755,
-                40.695388465990035
+                -74.09892266404998,
+                40.69539419431938
               ]
             }
           },
@@ -1474,8 +2992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0969620902619,
-                40.69323672704381
+                -74.09696063222529,
+                40.69324546444251
               ]
             }
           },
@@ -1495,8 +3013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.10101027830123,
-                40.691097110536205
+                -74.10100315429075,
+                40.69109335146102
               ]
             }
           },
@@ -1516,8 +3034,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.10296091971482,
-                40.69324884948242
+                -74.10296518611544,
+                40.693242081337885
               ]
             }
           }
@@ -1542,8 +3060,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1562,7 +3080,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1482.2 468.4,1472.8 523.1,2939.2 3395.7,2881.0 3415.9,1838.1 4086.3,2867.0 5747.0,6474.6 5747.0,6877.1 3641.2,8017.1 3674.5,8150.0 -0.0,8150.0 -0.0,1482.2\" /></svg>"
+          "value": "<svg><polygon points=\"450.7,1473.8 513.7,2941.3 3395.4,2876.5 3414.7,1753.9 3508.8,1895.4 4083.9,2861.1 5747.0,6452.3 5747.0,6874.7 3644.8,8019.2 3677.7,8150.0 -0.0,8150.0 -0.0,1483.8 450.7,1473.8\" /></svg>"
         }
       },
       "body": {
@@ -1591,8 +3109,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09715770272521,
-                40.69335917160548
+                -74.0971534915742,
+                40.69335468724432
               ]
             }
           },
@@ -1612,8 +3130,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09533731130684,
-                40.6911816626074
+                -74.09534100632774,
+                40.69117593964936
               ]
             }
           },
@@ -1633,8 +3151,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09938168039375,
-                40.689210289722986
+                -74.09938767590707,
+                40.68921312866694
               ]
             }
           },
@@ -1654,8 +3172,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.10120207181212,
-                40.69138779872107
+                -74.10120016115353,
+                40.6913918762619
               ]
             }
           }
@@ -1680,8 +3198,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1700,7 +3218,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,237.2 5674.0,329.7 5674.0,6474.7 4789.0,6466.0 1919.9,8149.0 -0.0,8149.0 -0.0,237.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,239.6 5674.0,339.5 5674.0,6492.6 4817.6,6481.3 1910.5,8149.0 -0.0,8149.0 -0.0,239.6\" /></svg>"
         }
       },
       "body": {
@@ -1729,8 +3247,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0970387146868,
-                40.69736929281987
+                -74.09705110012672,
+                40.69737636530592
               ]
             }
           },
@@ -1750,8 +3268,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0951539327879,
-                40.69521381978629
+                -74.09515936327261,
+                40.695228269479664
               ]
             }
           },
@@ -1771,8 +3289,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09920926514673,
-                40.69314650391224
+                -74.09920081341579,
+                40.69315332372838
               ]
             }
           },
@@ -1792,8 +3310,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.10109404704562,
-                40.69530197694582
+                -74.1010925502699,
+                40.69530141955464
               ]
             }
           }
@@ -1818,8 +3336,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,7 +3356,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2670.8,1679.3 3397.0,3276.2 5747.0,6687.2 5747.0,7793.3 2917.9,7904.8 2835.9,6461.1 885.8,6516.3 695.5,1748.6 2670.8,1679.3\" /></svg>"
+          "value": "<svg><polygon points=\"591.8,345.8 -0.0,356.5 -0.0,-0.0 1976.5,-0.0 3399.0,3280.3 5747.0,6683.9 5747.0,7793.3 2902.9,7905.5 2815.7,6457.7 858.8,6513.2 591.8,345.8\" /></svg>"
         }
       },
       "body": {
@@ -1867,8 +3385,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09533063922991,
-                40.69546660946909
+                -74.09533580722498,
+                40.69545352538316
               ]
             }
           },
@@ -1888,8 +3406,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09353973581875,
-                40.693230041878955
+                -74.09355032802179,
+                40.6932234069282
               ]
             }
           },
@@ -1909,8 +3427,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09769392862201,
-                40.69129066432429
+                -74.097692542224,
+                40.69128990327334
               ]
             }
           },
@@ -1930,8 +3448,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09948483203317,
-                40.69352723191442
+                -74.09947802142719,
+                40.693520021728304
               ]
             }
           }
@@ -1956,8 +3474,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1976,7 +3494,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5716.0,2148.7 5716.0,5182.6 3353.6,5168.7 3385.7,2646.5 5716.0,2148.7\" /></svg>"
+          "value": "<svg><polygon points=\"5716.0,5160.4 2226.8,5124.0 1936.2,5249.4 1127.8,2923.0 325.0,1312.3 5716.0,1362.1 5716.0,5160.4\" /></svg>"
         }
       },
       "body": {
@@ -2005,8 +3523,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09527353327897,
-                40.69943649820378
+                -74.09525413552556,
+                40.69941472751388
               ]
             }
           },
@@ -2026,8 +3544,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09342974635679,
-                40.697252416744966
+                -74.09338493764754,
+                40.697222753442276
               ]
             }
           },
@@ -2047,8 +3565,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09750739857962,
-                40.695245695816496
+                -74.09750896488327,
+                40.69520398378915
               ]
             }
           },
@@ -2068,8 +3586,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0993511855018,
-                40.6974297772753
+                -74.0993781627613,
+                40.697395957860756
               ]
             }
           }
@@ -2094,8 +3612,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2114,7 +3632,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3210.3,5165.7 3110.3,5167.0 1013.6,5194.2 941.8,1376.0 2821.1,1356.7 4040.9,3542.0 5233.0,6487.5 3258.6,6547.0 3210.3,5165.7\" /></svg>"
+          "value": "<svg><polygon points=\"1016.8,1368.4 2809.8,1348.1 3589.1,2593.2 4560.6,4828.3 2585.0,4821.1 2583.7,5177.4 1085.0,5199.0 1016.8,1368.4\" /></svg>"
         }
       },
       "body": {
@@ -2143,8 +3661,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09370035799849,
-                40.697616535061634
+                -74.09369791230418,
+                40.697605887029916
               ]
             }
           },
@@ -2164,8 +3682,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0918937312721,
-                40.695385330513126
+                -74.09190104927984,
+                40.69537966519308
               ]
             }
           },
@@ -2185,8 +3703,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0960380926908,
-                40.6934289874339
+                -74.09603615553728,
+                40.693433894940384
               ]
             }
           },
@@ -2206,8 +3724,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0978447194172,
-                40.695660191982405
+                -74.09783301856162,
+                40.69566011677722
               ]
             }
           }
@@ -2232,8 +3750,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2252,7 +3770,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"371.4,7744.9 774.0,5911.5 -0.0,5746.2 -0.0,1194.5 1912.0,729.0 5309.6,554.4 4138.1,5995.5 1987.1,7182.7 371.4,7744.9\" /></svg>"
+          "value": "<svg><polygon points=\"375.6,7747.2 1905.2,735.5 4860.7,579.5 3658.6,6258.9 1989.0,7183.4 375.6,7747.2\" /></svg>"
         }
       },
       "body": {
@@ -2281,8 +3799,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09693109715556,
-                40.69858470038396
+                -74.09693262477052,
+                40.698589832942865
               ]
             }
           },
@@ -2302,8 +3820,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09450563446691,
-                40.70042760098629
+                -74.09450168957322,
+                40.7004318371435
               ]
             }
           },
@@ -2323,8 +3841,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.091064915239,
-                40.69778783835821
+                -74.09106264393894,
+                40.69778611848732
               ]
             }
           },
@@ -2344,8 +3862,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09349037792767,
-                40.69594493775588
+                -74.09349357913624,
+                40.69594411428669
               ]
             }
           }
@@ -2370,8 +3888,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2390,7 +3908,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4504.6,1422.4 5259.5,1211.5 5516.4,3817.1 5289.0,3950.6 3391.5,6947.9 2111.0,7271.0 2141.6,5958.8 852.5,7099.1 1068.2,7398.8 424.6,7477.6 425.2,1870.1 4334.7,814.5 4504.6,1422.4\" /></svg>"
+          "value": "<svg><polygon points=\"5747.0,446.2 5260.9,1230.0 5517.9,3828.9 5290.1,3962.0 3385.7,6956.8 2104.1,7277.4 2137.3,5964.7 -0.0,7841.8 -0.0,1985.4 5747.0,446.2\" /></svg>"
         }
       },
       "body": {
@@ -2419,8 +3937,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09525706958571,
-                40.700726509574245
+                -74.09526012602107,
+                40.700724472151244
               ]
             }
           },
@@ -2440,8 +3958,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09238442004113,
-                40.70213535233819
+                -74.09239247164741,
+                40.7021371038807
               ]
             }
           },
@@ -2461,8 +3979,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08976738839796,
-                40.6990248464956
+                -74.08976840171516,
+                40.699032006810775
               ]
             }
           },
@@ -2482,8 +4000,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09264003794254,
-                40.697616003731646
+                -74.09263605608882,
+                40.69761937508132
               ]
             }
           }
@@ -2508,8 +4026,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2528,7 +4046,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4284.8,7215.2 1732.4,6747.5 1774.0,682.1 4568.4,642.0 4627.1,5168.3 4284.8,7215.2\" /></svg>"
+          "value": "<svg><polygon points=\"1354.9,1084.0 1109.7,1084.3 281.7,-0.0 4560.6,-0.0 4620.6,5168.6 4288.0,7214.5 1742.6,6748.2 1731.7,6735.4 1746.1,676.3 1399.6,680.5 1354.9,1084.0\" /></svg>"
         }
       },
       "body": {
@@ -2557,8 +4075,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09035097627115,
-                40.70439713693536
+                -74.0903436,
+                40.7043861
               ]
             }
           },
@@ -2578,8 +4096,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08777590966625,
-                40.70267115542134
+                -74.0877603,
+                40.7026631
               ]
             }
           },
@@ -2599,8 +4117,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09099852911612,
-                40.69986873568352
+                -74.0910002,
+                40.6998714
               ]
             }
           },
@@ -2620,8 +4138,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09357359572101,
-                40.701594717197544
+                -74.0935835,
+                40.7015944
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0004/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p4",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0004/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0004/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5715
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,8149 0,0 5715,0 5715,8149 0,8149\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0004/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10002230977359,
+                40.70785446238406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5715.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09685310433154,
+                40.70704667552907
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5715.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09836142410336,
+                40.70359784899583
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10153062954541,
+                40.70440563585082
               ]
             }
           }
@@ -2646,8 +4302,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2666,7 +4322,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3305.6 571.2,2873.9 5074.7,2939.2 5057.9,3894.2 5346.1,3920.3 5356.6,6716.2 437.9,6742.6 403.6,3598.7 -0.0,3550.8 -0.0,3305.6\" /></svg>"
+          "value": "<svg><polygon points=\"4019.2,1902.9 3989.1,6725.5 1080.3,6740.7 1085.1,2485.9 1567.1,2121.7 2212.9,1913.7 4019.2,1902.9\" /></svg>"
         }
       },
       "body": {
@@ -2695,8 +4351,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09176757084481,
-                40.70467475238352
+                -74.09176737348938,
+                40.70467445235808
               ]
             }
           },
@@ -2716,8 +4372,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08950245924946,
-                40.70665806383007
+                -74.08950333551476,
+                40.706657408453815
               ]
             }
           },
@@ -2737,8 +4393,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08581805539743,
-                40.70420556890677
+                -74.08581959179905,
+                40.704206075967456
               ]
             }
           },
@@ -2758,8 +4414,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08808316699277,
-                40.70222225746022
+                -74.08808362977366,
+                40.70222311987172
               ]
             }
           }
@@ -2784,8 +4440,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2804,7 +4460,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1368.9,7047.4 1337.8,4238.3 1048.1,4214.2 1073.4,1763.8 2370.2,1152.9 4139.4,1006.5 4161.3,3141.6 5716.0,3149.7 5716.0,3704.1 4488.4,3907.0 4565.0,7119.6 1368.9,7047.4\" /></svg>"
+          "value": "<svg><polygon points=\"3295.5,7088.4 -0.0,7064.8 -0.0,2219.6 2369.4,1155.3 3192.8,1086.6 3295.5,7088.4\" /></svg>"
         }
       },
       "body": {
@@ -2833,8 +4489,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09031215877793,
-                40.70616327078833
+                -74.09031445659728,
+                40.70616473433925
               ]
             }
           },
@@ -2854,8 +4510,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08805081080163,
-                40.708114250664444
+                -74.08804961054871,
+                40.70811585910247
               ]
             }
           },
@@ -2875,8 +4531,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08440788356044,
-                40.70565338849705
+                -74.08440641277004,
+                40.7056511902349
               ]
             }
           },
@@ -2896,8 +4552,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08666923153675,
-                40.703702408620934
+                -74.08667125881861,
+                40.70370006547168
               ]
             }
           }
@@ -2922,8 +4578,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2942,7 +4598,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2479.5,3013.1 3403.1,3032.0 3401.0,3414.7 4708.6,3199.0 4698.1,7101.4 1269.9,6958.3 1242.3,3750.3 2471.1,3566.4 2479.5,3013.1\" /></svg>"
+          "value": "<svg><polygon points=\"5747.0,7147.8 -0.0,6909.9 -0.0,911.6 945.3,849.0 932.1,2986.5 3271.1,3029.6 3283.2,1067.1 5747.0,1158.1 5747.0,7147.8\" /></svg>"
         }
       },
       "body": {
@@ -2971,8 +4627,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08897543893805,
-                40.707199800991255
+                -74.08897759738355,
+                40.70719649095276
               ]
             }
           },
@@ -2992,8 +4648,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0867379208014,
-                40.70919057504326
+                -74.086743537542,
+                40.709188707863824
               ]
             }
           },
@@ -3013,8 +4669,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0830395114759,
-                40.70676804939779
+                -74.0830424477097,
+                40.70676992646002
               ]
             }
           },
@@ -3034,8 +4690,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08527702961257,
-                40.704777275345776
+                -74.08527650755124,
+                40.70477770954896
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p43",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5716
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2321.2,1231.9 2378.2,1221.8 3643.2,998.5 3665.0,2876.3 4416.0,2743.6 4446.8,7246.1 2361.2,7192.4 2321.2,1231.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08768873680535,
+                40.70841424101506
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.085426624146,
+                40.71037643724815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08173677969332,
+                40.70793207138691
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08399889235267,
+                40.70596987515382
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p44",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5785
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5482.3,7841.3 742.4,7783.3 764.1,3213.7 -0.0,3339.5 -0.0,1433.7 2099.5,533.1 4927.3,275.1 4919.5,521.2 4963.9,2108.7 5785.0,2079.5 5785.0,8150.0 5483.3,8150.0 5482.3,7841.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.086440885277,
+                40.70978347664291
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5785.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0842162562012,
+                40.711758811121214
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5785.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08054351989898,
+                40.70938207876255
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08276814897478,
+                40.70740674428425
               ]
             }
           }
@@ -3060,8 +4992,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3080,7 +5012,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7828.6 -0.0,4685.1 1112.7,4695.3 1270.9,-0.0 4488.6,-0.0 4377.8,6282.7 4625.2,6286.7 4590.5,7895.0 -0.0,7828.6\" /></svg>"
+          "value": "<svg><polygon points=\"1254.5,-0.0 4489.9,-0.0 4406.5,4734.8 5710.0,4748.8 5710.0,6322.4 4653.7,6293.6 4608.3,7901.2 999.2,7851.8 1254.5,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -3109,8 +5041,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0813776144341,
-                40.70974216790633
+                -74.0813701003344,
+                40.70973587172283
               ]
             }
           },
@@ -3130,8 +5062,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.07877142904043,
-                40.70807065751796
+                -74.07877101425427,
+                40.70806494105216
               ]
             }
           },
@@ -3151,8 +5083,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08189478131976,
-                40.70523261394434
+                -74.08189328743819,
+                40.70523463214506
               ]
             }
           },
@@ -3172,8 +5104,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08450096671342,
-                40.70690412433271
+                -74.08449237351832,
+                40.70690556281573
               ]
             }
           }
@@ -3198,8 +5130,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3218,7 +5150,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6288.5 0.0,0.0 3671.3,161.2 5056.8,4151.1 5400.4,8150.0 1412.5,8150.0 1412.3,7875.4 238.6,7878.7 244.9,6291.2 -0.0,6288.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,88.6 3657.8,162.4 5047.2,4149.1 5226.3,6341.4 1314.5,6303.9 1287.2,4751.6 -0.0,4760.6 -0.0,88.6\" /></svg>"
         }
       },
       "body": {
@@ -3247,8 +5179,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0792989432147,
-                40.708454465177724
+                -74.07929126858653,
+                40.70845270090878
               ]
             }
           },
@@ -3268,8 +5200,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0766708066802,
-                40.70670748564037
+                -74.07666461105107,
+                40.70670268100022
               ]
             }
           },
@@ -3289,8 +5221,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0798960649223,
-                40.70387972255157
+                -74.07989548239972,
+                40.70387650925145
               ]
             }
           },
@@ -3310,8 +5242,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08252420145678,
-                40.70562670208892
+                -74.08252213993518,
+                40.70562652916001
               ]
             }
           }
@@ -3336,8 +5268,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3356,7 +5288,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"861.8,6452.8 981.9,3042.1 5710.0,3032.3 5710.0,6431.1 861.8,6452.8\" /></svg>"
+          "value": "<svg><polygon points=\"875.7,6465.5 988.2,3050.8 5710.0,3030.4 5710.0,6432.9 875.7,6465.5\" /></svg>"
         }
       },
       "body": {
@@ -3385,8 +5317,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08316945756212,
-                40.70806571804758
+                -74.08316572159102,
+                40.70806784066841
               ]
             }
           },
@@ -3406,8 +5338,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08057795322934,
-                40.706345614602746
+                -74.08058215676989,
+                40.70634516850117
               ]
             }
           },
@@ -3427,8 +5359,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08379202366656,
-                40.70352348627692
+                -74.08380102604164,
+                40.70353168544839
               ]
             }
           },
@@ -3448,8 +5380,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08638352799935,
-                40.70524358972175
+                -74.08638459086276,
+                40.70525435761563
               ]
             }
           }
@@ -3474,8 +5406,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3494,7 +5426,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1200.1,6500.7 1185.5,3357.1 5179.5,3341.3 5429.2,6454.7 1200.1,6500.7\" /></svg>"
+          "value": "<svg><polygon points=\"1166.4,3049.8 -0.0,3058.6 -0.0,1434.4 5057.9,1467.6 5656.8,8150.0 3535.5,8098.7 3524.7,6484.4 1202.0,6511.7 1166.4,3049.8\" /></svg>"
         }
       },
       "body": {
@@ -3523,8 +5455,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08109177467108,
-                40.70670706038948
+                -74.08109845375586,
+                40.706671670868495
               ]
             }
           },
@@ -3544,8 +5476,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.07849600298508,
-                40.704967753660945
+                -74.07853335408582,
+                40.70494983569877
               ]
             }
           },
@@ -3565,8 +5497,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08170700562067,
-                40.702174735372864
+                -74.08173452041771,
+                40.70220914925276
               ]
             }
           },
@@ -3586,8 +5518,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08430277730668,
-                40.7039140421014
+                -74.08429962008775,
+                40.703930984422485
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p49",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5710
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1097.5,932.3 4520.3,915.8 4487.2,6950.7 1075.6,6924.8 1097.5,932.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08880031235633,
+                40.70320231427707
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0865761644805,
+                40.705185893327815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08284373828836,
+                40.70278071331479
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08506788616418,
+                40.70079713426404
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0005/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p5",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0005/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0005/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5711
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,8149 0,0 5711,0 5711,8149 0,8149\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0005/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10126106815639,
+                40.70868476929815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5711.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09912996297928,
+                40.71068124559243
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5711.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0953730962616,
+                40.70837678706221
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09750420143871,
+                40.706380310767926
               ]
             }
           }
@@ -3612,8 +5820,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3632,7 +5840,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1330.4,6974.5 1235.7,969.1 4404.0,1047.3 4492.0,8149.0 2904.8,8149.0 2895.6,6942.6 1330.4,6974.5\" /></svg>"
+          "value": "<svg><polygon points=\"1338.9,6973.9 1248.9,966.8 4418.0,1047.5 4500.4,8149.0 2912.8,8149.0 2904.6,6943.1 1338.9,6973.9\" /></svg>"
         }
       },
       "body": {
@@ -3661,8 +5869,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08754995118905,
-                40.70437063012086
+                -74.08755373970094,
+                40.70436486223476
               ]
             }
           },
@@ -3682,8 +5890,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08524523435639,
-                40.70636747260311
+                -74.08525167695703,
+                40.70636252541945
               ]
             }
           },
@@ -3703,8 +5911,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08156315304407,
-                40.703890546772705
+                -74.08156808168944,
+                40.70388845240803
               ]
             }
           },
@@ -3724,8 +5932,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08386786987673,
-                40.701893704290455
+                -74.08387014443335,
+                40.70189078922334
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p51",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4201.0,2370.1 4585.0,7253.7 934.4,7224.7 927.6,2276.9 4201.0,2370.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08278835101146,
+                40.704330624873265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08015555609971,
+                40.70261798432045
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.083371313221,
+                40.69977677779377
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08600410813274,
+                40.70148941834659
               ]
             }
           }
@@ -3750,8 +6096,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3770,7 +6116,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4853.8,7149.2 1027.6,6819.1 1008.1,822.4 3740.0,777.1 3738.4,2324.7 4836.5,2339.2 4853.8,7149.2\" /></svg>"
+          "value": "<svg><polygon points=\"1025.9,6819.8 1008.9,818.0 5789.0,763.6 5789.0,3838.9 4844.7,3844.1 4855.2,7151.7 1025.9,6819.8\" /></svg>"
         }
       },
       "body": {
@@ -3799,8 +6145,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08807830491155,
-                40.70389822191146
+                -74.08808060780457,
+                40.70389639977392
               ]
             }
           },
@@ -3820,8 +6166,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08544853128635,
-                40.70214912500378
+                -74.08545209346494,
+                40.70214960738398
               ]
             }
           },
@@ -3841,8 +6187,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08867366011891,
-                40.69932274751598
+                -74.08867297303802,
+                40.699324583326884
               ]
             }
           },
@@ -3862,8 +6208,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09130343374412,
-                40.70107184442366
+                -74.09130148737765,
+                40.70107137571682
               ]
             }
           }
@@ -3888,8 +6234,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3908,7 +6254,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"77.7,6284.9 953.6,1043.2 4151.3,114.3 5687.1,5431.3 3280.8,8149.0 2901.5,8149.0 575.9,8149.0 77.7,6284.9\" /></svg>"
+          "value": "<svg><polygon points=\"72.6,6292.3 943.7,1046.0 4142.7,113.2 5685.1,5432.3 3278.7,8149.0 571.4,8149.0 72.6,6292.3\" /></svg>"
         }
       },
       "body": {
@@ -3937,8 +6283,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0895213121632,
-                40.700112548940425
+                -74.0895164855722,
+                40.70011663096158
               ]
             }
           },
@@ -3958,8 +6304,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08665618023302,
-                40.701542197507386
+                -74.0866514511911,
+                40.70154300528743
               ]
             }
           },
@@ -3979,8 +6325,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.083990696151,
-                40.69842832652003
+                -74.08399207171256,
+                40.69842924031796
               ]
             }
           },
@@ -4000,8 +6346,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0868558280812,
-                40.69699867795307
+                -74.08685710609366,
+                40.69700286599211
               ]
             }
           }
@@ -4026,8 +6372,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4046,7 +6392,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2867.2,1100.7 2880.6,0.0 4431.9,0.0 4476.4,6906.8 3550.2,6923.8 1349.0,6630.8 1358.2,1095.0 2867.2,1100.7\" /></svg>"
+          "value": "<svg><polygon points=\"1351.9,2055.1 4437.1,2051.9 4432.8,6912.7 3505.0,6929.4 1350.3,6604.7 1351.9,2055.1\" /></svg>"
         }
       },
       "body": {
@@ -4075,8 +6421,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08843866245972,
-                40.70096663543212
+                -74.08843859295706,
+                40.700966667007435
               ]
             }
           },
@@ -4096,8 +6442,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08615050053366,
-                40.70296781046413
+                -74.08615506999426,
+                40.70296527451627
               ]
             }
           },
@@ -4117,8 +6463,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08246061872836,
-                40.700508550887136
+                -74.08244392145373,
+                40.70052819580423
               ]
             }
           },
@@ -4138,8 +6484,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08474878065442,
-                40.69850737585512
+                -74.08472744441653,
+                40.6985295882954
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p55",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2834.3,8149.0 2043.7,6673.1 735.0,2920.4 974.3,858.3 4835.0,1008.9 4868.0,7356.3 2834.3,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09037378359658,
+                40.70181227504713
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08789728648402,
+                40.70000181270728
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09129660358707,
+                40.6973291852095
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09377310069962,
+                40.69913964754935
               ]
             }
           }
@@ -4164,8 +6648,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4184,7 +6668,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4860.7,7670.1 336.6,6685.9 251.7,338.5 5316.0,481.7 5183.2,2300.1 5789.0,2209.5 5789.0,6848.5 4915.5,6744.1 4860.7,7670.1\" /></svg>"
+          "value": "<svg><polygon points=\"5183.0,2296.0 5789.0,2205.2 5789.0,6843.8 4916.8,6738.3 4862.0,7668.8 335.4,6685.5 248.4,335.0 5315.3,476.7 5183.0,2296.0\" /></svg>"
         }
       },
       "body": {
@@ -4213,8 +6697,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08866766605068,
-                40.70014302632699
+                -74.08866767778838,
+                40.700140773597866
               ]
             }
           },
@@ -4234,8 +6718,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0862011935527,
-                40.69828413823812
+                -74.08620318539639,
+                40.698282180325904
               ]
             }
           },
@@ -4255,8 +6739,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.08962857179476,
-                40.69563312142387
+                -74.08963002006134,
+                40.69563329177146
               ]
             }
           },
@@ -4276,8 +6760,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09209504429276,
-                40.697492009512736
+                -74.09209451245333,
+                40.69749188504342
               ]
             }
           }
@@ -4302,8 +6786,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4322,7 +6806,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3430.1 4754.3,830.2 4828.6,5830.4 -0.0,7157.2 -0.0,3430.1\" /></svg>"
+          "value": "<svg><polygon points=\"2947.9,6338.2 1896.9,2596.1 4753.2,826.8 4831.0,5819.7 2947.9,6338.2\" /></svg>"
         }
       },
       "body": {
@@ -4351,8 +6835,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09567607435031,
-                40.69614071332772
+                -74.09567910219458,
+                40.69613992040515
               ]
             }
           },
@@ -4372,8 +6856,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09278051181113,
-                40.69753144585917
+                -74.092778042826,
+                40.69753106945871
               ]
             }
           },
@@ -4393,8 +6877,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09018774109212,
-                40.69438431182169
+                -74.09018449431518,
+                40.69437796255108
               ]
             }
           },
@@ -4414,3059 +6898,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0930833036313,
-                40.692993579290246
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p61",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5724
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4605.4,7239.2 -0.0,6947.6 -0.0,3416.5 4670.4,528.8 4562.9,732.0 4605.4,7239.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09845550986955,
-                40.69237771997954
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5724.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09559104678802,
-                40.693835327907806
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5724.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0928737504211,
-                40.69072182171796
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09573821350264,
-                40.68926421378969
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p62",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5789
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,6645.4 2260.0,6065.8 2353.7,5691.5 1669.5,1987.9 5094.8,2773.5 4840.6,3627.2 5666.9,8149.0 -0.0,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09722386285947,
-                40.692267973795005
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5789.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09468262828395,
-                40.690432885018424
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5789.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0980657271644,
-                40.68770119045064
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.10060696173993,
-                40.68953627922722
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p68",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5789
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,8149.0 0.0,495.2 3246.4,572.7 4359.5,1165.2 1284.4,7993.0 1624.9,8149.0 0.0,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09790151909748,
-                40.688416236054515
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5789.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09609906858641,
-                40.69062303343008
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5789.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09203080089263,
-                40.68868544611777
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09383325140368,
-                40.68647864874221
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p70",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5757
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"254.2,2678.9 318.0,-0.0 5328.6,-0.0 5421.8,7181.3 928.2,6908.3 254.2,2678.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.08952870493746,
-                40.69648453000298
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5757.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.08737678718923,
-                40.69442281139645
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5757.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09120094329583,
-                40.692095758706174
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09335286104407,
-                40.6941574773127
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p71",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5701
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"542.3,6902.2 901.4,3034.6 957.3,-0.0 5701.0,-0.0 5701.0,8150.0 3565.3,8150.0 3549.5,7547.4 542.3,6902.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0870446555387,
-                40.69555286049998
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5701.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0846538385698,
-                40.693675567465675
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5701.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.088170075289,
-                40.691064735483366
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0905608922579,
-                40.69294202851767
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p72",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5757
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"836.3,7731.6 360.2,173.2 3431.5,323.4 4842.2,7861.4 836.3,7731.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0898344074898,
-                40.69334418293259
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5757.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.08784434161255,
-                40.69118232414982
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5757.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09185405690177,
-                40.689030196587446
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09384412277902,
-                40.691192055370216
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p76",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5757
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1018.1,8150.0 1388.9,1586.2 5757.0,1804.5 5757.0,8150.0 1018.1,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.08042722271094,
-                40.70077338456808
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5757.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07793590462494,
-                40.69895565875215
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5757.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.08130770525842,
-                40.69626175273927
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.08379902334443,
-                40.69807947855521
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p78",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5757
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"505.3,6830.5 518.0,1323.1 5217.0,678.1 5233.7,7288.0 3871.0,7307.6 505.3,6830.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.08249723677022,
-                40.70260776252953
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5757.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.08004249421109,
-                40.70447973178597
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5757.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07656987909769,
-                40.70182552481975
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07902462165683,
-                40.69995355556331
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p79",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5730
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1321.8,830.6 5111.3,784.0 5730.0,619.9 5730.0,6999.7 5730.0,6999.7 5730.0,8150.0 1157.8,8150.0 1283.0,7424.8 384.8,7399.4 1321.8,830.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.08085843431448,
-                40.70382612710363
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5730.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07879925108753,
-                40.70592945154752
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5730.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07487829380155,
-                40.70369211419515
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0769374770285,
-                40.70158878975126
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0008/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p8",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0008/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0008/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5714
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6528.1 0.0,-0.0 5534.9,-0.0 4955.4,2981.9 4976.7,6506.3 -0.0,6528.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0008/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09359572547787,
-                40.713842582584924
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5714.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0913364294644,
-                40.71233902300491
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5714.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09414750335486,
-                40.709877672511176
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09640679936832,
-                40.711381232091185
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p82",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5757
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1301.8,1743.5 5757.0,1200.0 5757.0,8150.0 781.6,8150.0 1301.8,1743.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07727548363329,
-                40.70262179130637
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5757.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07491591543693,
-                40.70071923383243
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5757.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07844517770417,
-                40.698167865518954
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.08080474590054,
-                40.700070422992894
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p83",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5723
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1227.5 2059.3,643.9 2847.4,531.9 2759.5,0.0 5723.0,0.0 5723.0,8150.0 1097.0,8150.0 88.9,6346.2 -0.0,6200.5 -0.0,1227.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07574249981643,
-                40.70466130976678
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5723.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07331980841013,
-                40.70645274368351
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5723.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.06997792516195,
-                40.70381861668528
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.07240061656826,
-                40.702027182768546
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p10",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5714
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3709.0,1417.5 3670.2,0.0 5714.0,0.0 5714.0,2492.2 5714.0,5374.5 5290.7,5342.2 5348.2,7250.2 2176.1,6413.5 2171.3,5014.8 971.0,4908.4 1348.9,1209.3 0.0,1081.2 -0.0,0.0 2142.7,0.0 2159.0,1414.3 3709.0,1417.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3709.3,
-                1427.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0926671,
-                40.7146597
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5277.8,
-                1427.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.092121,
-                40.715241
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p15",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5696
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1011.9,7261.0 1037.4,662.5 4213.9,493.0 4284.4,6359.6 3983.2,6360.0 3984.0,7256.9 1011.9,7261.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2496.0,
-                7256.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0922662,
-                40.7072462
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3984.0,
-                7256.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0916701,
-                40.7077517
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p17",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5696
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5014.0,0.0 5040.4,6491.4 4683.9,6661.8 4668.8,8149.0 151.4,8149.0 441.8,7924.2 -0.0,8149.0 -0.0,4578.1 244.8,4576.4 276.5,908.8 4712.0,898.1 4712.4,0.0 5014.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1736.0,
-                896.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0928589,
-                40.7067408
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4712.0,
-                896.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0916701,
-                40.7077517
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p20",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5755
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2087.6,567.9 2087.6,2027.5 5755.0,2086.1 5755.0,7105.4 4699.1,6790.5 4699.1,6806.5 876.7,5651.7 855.1,552.5 2087.6,567.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2087.6,
-                2027.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0934371,
-                40.7062418
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2087.6,
-                567.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0928589,
-                40.7067408
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p22",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5755
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4914.7,6311.0 807.4,6326.1 753.1,693.2 3370.2,749.9 4914.7,6311.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                815.9,
-                5458.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0956968,
-                40.7016045
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                815.9,
-                7206.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0965855,
-                40.7011754
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p24",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5250.4,8150.0 3785.1,8150.0 3765.9,7195.6 761.7,7145.5 779.6,651.2 5225.1,715.8 5250.4,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5223.1,
-                3735.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0948208,
-                40.7020491
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5223.1,
-                715.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0932937,
-                40.7027988
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p26",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3311.5,5543.2 802.8,5519.5 859.9,742.7 1634.8,699.6 1222.4,0.0 4903.7,0.0 4885.6,1415.6 3917.6,1438.9 3923.4,2924.9 5747.0,2904.1 5747.0,7072.4 3297.6,7742.8 3311.5,5543.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3303.4,
-                2935.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0973521,
-                40.7007884
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2023.6,
-                5534.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0971575,
-                40.6994919
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p27",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5674
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4464.2 -0.0,-0.0 4473.9,0.0 5674.0,1220.8 5674.0,2831.1 4963.2,7592.4 693.0,7558.8 -0.0,4464.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2148.8,
-                7584.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0992049,
-                40.6985058
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3537.2,
-                7584.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0984995,
-                40.69885
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p28",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"607.9,697.8 5747.0,689.9 5747.0,4487.9 4627.8,4494.8 4649.8,5254.3 5430.1,7416.2 607.9,7414.2 607.9,697.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                607.9,
-                695.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.096511,
-                40.699802
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                607.9,
-                7414.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.099953,
-                40.698155
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p30",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3610.5,7531.0 131.0,8009.1 185.3,7794.9 -0.0,7813.5 -0.0,0.0 5547.4,0.0 5747.0,380.4 5747.0,593.8 5276.0,828.7 3610.5,7531.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4779.2,
-                2795.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.099953,
-                40.698155
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5275.1,
-                827.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.100595,
-                40.698936
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p43",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5716
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3508.2 -0.0,1154.7 2378.7,1221.8 3643.2,998.5 3665.0,2876.3 4416.0,2743.6 4438.9,6092.6 1312.4,6164.3 1304.0,3273.4 -0.0,3508.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1304.0,
-                3272.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0856905,
-                40.70788
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4416.0,
-                2744.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0846988,
-                40.7091072
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p44",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5785
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"742.4,7783.3 764.1,3213.7 -0.0,3339.5 -0.0,1310.4 2099.5,533.1 4927.3,275.1 4963.8,2103.9 5785.0,2075.0 5785.0,8150.0 5487.7,8150.0 5486.3,7841.2 742.4,7783.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4896.8,
-                2591.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0833898,
-                40.7106997
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                764.1,
-                3215.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0846988,
-                40.7091072
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p49",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5710
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1075.6,6924.8 1097.5,932.3 4520.3,915.8 4487.2,6950.7 1075.6,6924.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2703.1,
-                3964.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0859316,
-                40.7029712
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1075.6,
-                6924.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0852096,
-                40.7015321
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p51",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5724
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"934.4,7224.7 927.6,2276.9 2130.0,2287.7 2145.4,704.3 4071.0,716.7 4585.0,7253.7 934.4,7224.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2368.0,
-                3836.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0832122,
-                40.7022839
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                932.0,
-                5640.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0845856,
-                40.7020851
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p55",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5724
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2853.0,8149.0 2046.2,6650.4 738.0,2922.8 971.9,872.7 4809.7,1014.9 4854.9,7324.1 2853.0,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4868.0,
-                2684.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0893795,
-                40.6993837
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3300.0,
-                6980.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0918671,
-                40.698469
+                -74.09308555368376,
+                40.69298681349752
               ]
             }
           }
@@ -7484,15 +6917,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7511,34 +6944,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1167.7,2735.0 3193.0,1404.4 4854.6,1423.5 4051.1,7523.5 2323.3,7351.2 668.3,7548.9 1330.2,2664.2 1167.7,2735.0\" /></svg>"
+          "value": "<svg><polygon points=\"1168.2,2734.6 3689.0,1069.8 3837.6,1411.8 4854.6,1423.5 4051.1,7523.5 2323.3,7351.1 668.3,7548.9 1330.2,2664.2 1168.2,2734.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0058/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4276.7,
-                5624.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0904698,
-                40.6968215
+                -74.09467788506102,
+                40.6975107068517
               ]
             }
           },
@@ -7546,20 +6982,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4660.8,
-                2992.4
+                5789.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0913363,
-                40.6978599
+                -74.09199844045017,
+                40.699249161523106
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08877055014106,
+                40.69638936994483
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09144999475191,
+                40.69465091527343
               ]
             }
           }
@@ -7577,15 +7055,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7604,34 +7082,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1531.7,5961.2 1050.1,2057.9 4663.1,3068.8 4645.3,6841.5 1705.4,6116.8 1531.7,5961.2\" /></svg>"
+          "value": "<svg><polygon points=\"1705.4,6116.8 1531.7,5961.2 745.5,-0.0 4656.6,-0.0 4645.3,6841.5 1705.4,6116.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0059/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4664.0,
-                4344.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.093912,
-                40.6929496
+                -74.0942200520262,
+                40.695823762134836
               ]
             }
           },
@@ -7639,20 +7120,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1272.0,
-                4216.5
+                5724.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0953543,
-                40.6940276
+                -74.09169733699086,
+                40.69407845245971
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09497404360404,
+                40.6913557140084
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09749675863938,
+                40.693101023683525
               ]
             }
           }
@@ -7670,15 +7193,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7697,7 +7220,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7618.7 -0.0,-0.0 5715.0,0.0 5715.0,7493.4 -0.0,7618.7\" /></svg>"
+          "value": "<svg><polygon points=\"5715.0,7428.7 -0.0,7649.7 -0.0,-0.0 5715.0,0.0 5715.0,7428.7\" /></svg>"
         }
       },
       "body": {
@@ -7726,8 +7249,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09978713292703,
-                40.71056610191184
+                -74.09978703513843,
+                40.71060323015165
               ]
             }
           },
@@ -7747,8 +7270,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09755037158898,
-                40.71255377345359
+                -74.09750544983602,
+                40.71257606293995
               ]
             }
           },
@@ -7768,8 +7291,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09381072353379,
-                40.71013802819536
+                -74.09382147753647,
+                40.71009334014217
               ]
             }
           },
@@ -7789,29 +7312,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09604748487185,
-                40.708150356653604
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2727.5,
-                7556.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0952509,
-                40.7092752
+                -74.09610306283888,
+                40.70812050735387
               ]
             }
           }
@@ -7829,15 +7331,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7863,27 +7365,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0060/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                944.2,
-                3676.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0936134,
-                40.6932082
+                -74.0922856930051,
+                40.69464076092679
               ]
             }
           },
@@ -7891,20 +7396,752 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1332.2,
-                6844.8
+                5789.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0949237,
-                40.6921215
+                -74.08999692752825,
+                40.69261092440037
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09376566122509,
+                40.6901679894532
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09605442670194,
+                40.69219782597962
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p61",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1050.4,7011.3 1050.2,2815.7 4669.9,524.0 4562.3,727.2 4602.4,7236.8 1050.4,7011.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09845229850148,
+                40.69237568219588
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09558955225495,
+                40.693833571482365
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09287173137547,
+                40.690721931393185
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.095734477622,
+                40.6892640421067
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p62",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"216.4,8149.0 -0.0,8149.0 -0.0,6651.3 2260.0,6068.6 2359.4,5672.8 1706.7,2098.4 1327.1,828.1 5403.2,1756.3 4850.2,3621.5 5338.5,6338.4 71.6,7422.4 216.4,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09722538562474,
+                40.69226539611423
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0946908095231,
+                40.69043094889719
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09807272407262,
+                40.68770641057131
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10060730017426,
+                40.68954085778835
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0064/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p64",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0064/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0064/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,0.0 5395.0,0.0 5384.3,563.8 5789.0,570.1 5789.0,8149.0 -0.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0064/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.1002744,
+                40.6897611
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0973173,
+                40.6883591
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09992009999999,
+                40.6852025
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.1028772,
+                40.6866045
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0067/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p67",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0067/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0067/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5708
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,8149 0,0 5708,0 5708,8149 0,8149\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0067/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09931327629351,
+                40.686905207952336
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5708.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09738567802633,
+                40.68906354409758
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5708.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09331924661325,
+                40.686978783111066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09524684488044,
+                40.68482044696582
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p68",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3035.0,6102.6 5789.0,6665.9 5789.0,8149.0 0.0,8149.0 0.0,525.9 3334.8,536.6 5071.8,1417.5 3035.0,6102.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0979706,
+                40.6883695
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0960718,
+                40.6905942
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09194160000001,
+                40.6885674
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0938404,
+                40.6863427
               ]
             }
           }
@@ -7922,15 +8159,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7949,34 +8186,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4994.0,5066.2 5708.0,4910.7 5708.0,8149.0 -0.0,8149.0 -0.0,826.1 5032.7,1061.8 4994.0,5066.2\" /></svg>"
+          "value": "<svg><polygon points=\"714.0,868.7 5032.7,1061.8 4994.0,5066.2 4711.4,5125.9 4731.1,5990.7 5708.0,5962.0 5708.0,8149.0 824.0,8149.0 4047.8,6748.7 3458.0,5390.4 712.0,5969.9 714.0,868.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0069/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2768.0,
-                992.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0945123,
-                40.6904395
+                -74.09623895299096,
+                40.69011642677871
               ]
             }
           },
@@ -7984,20 +8224,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                712.0,
-                5968.7
+                5708.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0938821,
-                40.688018
+                -74.0933645566928,
+                40.69156529003651
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5708.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09063684446853,
+                40.6884542213057
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09351124076669,
+                40.6870053580479
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p70",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"249.5,2682.4 308.7,-0.0 5319.0,-0.0 5423.6,7175.5 930.4,6910.0 249.5,2682.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08952326432129,
+                40.69648255453748
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08737541346062,
+                40.694417775839426
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09120524554446,
+                40.692095121022525
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09335309640512,
+                40.69415989972058
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p71",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5701
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"540.6,6907.6 898.2,3029.4 952.6,-0.0 5701.0,-0.0 5701.0,8150.0 3572.5,8150.0 3556.4,7552.3 540.6,6907.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08704702510614,
+                40.69554627386061
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5701.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08466423530139,
+                40.69367287936899
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5701.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08817316991127,
+                40.69107081325088
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09055595971603,
+                40.6929442077425
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p72",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3429.6,326.3 3541.4,924.4 5639.4,590.2 5567.9,141.6 5757.0,107.0 5757.0,8150.0 4890.9,8150.0 4839.6,7865.2 833.3,7734.9 358.0,175.8 3429.6,326.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0898324020123,
+                40.69334403352699
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08784217396327,
+                40.69118253513932
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09185122080838,
+                40.68903023219865
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09384144885742,
+                40.69119173058632
               ]
             }
           }
@@ -8015,15 +8711,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8042,34 +8738,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5355.0,994.5 5308.3,8150.0 -0.0,8150.0 -0.0,5326.7 3798.6,5384.7 3850.9,3043.8 2829.4,3026.5 3074.8,1006.2 5355.0,994.5\" /></svg>"
+          "value": "<svg><polygon points=\"5304.6,7349.6 4553.5,7436.9 4557.5,8150.0 -0.0,8150.0 -0.0,5320.4 3790.5,5380.7 3844.3,3043.8 2827.3,3026.5 3076.1,1005.4 5355.0,994.4 5304.6,7349.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0073/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3773.3,
-                611.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0888235,
-                40.6967735
+                -74.09260097264213,
+                40.69468800878239
               ]
             }
           },
@@ -8077,20 +8776,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5345.9,
-                3043.3
+                5714.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0853595,
-                40.6962211
+                -74.08768590229471,
+                40.698450712993385
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08060303428016,
+                40.69313241567318
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08551810462758,
+                40.68936971146219
               ]
             }
           }
@@ -8108,15 +8849,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8135,34 +8876,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"822.7,1292.8 2101.4,1570.2 2103.8,2675.4 3103.5,2684.4 3123.7,4980.8 5757.0,4939.3 5757.0,8150.0 -0.0,8150.0 -0.0,7711.1 740.9,7715.2 822.7,1292.8\" /></svg>"
+          "value": "<svg><polygon points=\"822.8,1288.7 2101.4,1567.5 2103.8,2675.4 3101.9,2684.4 3123.0,4977.1 5757.0,4934.4 5757.0,8150.0 -0.0,8150.0 -0.0,7007.3 741.6,6925.3 822.8,1288.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0074/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2708.5,
-                2675.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0837104,
-                40.6974977
+                -74.08842525361658,
+                40.69744040001042
               ]
             }
           },
@@ -8170,20 +8914,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                804.1,
-                2675.3
+                5757.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0853595,
-                40.6962211
+                -74.08343518490163,
+                40.70130330809453
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0762192052368,
+                40.69594518889022
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08120927395174,
+                40.69208228080611
               ]
             }
           }
@@ -8201,15 +8987,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8228,34 +9014,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"842.7,3019.6 554.1,571.9 5224.4,1333.6 5073.2,8150.0 463.7,8150.0 842.7,3019.6\" /></svg>"
+          "value": "<svg><polygon points=\"463.7,8150.0 842.7,3019.6 554.1,571.9 5224.4,1333.6 5073.2,8150.0 463.7,8150.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0075/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                740.3,
-                3731.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0842419,
-                40.6999055
+                -74.08299784195978,
+                40.70135435398988
               ]
             }
           },
@@ -8263,20 +9052,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5113.8,
-                4618.9
+                5714.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0827378,
-                40.6982291
+                -74.08054656024778,
+                40.69954212278419
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08395805688708,
+                40.696889876642665
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08640933859908,
+                40.698702107848355
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p76",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1020.6,8150.0 1395.7,1564.4 5757.0,1784.4 5757.0,8150.0 1020.6,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08043458999568,
+                40.70077077568364
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07794498326669,
+                40.698955839873015
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08131160991745,
+                40.696263785462584
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08380121664644,
+                40.698078721273205
               ]
             }
           }
@@ -8294,15 +9263,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8321,34 +9290,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"782.4,6522.7 1475.4,1855.9 5089.9,1263.8 5064.9,6808.2 782.4,6522.7\" /></svg>"
+          "value": "<svg><polygon points=\"5064.9,6808.2 782.4,6522.7 1475.4,1855.9 5089.9,1263.8 5064.9,6808.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0077/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3337.2,
-                1555.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.082334,
-                40.7016873
+                -74.08441453229746,
+                40.7011173918342
               ]
             }
           },
@@ -8356,20 +9328,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2805.0,
-                5054.8
+                5714.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.081077,
-                40.7003877
+                -74.08198311711706,
+                40.70295379929723
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07852603360219,
+                40.70032310583087
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08095744878258,
+                40.698486698367844
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p78",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3859.0,7303.2 475.5,6833.3 510.9,1293.4 5240.3,630.7 5229.9,7279.5 3859.0,7303.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08247993799802,
+                40.702597668784264
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08003235873987,
+                40.70445318890567
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0765659355823,
+                40.70182529621779
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07901351484044,
+                40.69996977609639
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p79",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5730
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1677.1,7427.0 344.5,7387.2 320.7,7236.7 1333.0,855.0 5110.2,814.7 5064.5,7071.8 1677.1,7427.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08087950893001,
+                40.70382511609828
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5730.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07881793913079,
+                40.705937979051214
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5730.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07485140994855,
+                40.70371374215187
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07691297974777,
+                40.701600879198935
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0008/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p8",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0008/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0008/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5714
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4985.5,7298.8 -0.0,7254.8 0.0,-0.0 5536.0,-0.0 4951.8,2965.2 4985.5,7298.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0008/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09361087833447,
+                40.713842592130376
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09133840164398,
+                40.71233812840634
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09415116608977,
+                40.709862418592316
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09642364278027,
+                40.711366882316355
               ]
             }
           }
@@ -8387,15 +9815,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8414,34 +9842,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2304.4,7370.5 2331.2,1107.2 5757.0,192.4 5757.0,7059.1 2304.4,7370.5\" /></svg>"
+          "value": "<svg><polygon points=\"4795.1,7060.0 1702.0,7445.6 1694.2,7255.7 1722.0,1269.9 5757.0,192.4 5757.0,7059.1 4795.1,7060.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0080/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1164.2,
-                1275.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0788466,
-                40.705278
+                -74.07990003183883,
+                40.70519867494526
               ]
             }
           },
@@ -8449,20 +9880,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1664.3,
-                5722.6
+                5757.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0764765,
-                40.7042276
+                -74.07778945361457,
+                40.707343351357466
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07378268931963,
+                40.705077370666686
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07589326754389,
+                40.70293269425448
               ]
             }
           }
@@ -8480,15 +9953,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8507,34 +9980,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5729.8,8150.0 1288.6,8150.0 1282.0,6410.6 2014.4,6499.9 1757.1,1946.4 612.1,2003.3 612.1,2003.3 520.5,1371.6 5337.6,1903.3 5730.0,1730.0 5729.8,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"5730.0,1777.5 5648.1,8150.0 1277.1,8150.0 1269.8,5953.0 266.0,-0.0 2027.2,-0.0 5474.0,1940.6 5730.0,1777.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0081/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2729.0,
-                7446.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0765563,
-                40.7014709
+                -74.07492330645175,
+                40.70493225888051
               ]
             }
           },
@@ -8542,20 +10018,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1268.4,
-                5786.6
+                5730.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0765913,
-                40.7024832
+                -74.0722183750736,
+                40.70323145283136
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5730.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0754112348539,
+                40.700312994339384
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07811616623205,
+                40.702013800388535
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p82",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1300.3,1781.9 5757.0,1227.7 5757.0,8150.0 781.4,8150.0 1300.3,1781.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07727489370413,
+                40.702620775400284
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07491905596679,
+                40.70072103442188
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07844309360797,
+                40.69817369980195
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08079893134531,
+                40.70007344078035
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p83",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5723
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5723.0,8150.0 -0.0,8150.0 -0.0,6591.8 1709.6,2584.6 1509.1,784.4 2572.0,563.3 2812.3,0.0 5723.0,0.0 5723.0,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0757663954107,
+                40.70463137745238
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5723.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07332557071388,
+                40.70644161198032
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5723.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.06994861081866,
+                40.70378777267489
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07238943551548,
+                40.701977538146956
               ]
             }
           }
@@ -8573,15 +10367,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T14:36:34Z",
-      "modified": "2026-08-07T14:36:34Z",
+      "created": "2026-08-15T01:29:26Z",
+      "modified": "2026-08-15T01:29:26Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8600,34 +10394,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3572.8,7062.0 2027.4,7029.5 2028.6,5618.2 0.0,5593.1 -0.0,0.0 5711.0,0.0 5711.0,8149.0 5558.2,8149.0 5588.9,5662.2 3551.4,5637.0 3572.8,7062.0\" /></svg>"
+          "value": "<svg><polygon points=\"5581.9,7073.7 2038.9,7029.5 2037.2,5619.8 0.0,5601.4 -0.0,-0.0 5711.0,0.0 5711.0,8149.0 5572.2,8149.0 5581.9,7073.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0009/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2031.6,
-                2044.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0956783,
-                40.7153869
+                -74.09738897616964,
+                40.71515874530653
               ]
             }
           },
@@ -8635,20 +10432,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3583.4,
-                1748.2
+                5711.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0952921,
-                40.7160456
+                -74.0954226825461,
+                40.717298435833854
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5711.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09139587201733,
+                40.71517243327697
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09336216564087,
+                40.71303274274965
               ]
             }
           }

--- a/gallery/kansas_city_mo_1951_vol_4.iiif.json
+++ b/gallery/kansas_city_mo_1951_vol_4.iiif.json
@@ -7,25 +7,41 @@
   "label": "Mosaic of main content, Kansas City, Mo. | 1951 | Vol. 4",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0451__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p453",
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p451 [1]",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
           "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6553.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -34,21 +50,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0451__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0451/info.json",
           "type": "ImageService2",
           "height": 7795,
           "width": 6553
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"810.8,7707.2 983.2,0.0 6553.0,0.0 6553.0,7750.0 810.8,7707.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 6553.0,0.0 6553.0,5457.1 6145.0,5455.1 6137.5,7228.5 6553.0,7230.5 6553.0,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0451__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -73,8 +89,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5959255,
-                39.0713122
+                -94.60731243366273,
+                39.07229091531772
               ]
             }
           },
@@ -94,8 +110,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5920454,
-                39.0711998
+                -94.60351614111048,
+                39.07216265560463
               ]
             }
           },
@@ -115,8 +131,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5922177,
-                39.0676154
+                -94.60371271158122,
+                39.06865572200762
               ]
             }
           },
@@ -136,8 +152,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5960978,
-                39.0677278
+                -94.60750900413348,
+                39.06878398172071
               ]
             }
           }
@@ -145,25 +161,41 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0451__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p470",
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p451 [1]",
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
           "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "5301.2"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "6021.6"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1251.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "1773.4"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -172,21 +204,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0451__2/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0451/info.json",
           "type": "ImageService2",
           "height": 7795,
-          "width": 6386
+          "width": 6553
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"190.5,7774.0 116.1,0.0 5936.2,0.0 6035.9,7335.1 2193.9,7378.8 2188.2,7771.9 190.5,7774.0\" /></svg>"
+          "value": "<svg><polygon points=\"6553.0,6021.6 6553.0,7795.0 5301.2,7795.0 5301.2,6021.6 6553.0,6021.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0451__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -199,8 +231,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
+                5301.2,
+                6021.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -211,8 +243,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5621626,
-                39.0701439
+                -94.60389008382857,
+                39.06971642276868
               ]
             }
           },
@@ -220,8 +252,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6386.0,
-                0.0
+                6553.0,
+                6021.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -232,8 +264,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5583748,
-                39.069997
+                -94.6031708430642,
+                39.06968939200693
               ]
             }
           },
@@ -241,7 +273,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6386.0,
+                6553.0,
                 7795.0
               ],
               "creator": {
@@ -253,8 +285,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5586058,
-                39.0664058
+                -94.60321988565629,
+                39.06889169781964
               ]
             }
           },
@@ -262,7 +294,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
+                5301.2,
                 7795.0
               ],
               "creator": {
@@ -274,146 +306,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5623936,
-                39.0665527
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p548",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6472
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3187.6,6684.4 3097.6,6041.9 3229.9,6040.4 3233.4,5735.6 -0.0,5699.9 -0.0,3933.3 669.5,3951.8 426.2,3505.7 473.5,3000.8 702.5,2758.0 704.9,953.3 695.3,916.2 705.6,485.7 0.0,466.2 0.0,0.0 6472.0,-0.0 6472.0,7774.8 5935.3,6783.8 3187.6,6684.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5616689,
-                39.0441843
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6472.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5617955,
-                39.0386224
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6472.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.570422,
-                39.0387408
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5702953,
-                39.0443028
+                -94.60393912642066,
+                39.06891872858139
               ]
             }
           }
@@ -438,8 +332,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +352,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6367.0,7518.3 -0.0,7295.2 -0.0,577.2 172.8,575.9 172.5,216.0 6360.9,529.9 6367.0,7518.3\" /></svg>"
+          "value": "<svg><polygon points=\"6367.0,7577.9 -0.0,7334.0 -0.0,730.7 175.4,729.2 176.4,225.9 4184.4,386.8 4183.5,520.3 6367.0,675.4 6367.0,7577.9\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +381,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.60736425914018,
-                39.06392382834175
+                -94.60736717264011,
+                39.06392765442766
               ]
             }
           },
@@ -508,8 +402,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.60367647239816,
-                39.063915373488946
+                -94.60366864340938,
+                39.06392765442766
               ]
             }
           },
@@ -529,8 +423,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.60368970972942,
-                39.06038509502143
+                -94.60366864340938,
+                39.06041187732181
               ]
             }
           },
@@ -550,8 +444,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.60737749647144,
-                39.060393549874235
+                -94.60736717264011,
+                39.06041187732181
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p453",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6553
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6241.0,7599.0 873.5,7597.7 977.2,0.0 6553.0,0.0 6553.0,5845.0 6241.0,7599.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59592229388102,
+                39.071198992869945
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6553.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.592115581881,
+                39.071069044869944
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6553.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59231473492622,
+                39.06755239967862
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59612144692623,
+                39.06768234767862
               ]
             }
           }
@@ -576,8 +608,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +628,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"566.4,7737.1 553.9,189.9 -0.0,191.1 -0.0,-0.0 6367.0,0.0 6367.0,1034.2 6065.4,1686.5 6029.5,7664.1 5605.2,7796.0 566.4,7737.1\" /></svg>"
+          "value": "<svg><polygon points=\"5578.1,7796.0 113.1,7711.2 425.9,6041.5 470.5,469.7 -0.0,466.3 -0.0,0.0 6367.0,0.0 6367.0,1057.1 6069.4,1699.0 6015.9,7661.3 5578.1,7796.0\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +657,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59237544763278,
-                39.07129971839407
+                -94.59239022272118,
+                39.07129950104874
               ]
             }
           },
@@ -646,8 +678,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58852984368995,
-                39.07118173366038
+                -94.58853447881057,
+                39.0711902019039
               ]
             }
           },
@@ -667,8 +699,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58871458534733,
-                39.06750075680365
+                -94.58870562048743,
+                39.06749951916293
               ]
             }
           },
@@ -688,8 +720,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59256018929015,
-                39.067618741537345
+                -94.59256136439804,
+                39.06760881830777
               ]
             }
           }
@@ -714,8 +746,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +766,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2140.1,4216.0 2222.3,68.8 6379.6,120.7 6268.7,7020.5 1281.4,6970.6 1944.0,5372.4 2140.1,4216.0\" /></svg>"
+          "value": "<svg><polygon points=\"4098.2,7795.0 908.5,7795.0 1450.7,6744.8 2088.3,4641.1 2208.2,79.2 6371.8,127.8 6266.4,7038.1 4114.1,7018.3 4098.2,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +795,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59725226584546,
-                39.067826146453676
+                -94.59724206529678,
+                39.0678313446119
               ]
             }
           },
@@ -784,8 +816,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59348834347223,
-                39.06773992271448
+                -94.5934838954711,
+                39.06774287309055
               ]
             }
           },
@@ -805,8 +837,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59361955568278,
-                39.06423814042539
+                -94.59361852827634,
+                39.0642464427102
               ]
             }
           },
@@ -826,8 +858,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.597383478056,
-                39.064324364164584
+                -94.59737669810202,
+                39.06433491423155
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p456",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6367
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"255.2,6647.3 256.0,136.0 5090.6,160.1 6295.9,172.6 6135.0,6668.0 255.2,6647.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59373612391134,
+                39.0677549482923
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6367.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59001266948518,
+                39.06762542790762
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6367.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59021689595224,
+                39.0640861905034
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5939403503784,
+                39.06421571088808
               ]
             }
           }
@@ -852,8 +1022,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +1042,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1808.3,5959.1 1136.3,5643.5 68.0,5637.0 -0.0,149.1 6130.4,164.9 6519.7,1359.9 6553.0,5995.8 1808.3,5959.1\" /></svg>"
+          "value": "<svg><polygon points=\"97.7,5653.6 -0.0,152.7 6553.0,172.0 6553.0,6002.1 1805.2,5966.7 1140.8,5656.5 97.7,5653.6\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +1071,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58523145874273,
-                39.071127157001555
+                -94.58522945932894,
+                39.07112430555592
               ]
             }
           },
@@ -922,8 +1092,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58535876031326,
-                39.06813129251487
+                -94.58535772594267,
+                39.06813073199565
               ]
             }
           },
@@ -943,8 +1113,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58991800093258,
-                39.0682497218515
+                -94.58991347736715,
+                39.06825005918947
               ]
             }
           },
@@ -964,8 +1134,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58979069936206,
-                39.071245586338186
+                -94.58978521075342,
+                39.071243632749734
               ]
             }
           }
@@ -990,8 +1160,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1010,7 +1180,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2191.8,5865.8 775.7,5877.1 586.9,1313.1 160.3,118.5 400.4,110.3 298.4,-0.0 6205.8,-0.0 6342.2,7795.0 2363.5,7795.0 2338.9,6296.3 2191.8,5865.8\" /></svg>"
+          "value": "<svg><polygon points=\"2192.7,5868.3 777.4,5877.2 634.0,1420.9 634.0,1420.9 592.0,114.2 6212.7,-0.0 6336.0,7795.0 2364.4,7795.0 2343.8,6313.0 2192.7,5868.3\" /></svg>"
         }
       },
       "body": {
@@ -1039,8 +1209,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58537075615531,
-                39.068397222967754
+                -94.58536789456431,
+                39.06840304554479
               ]
             }
           },
@@ -1060,8 +1230,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58562549278737,
-                39.06544443928838
+                -94.58561641944975,
+                39.06544727469988
               ]
             }
           },
@@ -1081,8 +1251,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59021997147926,
-                39.06568675716091
+                -94.5902155502612,
+                39.06568368344395
               ]
             }
           },
@@ -1102,8 +1272,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5899652348472,
-                39.06863954084029
+                -94.58996702537577,
+                39.06863945428886
               ]
             }
           }
@@ -1128,8 +1298,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1148,7 +1318,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"268.6,7339.5 281.3,7795.0 -0.0,7795.0 -0.0,0.0 518.2,-0.0 516.6,303.9 6150.1,287.5 6149.3,1386.9 6553.0,1385.9 6553.0,7292.2 268.6,7339.5\" /></svg>"
+          "value": "<svg><polygon points=\"6143.7,289.2 6110.2,6202.9 6399.1,7294.2 264.4,7335.7 276.4,7795.0 -0.0,7795.0 -0.0,0.0 512.9,-0.0 511.2,301.7 6143.7,289.2\" /></svg>"
         }
       },
       "body": {
@@ -1177,8 +1347,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.581031861357,
-                39.07110977830444
+                -94.58103344192654,
+                39.07110746417866
               ]
             }
           },
@@ -1198,8 +1368,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58119419496853,
-                39.068120635776886
+                -94.58119317232578,
+                39.06811773221837
               ]
             }
           },
@@ -1219,8 +1389,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58574321013391,
-                39.068271655466354
+                -94.58574307655162,
+                39.068266330387885
               ]
             }
           },
@@ -1240,8 +1410,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58558087652239,
-                39.07126079799391
+                -94.58558334615238,
+                39.071256062348176
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0460/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p460",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0460/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0460/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6406
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6893.5 148.8,-0.0 6406.0,-0.0 6252.4,7617.7 140.0,7375.1 -0.0,6893.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0460/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5811609918704,
+                39.06837236569408
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6406.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58118089865786,
+                39.06548158687988
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6406.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58571049854437,
+                39.06550039107966
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58569059175692,
+                39.06839116989386
               ]
             }
           }
@@ -1266,8 +1574,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1286,7 +1594,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5802.3,6766.1 148.3,6839.5 146.8,6534.5 -0.0,6535.9 -0.0,-0.0 127.9,-0.0 130.8,809.9 5722.9,726.3 5769.5,4433.8 5795.7,4488.8 5802.3,6766.1\" /></svg>"
+          "value": "<svg><polygon points=\"150.3,6842.6 148.6,6539.6 -0.0,6541.2 0.0,-0.0 6097.2,-0.0 6093.9,720.4 5717.3,723.3 5806.5,6765.5 150.3,6842.6\" /></svg>"
         }
       },
       "body": {
@@ -1315,8 +1623,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.57724339813979,
-                39.07078407157093
+                -94.57724324903475,
+                39.070782940116636
               ]
             }
           },
@@ -1336,8 +1644,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.57744298005892,
-                39.067815164465735
+                -94.57744518857709,
+                39.06781534414867
               ]
             }
           },
@@ -1357,8 +1665,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58197223326852,
-                39.06800129206536
+                -94.5819724426709,
+                39.068003670392166
               ]
             }
           },
@@ -1378,8 +1686,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58177265134937,
-                39.07097019917055
+                -94.58177050312857,
+                39.07097126636013
               ]
             }
           }
@@ -1404,8 +1712,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1424,7 +1732,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6365.2,2076.6 6371.0,7796.0 -0.0,7796.0 -0.0,791.7 5506.1,868.1 6250.8,669.6 6343.9,2009.8 6365.2,2076.6\" /></svg>"
+          "value": "<svg><polygon points=\"6365.9,2074.5 6371.0,7796.0 6133.0,7796.0 6078.5,6177.4 1.3,6381.7 -0.0,784.0 5508.4,865.8 6252.9,668.3 6272.6,1780.7 6365.9,2074.5\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +1761,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.57737072356691,
-                39.06818716411501
+                -94.57737479469162,
+                39.06819034954865
               ]
             }
           },
@@ -1474,8 +1782,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5775217667562,
-                39.06523283557171
+                -94.5775222161624,
+                39.06523409877044
               ]
             }
           },
@@ -1495,8 +1803,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58214460367442,
-                39.06537732746821
+                -94.58214806093088,
+                39.06537512603555
               ]
             }
           },
@@ -1516,8 +1824,560 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.58199356048513,
-                39.06833165601151
+                -94.5820006394601,
+                39.06833137681376
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p463",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4101.6,881.9 4099.1,1411.2 6536.0,1391.9 6536.0,7362.0 6028.8,7357.6 6038.0,6638.3 -0.0,6593.8 54.7,888.7 4101.6,881.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5734094826939,
+                39.07060548323738
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57358230810604,
+                39.067653314256184
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57811784229685,
+                39.067813358457165
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57794501688471,
+                39.07076552743836
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p464",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6371
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"505.4,7435.0 431.9,1636.8 6106.9,1564.0 6148.4,4372.5 6062.6,4375.4 6018.1,7202.5 5260.3,7419.0 505.4,7435.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5735418840276,
+                39.06783865000835
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6371.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57375539380705,
+                39.06495244218441
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6371.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.578271622506,
+                39.06515669195245
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57805811272655,
+                39.06804289977639
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p465",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6536.0,414.5 6536.0,7526.6 4115.6,7554.3 4116.2,7026.6 81.7,7047.5 -0.0,7172.0 -0.0,332.7 6536.0,414.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56981332120289,
+                39.07047964403149
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57000008970755,
+                39.06751899268921
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57454861685986,
+                39.0676919503051
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5743618483552,
+                39.070652601647375
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p466",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6158.6,7795.0 457.1,7795.0 478.8,463.0 2034.9,462.4 2037.6,672.1 6102.1,651.9 6129.0,4599.8 6154.4,4599.9 6158.6,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56996031563764,
+                39.06773491044653
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57012611428954,
+                39.064853270750724
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57465848027749,
+                39.065010471135764
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5744926816256,
+                39.06789211083157
               ]
             }
           }
@@ -1542,8 +2402,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1562,7 +2422,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7434.1 0.0,-0.0 142.7,-0.0 142.9,139.9 6536.0,3.8 6536.0,7534.5 -0.0,7434.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7441.7 -0.0,0.0 138.8,-0.0 139.1,145.3 6536.0,1.1 6536.0,7533.8 -0.0,7441.7\" /></svg>"
         }
       },
       "body": {
@@ -1591,8 +2451,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.56546255774731,
-                39.07036919916323
+                -94.56545927727899,
+                39.07036716602519
               ]
             }
           },
@@ -1612,8 +2472,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.56564477257848,
-                39.06724701513892
+                -94.56564646783134,
+                39.06724600350472
               ]
             }
           },
@@ -1633,8 +2493,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.57040782633328,
-                39.06741694758588
+                -94.57040796322902,
+                39.06742057627909
               ]
             }
           },
@@ -1654,8 +2514,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.57022561150211,
-                39.0705391316102
+                -94.57022077267666,
+                39.07054173879956
               ]
             }
           }
@@ -1680,8 +2540,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1700,7 +2560,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5925.6,7777.1 519.2,7795.0 519.4,7608.5 768.2,7607.7 753.3,-0.0 5806.5,-0.0 5925.6,7777.1\" /></svg>"
+          "value": "<svg><polygon points=\"2004.4,7795.0 2001.5,7599.2 749.4,7601.7 752.1,-0.0 5889.2,-0.0 5912.7,7776.4 2004.4,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -1729,8 +2589,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.56565151113283,
-                39.06760210200188
+                -94.56565450451393,
+                39.067600700311864
               ]
             }
           },
@@ -1750,8 +2610,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.56583416395166,
-                39.06460061351057
+                -94.56583317306934,
+                39.064598258448726
               ]
             }
           },
@@ -1771,8 +2631,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.57052193323808,
-                39.06477501682587
+                -94.57052243523295,
+                39.064768857308216
               ]
             }
           },
@@ -1792,8 +2652,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.57033928041926,
-                39.067776505317184
+                -94.57034376667754,
+                39.067771299171355
               ]
             }
           }
@@ -1818,8 +2678,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,7 +2698,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6110.6,7795.0 294.9,7795.0 226.6,0.0 6098.2,0.0 6110.6,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6099.5,0.0 6109.6,7795.0 348.6,7795.0 232.1,0.0 6099.5,0.0\" /></svg>"
         }
       },
       "body": {
@@ -1867,8 +2727,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.56568710482728,
-                39.07027855019029
+                -94.56569026172315,
+                39.070281965726544
               ]
             }
           },
@@ -1888,8 +2748,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.56183448826373,
-                39.07015115377979
+                -94.56183485685656,
+                39.07015537573579
               ]
             }
           },
@@ -1909,8 +2769,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.56202883675897,
-                39.06655820215067
+                -94.56202797512512,
+                39.06655982373422
               ]
             }
           },
@@ -1930,8 +2790,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.56588145332252,
-                39.066685598561165
+                -94.5658833799917,
+                39.06668641372497
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p470",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"165.7,0.0 6012.2,0.0 6077.5,7726.2 2215.7,7795.0 2210.0,7771.5 203.1,7765.3 165.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56219127424723,
+                39.0701492817402
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55842012483502,
+                39.07001517163978
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55862958637442,
+                39.06641445587342
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56240073578662,
+                39.06654856597384
               ]
             }
           }
@@ -1956,8 +2954,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1976,7 +2974,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6243.6,0.0 6248.1,7795.0 320.9,7795.0 279.5,0.0 6243.6,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6243.9,0.0 6251.6,7795.0 320.2,7795.0 275.6,0.0 6243.9,0.0\" /></svg>"
         }
       },
       "body": {
@@ -2005,8 +3003,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.55880312978788,
-                39.070058277612326
+                -94.55880064515763,
+                39.07005968192293
               ]
             }
           },
@@ -2026,8 +3024,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.55497819701132,
-                39.06993197109567
+                -94.55497846388843,
+                39.06993222919656
               ]
             }
           },
@@ -2047,8 +3045,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.55517088222254,
-                39.06636482616037
+                -94.55517289768449,
+                39.06636765032611
               ]
             }
           },
@@ -2068,8 +3066,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5589958149991,
-                39.06649113267702
+                -94.55899507895369,
+                39.066495103052475
               ]
             }
           }
@@ -2094,8 +3092,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2114,7 +3112,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"291.3,7767.1 280.8,40.8 6386.0,0.0 6386.0,258.3 6118.3,259.7 6129.9,7761.7 291.3,7767.1\" /></svg>"
+          "value": "<svg><polygon points=\"286.0,7772.6 280.9,24.5 6386.0,0.0 6386.0,260.3 6124.4,261.4 6130.9,7704.5 6386.0,7771.2 286.0,7772.6\" /></svg>"
         }
       },
       "body": {
@@ -2143,8 +3141,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.55531564258604,
-                39.06996228630911
+                -94.5553156406153,
+                39.06996094416888
               ]
             }
           },
@@ -2164,8 +3162,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.55150906295401,
-                39.069834080533894
+                -94.55151296898636,
+                39.069834982641225
               ]
             }
           },
@@ -2185,8 +3183,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.55170930188474,
-                39.06619952009388
+                -94.55170970303617,
+                39.06620415932452
               ]
             }
           },
@@ -2206,7097 +3204,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.55551588151677,
-                39.066327725869094
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p476",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6386
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6085.3,7755.5 241.3,7740.1 226.6,68.6 6058.2,108.3 6085.3,7755.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59039145128392,
-                39.06575476391245
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6386.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58660457418803,
-                39.065615047704014
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6386.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58682277781503,
-                39.06199908501482
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59060965491092,
-                39.062138801223256
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p477",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6531
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6280.7,7796.0 220.2,7796.0 182.0,194.2 2244.8,172.5 2243.3,0.0 5990.4,52.7 5987.4,1430.3 6407.1,1729.2 6272.0,2228.0 6280.7,7796.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58690328073469,
-                39.065665139951285
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6531.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5830710757882,
-                39.06551969176113
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6531.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58329308435606,
-                39.06194335322672
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58712528930256,
-                39.06208880141686
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p480",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6402
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"197.9,7757.7 171.6,0.0 5688.6,0.0 5718.5,7771.3 197.9,7757.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57638077841817,
-                39.06517293934752
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6402.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57265164252627,
-                39.06504360182712
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6402.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57285313063555,
-                39.0614916502907
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57658226652745,
-                39.0616209878111
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p481",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6494
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"429.1,7552.1 428.8,7731.3 -0.0,7728.6 -0.0,42.3 462.2,44.1 462.4,14.9 2033.3,231.0 2677.8,16.8 6203.1,0.0 6214.7,3887.9 6411.5,3886.4 6388.9,7537.0 429.1,7552.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57306620225816,
-                39.06507751167588
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6494.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56923860189895,
-                39.06495628254704
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6494.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56942466703374,
-                39.06136441595809
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57325226739296,
-                39.06148564508693
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p482",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6402
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6245.6,0.0 6294.2,7795.0 340.1,7792.9 333.9,3904.8 137.0,3907.8 95.0,17.1 6245.6,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.569465424622,
-                39.064972969059646
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6402.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56569596367642,
-                39.064830526900444
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6402.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56591786693146,
-                39.0612401682262
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56968732787703,
-                39.06138261038541
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p483",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6494
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6494.0,7724.4 3954.8,7700.3 3874.1,7795.0 54.4,7693.6 160.4,68.1 6494.0,128.1 6494.0,7724.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5610506369699,
-                39.06658786444654
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6494.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5611777394732,
-                39.06351444568608
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6494.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56589502200906,
-                39.06363371688419
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56576791950576,
-                39.066707135644656
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p484",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6402
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1124.1,63.7 6258.3,85.4 6402.0,7664.0 1224.4,7681.0 1124.1,63.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56118599458823,
-                39.064044960261654
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6402.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56136165643053,
-                39.06102701689671
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6402.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56606309991909,
-                39.06119433425976
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56588743807679,
-                39.064212277624705
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p492",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6414
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6414.0,2229.8 6105.3,7623.2 75.1,7461.2 169.9,7311.2 44.9,0.0 6414.0,0.0 6414.0,2229.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60371521884136,
-                39.0606560322617
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6414.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59992762220985,
-                39.06060464489626
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6414.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.6000074711396,
-                39.05700577683607
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.6037950677711,
-                39.05705716420151
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p494",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6430
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"187.6,-0.0 6430.0,-0.0 6430.0,4570.6 5403.4,5024.4 5323.1,4850.0 5637.4,7716.6 185.5,7737.3 187.6,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59554727522813,
-                39.05699740057091
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6430.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59572796697883,
-                39.054075106021706
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6430.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60025730916277,
-                39.05424637502527
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60007661741207,
-                39.057168669574466
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p495",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6452
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6196.4,7673.8 142.3,7638.2 188.4,1006.2 3924.1,1013.6 4932.8,0.0 6255.9,0.0 6196.4,7673.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59759280374537,
-                39.06167842691622
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6452.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59383102384056,
-                39.06156143724729
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6452.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59401179791398,
-                39.05800709131915
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59777357781877,
-                39.05812408098807
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p499",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6500
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6500.0,7710.0 141.2,7690.7 208.9,2012.3 -0.0,2010.7 118.1,-0.0 6500.0,86.7 6500.0,7710.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58576661084233,
-                39.062093721879684
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6500.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58591001577051,
-                39.05899106569392
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6500.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59066893719064,
-                39.05912556069508
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59052553226246,
-                39.062228216880854
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p501",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6500
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"75.7,7795.0 33.3,-0.0 4363.0,-0.0 2829.8,7010.1 6180.3,7755.0 75.7,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58108994133508,
-                39.06190648983611
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6500.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58126684607427,
-                39.05886363018734
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6500.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58593403947246,
-                39.05902954399824
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58575713473327,
-                39.062072403647015
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p503",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6500
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5648.3,408.4 5655.1,6640.4 -0.0,6623.0 104.8,373.2 5671.3,382.9 5648.3,408.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57277903817823,
-                39.06154724929158
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6500.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57294094818839,
-                39.05860113125125
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6500.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57745973822587,
-                39.0587529825912
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57729782821569,
-                39.06169910063153
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p504",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6454
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6290.4,7795.0 1900.7,7795.0 1904.9,6607.0 -0.0,6599.0 -0.0,6343.7 -0.0,6343.7 -0.0,1622.4 -0.0,1479.3 -0.0,0.0 6321.4,-0.0 6290.4,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57293774974919,
-                39.058987936240115
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6454.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57309471748236,
-                39.05605692990007
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6454.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57762080076115,
-                39.056205154818926
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57746383302798,
-                39.05913616115897
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p505",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6500
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6500.0,121.2 6500.0,7441.9 5470.8,7437.9 5469.5,7768.6 -0.0,7737.5 -0.0,1949.6 230.3,1951.6 236.6,63.2 6500.0,121.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56829716345295,
-                39.061450132238285
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6500.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56844693449924,
-                39.058365476422765
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6500.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57317820574889,
-                39.05850594321883
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57302843470261,
-                39.06159059903435
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p506",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6454
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6263.1,167.3 6254.7,7393.0 1263.7,7398.4 1227.4,119.1 6263.1,167.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56841565415559,
-                39.05895106478964
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6454.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5685849239323,
-                39.05587044001022
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6454.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57334204471925,
-                39.05603028192173
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57317277494253,
-                39.05911090670116
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p508",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6454
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,58.9 6205.2,109.8 6166.9,7771.9 -0.0,7717.0 -0.0,58.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56376664532516,
-                39.05875504777081
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6454.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56393640343066,
-                39.05566783636853
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6454.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56870367668972,
-                39.055828140036816
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56853391858424,
-                39.0589153514391
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p509",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6477
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6477.0,1128.4 6477.0,2278.3 5540.4,2282.0 5558.7,7737.6 262.0,7748.5 240.5,3940.8 -0.0,3939.3 -0.0,2011.8 236.7,2010.4 224.7,-0.0 6313.6,-0.0 6307.1,1103.5 6477.0,1128.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55906654909595,
-                39.061123857795614
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6477.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55924346411905,
-                39.058122281375645
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6477.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56386434982305,
-                39.05828882149541
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56368743479995,
-                39.06129039791538
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p511",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6477
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"188.6,6705.8 -0.0,0.0 128.9,-0.0 129.2,749.7 6477.0,594.2 6477.0,6655.2 188.6,6705.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55522689623484,
-                39.06094813362475
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6477.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55542013185413,
-                39.05804269406834
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6477.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55989300823195,
-                39.05822459801167
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55969977261265,
-                39.06113003756808
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p513",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6477
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6311.5,7631.7 6307.5,7795.0 -0.0,7795.0 -0.0,1900.9 648.9,1911.1 506.3,2159.3 726.6,1915.5 -0.0,1874.5 -0.0,218.9 1335.5,240.9 1363.0,-0.0 6477.0,54.7 6477.0,7634.0 6311.5,7631.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55100669561817,
-                39.060898799425345
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6477.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55111279160235,
-                39.05787761025831
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6477.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55576385144116,
-                39.05797748482735
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55565775545698,
-                39.06099867399438
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p514",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6423
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6423.0,7793.0 6198.4,7647.5 975.4,7627.9 852.3,16.8 6423.0,2.9 6423.0,7793.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55111335550576,
-                39.05827374391506
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6423.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55127981581263,
-                39.05529132161929
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6423.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55590818522211,
-                39.05544929518105
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55574172491524,
-                39.05843171747682
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p516",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6423
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1730.0,7795.0 1731.1,7081.7 -0.0,7089.5 113.4,628.6 6423.0,619.3 6423.0,7045.0 3602.0,7074.7 3606.2,7795.0 1730.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60379695216713,
-                39.0575016353919
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6423.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60003171607536,
-                39.05736696730139
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6423.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60024070179513,
-                39.05379363915478
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.6040059378869,
-                39.05392830724529
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p517",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6477
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6477.0,4542.3 6452.8,5929.7 5541.6,5835.6 5346.2,7755.7 2427.9,7461.1 2393.7,7795.0 1449.2,7795.0 1495.0,7366.9 760.8,7292.8 1037.6,4405.3 -0.0,4305.8 -0.0,1371.5 50.5,1559.9 4995.5,-0.0 6477.0,4542.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59773060992609,
-                39.05472212657804
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6477.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59750476541063,
-                39.051825918849985
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6477.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.601963020088,
-                39.051613298727865
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60218886460345,
-                39.05450950645592
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p519",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6433
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"461.1,1944.4 4637.0,3760.1 5121.6,2646.2 5842.2,7315.6 2859.4,7418.5 2853.9,6636.4 2015.8,6637.3 983.2,7795.0 495.6,7795.0 461.1,1944.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59903765425193,
-                39.05493151858655
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6433.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5955248809042,
-                39.05597166049677
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6433.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59391277879777,
-                39.05264198608476
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59742555214551,
-                39.05160184417454
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p520",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6438
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5696.7 -0.0,-0.0 143.7,0.0 138.4,1374.7 335.1,1158.2 634.9,1158.5 1669.7,0.0 2508.7,0.0 2513.4,783.3 5894.7,721.4 5943.4,4056.5 4330.9,7790.4 185.8,5986.1 182.9,5774.0 -0.0,5696.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59747474608973,
-                39.05215188679964
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6438.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59396405694379,
-                39.05319454415708
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6438.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5923501271674,
-                39.04987084826263
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59586081631333,
-                39.04882819090519
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p521",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6481
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,548.2 390.8,0.0 1026.9,0.0 6339.0,3242.4 6481.0,5825.9 6264.1,6554.7 6261.0,7542.4 4426.3,7595.7 4738.9,7795.0 75.4,7795.0 385.2,5467.3 -0.0,5369.7 -0.0,548.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59587723718188,
-                39.05488287629405
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6481.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59258826273118,
-                39.05633857569828
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6481.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5903487986124,
-                39.053244137989346
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5936377730631,
-                39.05178843858512
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p522",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6438
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6135.6,7409.5 571.4,7520.6 539.2,3429.5 136.4,2522.3 4090.2,0.0 5953.8,0.0 6438.0,852.5 4969.8,1850.6 6127.3,3530.0 6135.6,7409.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59360147443473,
-                39.05295058418179
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6438.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5898732827087,
-                39.052796750348385
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6438.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59011140242103,
-                39.04926714070228
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59383959414707,
-                39.04942097453568
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p523",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6481
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2076.9,4028.4 -0.0,4042.1 1357.4,2991.5 1420.3,2947.9 4812.6,594.4 5095.3,753.3 6481.0,716.8 6481.0,6222.1 6312.6,5989.6 4374.7,7322.9 3780.3,6459.7 2273.5,7550.4 1106.5,5881.9 2632.9,4829.7 2076.9,4028.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59121882931869,
-                39.05469087277745
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6481.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58746211959364,
-                39.05451639142852
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6481.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58773053913559,
-                39.05098182484282
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59148724886064,
-                39.05115630619175
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p524",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6438
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6378.0,7552.7 -0.0,7570.7 -0.0,3764.2 1548.5,2685.0 2120.7,3550.4 4062.5,2266.1 4224.8,2499.3 4270.2,1210.4 6415.5,1208.1 6378.0,7552.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59009374243061,
-                39.05291973728198
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6438.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58631899951823,
-                39.05279934991473
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6438.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58650534751163,
-                39.049225671237636
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59028009042402,
-                39.0493460586049
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p525",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6481
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"966.7,7795.0 376.1,6991.4 177.2,6367.2 87.7,5075.2 169.4,240.0 6149.2,246.3 6103.4,5625.2 4687.5,5640.8 4406.0,5476.8 966.7,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59085451786436,
-                39.05685325671102
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6481.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58711216741551,
-                39.056724353261615
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6481.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58731047678661,
-                39.05320340693181
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59105282723546,
-                39.053332310381215
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p539",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6456
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6438.9,6351.2 5658.9,7109.1 5674.6,7788.8 248.5,7795.0 207.9,-0.0 6456.0,35.0 6438.9,6351.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57361420545742,
-                39.05084763459565
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6456.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57376674111788,
-                39.0477896636103
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6456.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57848833254782,
-                39.0479337201441
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57833579688737,
-                39.05099169112945
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p540",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6472
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7109.0 822.0,6346.3 968.3,-0.0 6243.5,150.2 6259.0,1307.8 6472.0,1118.4 6472.0,6010.7 6275.5,6112.0 6263.0,7795.0 -0.0,7795.0 -0.0,7109.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57378357417866,
-                39.048245356152435
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6472.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57384554126259,
-                39.04520503837484
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6472.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57852810112894,
-                39.0452634182744
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57846613404502,
-                39.048303736052
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p541",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6456
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6456.0,696.6 6456.0,2905.3 5790.1,2896.8 5728.3,7145.7 98.9,7070.1 177.8,648.0 6456.0,696.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56953495735864,
-                39.05068964236192
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6456.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56965629793844,
-                39.04777829526398
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6456.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57415149453792,
-                39.04789289087349
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57403015395812,
-                39.05080423797143
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p543",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6456
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6456.0,173.2 6456.0,2160.9 5622.7,2159.4 5589.2,7658.4 144.4,7667.5 165.6,153.1 6456.0,173.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56537744078162,
-                39.050538599391516
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6456.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56553581751176,
-                39.04755523206779
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6456.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57014220760878,
-                39.04770480534334
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56998383087864,
-                39.050688172667066
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p544",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6472
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6244.7,463.3 6472.0,462.9 6472.0,4034.3 6235.4,4038.0 6249.3,7583.2 -0.0,7603.4 -0.0,2134.9 828.6,2131.3 816.6,154.7 6242.9,128.3 6244.7,463.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56552315532792,
-                39.04793450304566
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6472.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56570624547535,
-                39.04492771242875
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6472.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57033714831773,
-                39.045100204499114
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5701540581703,
-                39.04810699511602
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p545",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6456
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3730.7 173.4,3730.9 207.9,0.0 2163.2,0.0 2258.7,183.1 6456.0,106.4 6277.0,7731.5 6456.0,7779.3 110.9,7795.0 69.4,6759.3 -0.0,6573.0 -0.0,3730.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57875908094705,
-                39.04536783345983
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6456.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57502496391895,
-                39.04526793074417
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6456.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57517920391028,
-                39.04174109816564
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57891332093838,
-                39.0418410008813
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p546",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6472
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6323.9,0.0 6186.9,7738.6 254.6,7700.8 369.0,284.2 1225.3,261.7 1028.5,51.8 1380.1,2.5 6323.9,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57523932010531,
-                39.04535919835028
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6472.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57139132066101,
-                39.045231988706675
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6472.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57158723406003,
-                39.04160657526441
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57543523350434,
-                39.04173378490802
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p547",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6433
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4192.5,7784.0 274.5,7661.5 512.8,0.0 6176.3,24.6 6175.6,260.1 6433.0,264.9 6433.0,7795.0 5868.4,7795.0 5862.8,7551.8 4192.5,7784.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57178675689705,
-                39.04522201344224
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6433.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56794475696398,
-                39.045135020124086
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6433.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56807956719007,
-                39.041492751256825
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57192156712314,
-                39.04157974457498
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p551",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6231.1,7795.0 -0.0,7795.0 -0.0,217.9 6218.2,258.2 6231.1,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57656352480885,
-                39.0418892925579
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6400.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57284978123546,
-                39.04179542246863
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6400.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5729959685522,
-                39.0382569716611
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57670971212559,
-                39.038350841750365
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p554",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6512
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"944.5,155.3 5495.9,156.0 5402.9,7474.9 6512.0,7485.1 6512.0,7795.0 2072.0,7795.0 2065.4,5637.8 925.0,5671.4 944.5,155.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60298806395872,
-                39.0525862326962
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6512.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60313305485921,
-                39.04960132191412
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6512.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60770232764214,
-                39.04973707193124
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60755733674166,
-                39.05272198271332
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p556",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6512
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6512.0,7795.0 653.7,7795.0 624.9,203.4 6512.0,176.8 6512.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59351803372118,
-                39.04962471555063
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6512.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5897331130624,
-                39.04952020904533
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6512.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58989308296171,
-                39.04597634778789
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5936780036205,
-                39.04608085429319
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p561",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6400.0,6899.4 -0.0,6957.1 29.9,3828.4 185.3,2970.6 -0.0,2876.1 -0.0,1052.0 6400.0,941.2 6400.0,6899.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59641344034455,
-                39.049761431624574
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6400.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59659062450787,
-                39.046864770876304
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6400.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60110222315633,
-                39.047033572178094
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.60092503899303,
-                39.049930232926364
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p565",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6392
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4099.3,6777.9 3388.8,7616.2 3056.8,7795.0 593.0,7795.0 550.4,274.8 6392.0,216.5 6392.0,7795.0 5282.8,7795.0 4628.2,6564.9 4099.3,6777.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58685343744717,
-                39.04947736935796
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6392.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58306547501856,
-                39.04934163081434
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6392.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58327715230503,
-                39.04572832502692
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58706511473363,
-                39.04586406357054
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p568",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6517
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"464.9,7770.9 340.0,284.9 -0.0,290.2 -0.0,-0.0 6517.0,0.0 6517.0,7796.0 464.9,7770.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.54844477609691,
-                39.069758089771405
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6517.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.54454901551367,
-                39.069594494724306
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6517.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.54479935045818,
-                39.06595012489643
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.54869511104143,
-                39.06611371994353
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p569",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6360
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1924.3 -0.0,-0.0 2254.5,121.9 2254.9,950.9 4267.4,872.4 4266.5,801.5 5948.7,806.7 5946.8,0.0 6360.0,0.0 6360.0,5872.6 2258.7,5908.9 2259.9,7795.0 283.3,7795.0 257.6,1949.3 -0.0,1924.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5511237459717,
-                39.061143260022355
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6360.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.54747100191456,
-                39.061017693445834
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6360.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.54766783427802,
-                39.05751641847753
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55132057833515,
-                39.05764198505406
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p570",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6517
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6517.0,7796.0 -0.0,7796.0 -0.0,6992.9 421.3,6996.5 453.4,1844.3 2404.3,1861.5 2419.6,0.0 6517.0,0.0 6517.0,7796.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55138405377377,
-                39.058483246297584
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6517.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.54759072719732,
-                39.058379097052715
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6517.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5477500724548,
-                39.05482999304634
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55154339903126,
-                39.05493414229121
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p574 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6517
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1025.6,3379.7 1410.9,2912.5 1654.2,2849.0 1984.1,3472.5 2545.6,3473.8 2553.7,0.0 6462.7,0.0 6517.0,75.0 6517.0,5540.8 6405.6,5541.8 6517.0,7796.0 -0.0,7796.0 -0.0,3467.8 857.3,3469.8 1025.6,3379.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58608071380952,
-                39.049011155019166
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6517.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57845058614402,
-                39.04875173566576
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6517.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57884742610405,
-                39.04161170150779
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58647755376956,
-                39.041871120861195
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p576",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6491
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6491.0,7730.9 -0.0,7795.0 0.0,-0.0 6491.0,0.0 6491.0,7730.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59925517915335,
-                39.07158911166376
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6491.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5953349441332,
-                39.07140474885564
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6491.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59561810828974,
-                39.06772402040304
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59953834330989,
-                39.06790838321116
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p456",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6367
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"255.2,6647.3 256.0,136.0 5090.6,160.1 6367.0,169.6 6134.5,4212.0 6135.0,6668.0 255.2,6647.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                256.0,
-                136.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59359,
-                39.067688
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6135.0,
-                6668.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.590323,
-                39.064603
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p463",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6536
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"29.9,7403.5 54.8,888.7 4101.6,881.9 4099.1,1411.2 6140.2,1395.0 6080.9,7357.6 29.9,7403.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4080.0,
-                5375.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.576645,
-                39.068873
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4088.0,
-                3403.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.575498,
-                39.068828
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p464",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "39"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6371
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5240.9,7416.5 -0.0,7422.9 -0.0,1442.4 396.8,1435.3 398.7,1629.0 6109.4,1567.7 6004.1,7201.7 5240.9,7416.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1959.7,
-                3392.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.575577,
-                39.067027
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1959.7,
-                5396.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.576739,
-                39.067077
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p465",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6536
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6536.0,7526.6 4115.6,7554.3 4116.2,7026.6 81.7,7047.5 -0.0,332.7 6536.0,414.5 6536.0,7526.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4120.0,
-                2551.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57142,
-                39.06867
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4120.0,
-                5571.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.573182,
-                39.068737
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p466",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "18"
-        }
-      ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6386
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6158.8,7795.0 457.1,7795.0 478.0,656.0 6109.9,651.9 6122.2,2354.5 6343.5,3006.8 6129.0,4599.8 6158.8,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2016.6,
-                5607.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.573273,
-                39.066938
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6109.9,
-                651.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.570498,
-                39.064991
+                -94.55551237466511,
+                39.06633012085218
               ]
             }
           }
@@ -9314,15 +3223,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9341,34 +3250,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"253.6,7796.0 275.8,0.0 6254.5,0.0 6265.8,7796.0 253.6,7796.0\" /></svg>"
+          "value": "<svg><polygon points=\"275.8,0.0 6254.5,0.0 6265.8,7796.0 253.6,7796.0 275.8,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0473/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2255.7,
-                3824.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.550625,
-                39.0679838
+                -94.55183332105112,
+                39.06972308587126
               ]
             }
           },
@@ -9376,20 +3288,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6247.0,
-                3824.0
+                6531.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5483382,
-                39.0679157
+                -94.54809149299501,
+                39.069611655710936
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6531.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54826278242703,
+                39.06614422874911
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55200461048314,
+                39.066255658909434
               ]
             }
           }
@@ -9407,11 +3361,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -9430,8 +3384,8 @@
           "value": "2841.6"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9450,7 +3404,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2270.5,2681.5 0.0,2841.6 -0.0,-0.0 1926.8,-0.0 2249.5,1243.7 2270.5,2681.5\" /></svg>"
+          "value": "<svg><polygon points=\"2268.6,2557.2 0.0,2581.1 -0.0,-0.0 1927.2,0.0 2249.6,1245.6 2268.6,2557.2\" /></svg>"
         }
       },
       "body": {
@@ -9479,8 +3433,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59874466102855,
-                39.062490820049305
+                -94.59874631959488,
+                39.0624925271782
               ]
             }
           },
@@ -9500,8 +3454,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59722809246729,
-                39.06242431754165
+                -94.59722771985734,
+                39.06242593560215
               ]
             }
           },
@@ -9521,8 +3475,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59732202065895,
-                39.06113526447877
+                -94.59732177384926,
+                39.06113515607991
               ]
             }
           },
@@ -9542,29 +3496,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59883858922021,
-                39.061201766986436
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2270.5,
-                2681.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5975063,
-                39.0612162
+                -94.5988403735868,
+                39.06120174765596
               ]
             }
           }
@@ -9582,11 +3515,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -9605,8 +3538,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9625,34 +3558,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5278.9 -0.0,635.3 1216.4,650.7 1476.5,0.0 6338.9,0.0 6386.0,6709.9 6302.7,6613.0 5042.7,6612.4 4112.6,7598.0 296.1,7613.0 299.5,6186.0 -0.0,5278.9\" /></svg>"
+          "value": "<svg><polygon points=\"299.5,6186.0 -0.0,5278.8 -0.0,635.2 1200.6,650.5 1130.7,790.0 4235.6,761.3 4243.6,0.0 6339.0,0.0 6386.0,6709.9 6302.6,6624.0 5034.7,6620.9 4112.6,7598.0 296.1,7613.0 299.5,6186.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0474__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6314.0,
-                2911.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5938524,
-                39.0632582
+                -94.59750317638402,
+                39.06470453692299
               ]
             }
           },
@@ -9660,20 +3596,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                296.1,
-                7615.0
+                6386.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5975063,
-                39.0612162
+                -94.5937420925748,
+                39.06458897362419
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59392384535636,
+                39.06102274008866
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59768492916558,
+                39.06113830338746
               ]
             }
           }
@@ -9691,15 +3669,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9725,27 +3703,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0475/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6259.0,
-                4356.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.590431,
-                39.062719
+                -94.5939760422364,
+                39.064821997465764
               ]
             }
           },
@@ -9753,20 +3734,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6259.0,
-                204.0
+                6531.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.590323,
-                39.064603
+                -94.59015873664198,
+                39.064690072986814
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6531.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59036152276913,
+                39.06115258165733
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59417882836355,
+                39.06128450613628
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p476",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6091.1,7747.6 247.5,7745.9 214.8,74.8 6046.2,100.9 6091.1,7747.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59038415355408,
+                39.0657576267477
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58659753156762,
+                39.06561098358698
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5868265534535,
+                39.06199526449327
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59061317543997,
+                39.06214190765399
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p477",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6531
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"219.1,7796.0 185.5,193.3 4478.0,0.0 4481.5,156.3 5954.3,93.5 5957.1,7796.0 219.1,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58690552265837,
+                39.065664850999674
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6531.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58306990905355,
+                39.06552107234248
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6531.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58328936928706,
+                39.061941552737046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58712498289188,
+                39.06208533139424
               ]
             }
           }
@@ -9784,15 +4083,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9811,34 +4110,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6305.8,7795.0 309.8,7795.0 289.1,2210.5 424.5,1703.4 -0.0,1400.2 0.0,-0.0 2150.5,0.0 2152.4,180.3 6247.8,103.5 6305.8,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"318.4,7795.0 318.4,7786.5 -0.0,7786.4 -0.0,62.1 2163.5,0.0 2165.3,211.9 6236.9,140.8 6270.9,7795.0 318.4,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0478/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                300.1,
-                3983.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.583332,
-                39.063703
+                -94.58340950230993,
+                39.065519268467995
               ]
             }
           },
@@ -9846,20 +4148,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6290.0,
-                3983.5
+                6402.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.579852,
-                39.063567
+                -94.57966242271137,
+                39.065379890757676
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5798795529506,
+                39.06181086529324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58362663254917,
+                39.06195024300356
               ]
             }
           }
@@ -9877,15 +4221,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9904,34 +4248,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6327.2,7795.0 326.1,7795.0 264.2,37.1 2145.7,0.0 6494.0,0.0 6248.5,63.9 6327.2,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"357.2,7765.0 353.4,72.3 6252.1,0.0 6274.4,7795.0 357.2,7765.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2303.3,
-                3919.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.578691,
-                39.063518
+                -94.57996981270004,
+                39.06535951487748
               ]
             }
           },
@@ -9939,20 +4286,752 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6310.1,
-                3919.5
+                6494.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.576359,
-                39.063426
+                -94.57613546603498,
+                39.06522865433414
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57633631447183,
+                39.06163047117468
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58017066113689,
+                39.06176133171802
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p480",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6402
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6147.3,7776.8 192.9,7754.2 176.9,0.0 6161.6,0.0 6147.3,7776.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57638396083168,
+                39.06517131004222
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57265464794897,
+                39.0650458523868
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57285009182098,
+                39.06149373226902
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5765794047037,
+                39.061619189924436
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p481",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4457.5,7529.3 437.1,7549.5 459.3,25.2 6187.9,0.0 6187.9,0.0 6494.0,0.5 6494.0,7759.4 4456.5,7762.4 4457.5,7529.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57306461809026,
+                39.065082529613356
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5692292256465,
+                39.06495662765582
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5694224627416,
+                39.06135744888025
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57325785518536,
+                39.06148335083779
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p482",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6402
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"394.1,21.1 6233.1,0.0 6297.4,7795.0 458.9,7790.4 394.1,21.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56946079034016,
+                39.064975274557376
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56568871541836,
+                39.064826782792565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56592004207212,
+                39.06123391930477
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56969211699392,
+                39.06138241106958
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p483",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6494.0,7726.3 3949.7,7698.1 3948.1,7795.0 -0.0,7687.1 -0.0,2018.6 126.5,2019.9 161.4,61.2 6494.0,131.4 6494.0,7726.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56105496929158,
+                39.06658849640298
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56117574317591,
+                39.063514309798435
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56589420424883,
+                39.06362764230968
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5657734303645,
+                39.066701828914226
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p484",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6402
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1108.0,54.9 6244.4,84.4 6402.0,7667.2 1209.1,7676.3 1108.0,54.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56119279211826,
+                39.064037183696065
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56136248988635,
+                39.06102060428539
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56606181052322,
+                39.06118224081881
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56589211275514,
+                39.064198820229485
               ]
             }
           }
@@ -9970,15 +5049,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9997,34 +5076,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6494.0,7600.7 -0.0,7572.8 -0.0,3851.5 363.8,3853.9 311.3,-0.0 6494.0,73.3 6494.0,7600.7\" /></svg>"
+          "value": "<svg><polygon points=\"6494.0,7696.9 268.9,7666.6 230.3,3872.2 153.4,3871.6 172.1,-0.0 6494.0,26.0 6494.0,7696.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4170.7,
-                5775.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5600759,
-                39.0646765
+                -94.55647635275558,
+                39.06649217279967
               ]
             }
           },
@@ -10032,20 +5114,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4170.7,
-                1967.7
+                6494.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5577442,
-                39.0646067
+                -94.55662402032445,
+                39.06343845874848
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5613110509208,
+                39.063577028147115
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56116338335194,
+                39.066630742198306
               ]
             }
           }
@@ -10063,15 +5187,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10090,34 +5214,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6152.1,5789.3 5920.4,5790.9 5921.0,7665.4 857.9,7653.9 797.4,268.1 6125.9,251.1 6152.1,5789.3\" /></svg>"
+          "value": "<svg><polygon points=\"6125.0,57.2 6152.1,5789.3 5925.7,5790.8 5927.0,7665.4 919.7,7653.6 854.2,89.8 6125.0,57.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0486/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2315.3,
-                1979.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5578333,
-                39.0627891
+                -94.5565605496726,
+                39.063841300957016
               ]
             }
           },
@@ -10125,20 +5252,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2315.3,
-                7647.0
+                6430.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5612878,
-                39.0629145
+                -94.5567438209297,
+                39.06079746836439
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6430.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56149528211532,
+                39.0609699486749
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56131201085822,
+                39.064013781267526
               ]
             }
           }
@@ -10156,15 +5325,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10183,34 +5352,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6494.0,7594.1 403.6,7534.0 406.6,5757.5 479.9,5757.5 489.0,175.7 6494.0,167.8 6494.0,7594.1\" /></svg>"
+          "value": "<svg><polygon points=\"5575.7,7595.0 397.0,7587.1 489.0,175.7 5537.0,163.5 5575.7,7595.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0487/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4210.7,
-                3895.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5542754,
-                39.0644915
+                -94.55173908236534,
+                39.06645351000176
               ]
             }
           },
@@ -10218,20 +5390,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4210.7,
-                7599.0
+                6494.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5565848,
-                39.0645647
+                -94.55190442486737,
+                39.063308834671076
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55676513825831,
+                39.063462902489654
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55659979575628,
+                39.066607577820335
               ]
             }
           }
@@ -10249,15 +5463,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10276,34 +5490,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"794.3,91.1 5796.5,87.6 6082.3,7795.0 799.8,7795.0 794.3,91.1\" /></svg>"
+          "value": "<svg><polygon points=\"6230.8,7709.6 -0.0,7678.2 -0.0,1959.1 -0.0,50.4 6430.0,94.4 6230.8,7709.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2295.3,
-                5759.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5555349,
-                39.0627132
+                -94.55195135640628,
+                39.06377463670491
               ]
             }
           },
@@ -10311,20 +5528,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2295.3,
-                7615.0
+                6430.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5566761,
-                39.0627518
+                -94.55208953940434,
+                39.060718881989914
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6430.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55682617943765,
+                39.06084984670719
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55668799643959,
+                39.06390560142219
               ]
             }
           }
@@ -10342,15 +5601,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10369,34 +5628,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6494.0,7566.4 228.7,7548.7 160.2,7548.2 269.9,-0.0 6494.0,-0.0 6494.0,7566.4\" /></svg>"
+          "value": "<svg><polygon points=\"6494.0,-0.0 6494.0,7566.4 228.7,7548.7 269.9,-0.0 6494.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0489/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4226.7,
-                5599.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5508051,
-                39.0643694
+                -94.54743523398635,
+                39.066198569514526
               ]
             }
           },
@@ -10404,20 +5666,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                247.9,
-                5599.3
+                6494.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5507198,
-                39.066179
+                -94.54757445730293,
+                39.06324501132357
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55213964293351,
+                39.06337474439314
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55200041961693,
+                39.06632830258409
               ]
             }
           }
@@ -10435,15 +5739,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10462,34 +5766,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5610.2,3625.9 5483.0,5839.4 6015.0,5840.7 6037.9,7528.4 649.8,7546.6 614.7,-0.0 6298.3,-0.0 6430.0,3627.4 5610.2,3625.9\" /></svg>"
+          "value": "<svg><polygon points=\"6430.0,5841.9 6430.0,7544.9 649.8,7546.6 614.7,-0.0 5477.4,-0.0 5487.4,4051.2 5610.2,3625.9 5491.8,5844.2 6430.0,5841.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0490/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2343.3,
-                3607.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5497424,
-                39.0625278
+                -94.54757555868058,
+                39.06352472337348
               ]
             }
           },
@@ -10497,20 +5804,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2343.3,
-                7551.0
+                6430.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5520492,
-                39.0626017
+                -94.54773077138722,
+                39.06060363048258
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6430.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55229056165092,
+                39.06074970664892
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55213534894428,
+                39.06367079953982
               ]
             }
           }
@@ -10528,15 +5877,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10555,34 +5904,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6292.6,7795.0 -0.0,7795.0 -0.0,-0.0 6401.4,185.4 6414.8,7297.2 6292.6,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6414.8,7297.2 6317.8,7448.9 2279.2,7308.7 2260.6,7795.0 -0.0,7795.0 -0.0,0.0 6401.4,185.4 6414.8,7297.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0491/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2247.3,
-                3811.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.6061096,
-                39.05888
+                -94.60740426449631,
+                39.060620504022204
               ]
             }
           },
@@ -10590,20 +5942,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                275.9,
-                3811.5
+                6494.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.607263,
-                39.0588881
+                -94.60360482920218,
+                39.060593821669265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60364606847281,
+                39.057053164886774
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60744550376694,
+                39.05707984723971
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p492",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6414
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"86.3,7457.4 181.0,7307.5 92.4,0.0 6414.0,0.0 6414.0,2920.1 6112.4,7621.2 86.3,7457.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60372324867835,
+                39.06065664766586
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6414.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59993311695341,
+                39.06060617073271
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6414.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60001155114387,
+                39.05700489150284
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6038016828688,
+                39.05705536843599
               ]
             }
           }
@@ -10621,11 +6153,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -10644,8 +6176,8 @@
           "value": "3654.7"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10664,34 +6196,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3447.6,136.0 3469.2,3654.7 -0.0,3654.7 -0.0,2355.1 251.3,2356.1 105.4,157.3 3447.6,136.0\" /></svg>"
+          "value": "<svg><polygon points=\"3446.7,3654.7 -0.0,3654.7 -0.0,136.4 3447.6,136.0 3446.7,3654.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3447.6,
-                3966.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.599912,
-                39.059743
+                -94.5974204790812,
+                39.06126976807195
               ]
             }
           },
@@ -10699,20 +6234,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3447.6,
-                136.0
+                3559.6,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.597599,
-                39.059649
+                -94.59751964134082,
+                39.05959331614887
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3559.6,
+                3654.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59973685401258,
+                39.059672391757644
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3654.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59963769175295,
+                39.061348843680726
               ]
             }
           }
@@ -10730,11 +6307,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -10753,8 +6330,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10773,34 +6350,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6324.3,157.5 6332.0,7581.0 -0.0,7474.9 -0.0,7080.7 606.5,7083.0 619.7,3529.8 3755.1,3524.5 3739.0,181.2 6324.3,157.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7483.8 -0.0,7100.3 606.4,7098.7 619.7,3529.8 3755.1,3524.5 3738.7,-0.0 6328.9,-0.0 6332.0,7581.0 -0.0,7483.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3752.0,
-                7583.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.600113,
-                39.058286
+                -94.5954699361211,
+                39.059857062333336
               ]
             }
           },
@@ -10808,20 +6388,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6332.0,
-                7583.0
+                6452.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.600188,
-                39.057088
+                -94.59565749426068,
+                39.056861133651154
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6452.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6003194591898,
+                39.0570371096052
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60013190105023,
+                39.06003303828738
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p494",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6430
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"187.4,-0.0 6430.0,-0.0 6430.0,4564.8 5393.5,5023.9 5281.9,4754.4 5619.2,7709.1 190.5,7726.5 187.4,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59554675583834,
+                39.0569973159128
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6430.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59573005864448,
+                39.05407373075257
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6430.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60026140196833,
+                39.05424747461957
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60007809916219,
+                39.057171059779805
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p495",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6452
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6207.1,7669.6 147.5,7645.7 180.9,1007.9 3943.4,984.1 4914.0,0.0 6251.6,0.0 6207.1,7669.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59758716108239,
+                39.06167875861501
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6452.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59382897408149,
+                39.06155619159209
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6452.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59401836636033,
+                39.05800524044612
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59777655336123,
+                39.05812780746904
               ]
             }
           }
@@ -10839,15 +6737,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10866,34 +6764,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"275.8,7627.6 319.9,0.0 1269.6,0.0 1852.2,298.5 6211.4,327.3 6222.1,7795.0 6198.1,7623.0 275.8,7627.6\" /></svg>"
+          "value": "<svg><polygon points=\"6198.1,7623.0 275.8,7627.6 320.0,0.0 1269.6,0.0 1852.2,298.5 6211.4,327.3 6198.1,7623.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0496/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                295.9,
-                4427.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.594069,
-                39.059516
+                -94.59413469880224,
+                39.061526752941326
               ]
             }
           },
@@ -10901,20 +6802,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6198.1,
-                7623.0
+                6430.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.590703,
-                39.057958
+                -94.59038359599941,
+                39.06140614890818
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6430.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5905718524544,
+                39.05787576031659
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59432295525723,
+                39.057996364349734
               ]
             }
           }
@@ -10932,15 +6875,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10959,34 +6902,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5673.0,6804.0 2157.3,6848.0 1365.2,7183.6 1373.1,5035.1 1343.3,5048.0 1381.1,2899.7 1045.2,2888.4 1032.4,235.5 5640.0,248.0 5673.0,6804.0\" /></svg>"
+          "value": "<svg><polygon points=\"1363.1,7183.7 1381.9,2899.8 1206.9,2893.9 1218.4,236.0 6452.0,243.4 6452.0,6801.2 1895.2,6850.9 1363.1,7183.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0497/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1912.0,
-                6851.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.595344,
-                39.055113
+                -94.59628259363815,
+                39.05825227424421
               ]
             }
           },
@@ -10994,20 +6940,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5640.0,
-                248.0
+                6452.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.593002,
-                39.058027
+                -94.59252236492175,
+                39.05812295928433
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6452.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59272358615864,
+                39.05459483268601
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59648381487504,
+                39.054724147645885
               ]
             }
           }
@@ -11025,15 +7013,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11052,34 +7040,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5167.7,7532.0 5175.2,7795.0 4500.4,7795.0 3750.9,6746.3 1312.0,6790.7 1215.8,238.4 5156.1,178.2 5230.7,7507.1 5167.7,7532.0\" /></svg>"
+          "value": "<svg><polygon points=\"3751.0,6746.2 2090.3,6776.5 2026.7,226.4 5155.9,178.3 5248.8,7795.0 4502.3,7795.0 3751.0,6746.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0498/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3950.8,
-                4867.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.591552,
-                39.055865
+                -94.59370294615391,
+                39.058164820050834
               ]
             }
           },
@@ -11087,20 +7078,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5198.4,
-                2863.6
+                6454.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5907628,
-                39.0567415
+                -94.58994069762771,
+                39.05800697181026
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5901861342892,
+                39.0544786807136
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5939483828154,
+                39.05463652895418
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p499",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"203.6,2006.7 -0.0,2005.1 119.5,-0.0 6500.0,69.6 6500.0,7743.5 133.5,7687.1 203.6,2006.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58577060755813,
+                39.06209167002657
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58591227982706,
+                39.05899003853414
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59066962955026,
+                39.05912290852834
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59052795728134,
+                39.062224540020765
               ]
             }
           }
@@ -11118,15 +7289,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11145,34 +7316,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6120.9,39.6 6159.1,7666.1 1135.0,7682.5 1025.7,65.8 6120.9,39.6\" /></svg>"
+          "value": "<svg><polygon points=\"6158.6,7666.2 1141.2,7716.9 1028.0,52.2 6120.5,39.6 6158.6,7666.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0500/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2315.3,
-                3883.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.588334,
-                39.058473
+                -94.5858910147511,
+                39.05947744194689
               ]
             }
           },
@@ -11180,20 +7354,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2315.3,
-                2055.7
+                6454.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.587218,
-                39.058429
+                -94.58609113542097,
+                39.05641689120807
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59085061900964,
+                39.056604541098665
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59065049833977,
+                39.05966509183748
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p501",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6500.0,1937.1 5435.1,1934.0 5390.7,7795.0 83.4,7795.0 104.9,-0.0 6500.0,-0.0 6500.0,1937.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58108850178115,
+                39.06190503829167
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58126774061694,
+                39.058862159991726
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58593496262269,
+                39.05903026288395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5857557237869,
+                39.062073141183895
               ]
             }
           }
@@ -11211,15 +7565,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11238,34 +7592,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6431.8,-0.0 5698.1,976.3 6454.0,4456.5 6454.0,7036.1 3008.2,7795.0 979.0,7795.0 977.9,7795.0 -0.0,7795.0 -0.0,673.0 2075.4,211.9 2028.7,-0.0 6431.8,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6273.1,-0.0 6320.8,7763.5 -0.0,7795.0 -0.0,1936.5 1059.3,1931.6 1044.8,3.9 6273.1,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6342.0,
-                3943.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.583775,
-                39.056491
+                -94.5812316561247,
+                39.05935353158707
               ]
             }
           },
@@ -11273,20 +7630,614 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2399.3,
-                140.0
+                6454.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.580176,
-                39.05817
+                -94.58143994358123,
+                39.05631747086211
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58612827315922,
+                39.0565141562307
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58591998570269,
+                39.05955021695566
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p503",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5725.9,2379.8 5720.0,4359.4 6500.0,5386.9 6500.0,6389.9 86.2,6377.3 94.8,368.5 5724.1,361.1 5702.7,1492.2 6238.6,2378.0 5725.9,2379.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57278279057202,
+                39.06154195221635
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57295432545332,
+                39.058629117024175
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57745358074646,
+                39.058788868423385
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57728204586516,
+                39.06170170361556
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p504",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6273.7,7795.0 1990.3,7795.0 1999.2,6596.4 -0.0,6581.5 -0.0,6338.7 760.9,6344.6 766.0,5348.8 2.4,4324.2 18.3,2358.8 523.6,2359.9 -0.0,1477.4 0.0,0.0 6317.3,-0.0 6273.7,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57293548635256,
+                39.05898993212314
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57308664103749,
+                39.05605468770369
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57761926879259,
+                39.05619742335039
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57746811410766,
+                39.05913266776984
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p505",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6500.0,126.0 6500.0,7435.5 5459.4,7432.0 5458.3,7765.0 -0.0,7729.4 -0.0,3819.9 226.6,3822.0 241.3,61.7 6500.0,126.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56829808738362,
+                39.061452536599255
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56844398087732,
+                39.05836520602828
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57317935468957,
+                39.05850203615757
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57303346119588,
+                39.06158936672855
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p506",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6255.5,165.4 6250.2,7384.5 1262.4,7400.0 1215.7,119.2 6255.5,165.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56841567649361,
+                39.05894469287523
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56858642511601,
+                39.05586691659296
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57333914058044,
+                39.05602815520825
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57316839195805,
+                39.05910593149052
               ]
             }
           }
@@ -11304,15 +8255,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11331,34 +8282,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5499.3,118.9 5483.5,7650.4 458.8,7623.9 502.1,3827.9 607.8,3828.0 503.2,106.5 5499.3,118.9\" /></svg>"
+          "value": "<svg><polygon points=\"5489.0,118.8 5470.6,7650.3 479.0,7624.0 515.0,3827.9 632.6,3828.0 503.2,106.5 5489.0,118.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0507/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4196.6,
-                5791.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.567297,
-                39.059498
+                -94.56358785082666,
+                39.06140881356251
               ]
             }
           },
@@ -11366,20 +8320,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4196.6,
-                112.0
+                6477.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.563765,
-                39.059385
+                -94.56375376993306,
+                39.0582818721294
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56860156429926,
+                39.05843696860827
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56843564519286,
+                39.06156391004138
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p508",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,63.5 6208.6,112.3 6172.9,7765.7 -0.0,7712.9 -0.0,63.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56376346636478,
+                39.058759911003385
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56393477028035,
+                39.05566923245443
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5687073975089,
+                39.0558309958411
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56853609359332,
+                39.05892167439006
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p509",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"254.3,7741.1 234.2,3935.6 -0.0,3934.0 -0.0,2007.6 231.2,2006.4 219.8,-0.0 6315.7,-0.0 6308.2,1109.1 5639.5,1116.4 5635.1,7732.2 254.3,7741.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5590684538825,
+                39.0611217437616
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5592440690009,
+                39.05811837820295
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56386770905927,
+                39.058283694648864
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56369209394087,
+                39.06128706020752
               ]
             }
           }
@@ -11397,15 +8669,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11424,34 +8696,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6401.0,4427.1 6227.9,4429.5 6263.3,7683.5 -0.0,7634.1 -0.0,2257.4 929.5,2256.3 933.4,1123.0 1947.5,1117.8 1953.7,531.6 6265.0,503.9 6401.0,1285.2 6401.0,4427.1\" /></svg>"
+          "value": "<svg><polygon points=\"6152.7,7672.5 -0.0,7642.1 -0.0,1098.2 1829.7,1106.2 1833.7,511.9 6128.0,471.0 6126.6,-0.0 6401.0,-0.0 6383.7,4403.9 6147.4,5770.5 6152.7,7672.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0510/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6265.0,
-                5787.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5628563,
-                39.0557502
+                -94.559225023188,
+                39.058506506966054
               ]
             }
           },
@@ -11459,20 +8734,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6265.0,
-                503.9
+                6401.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5596779,
-                39.055644
+                -94.55940305233996,
+                39.05550576319143
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6401.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5640773379941,
+                39.05567534860715
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56389930884215,
+                39.05867609238178
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p511",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6477.0,6652.2 196.1,6694.8 133.3,715.3 3452.3,679.6 3452.1,472.5 6477.0,438.8 6477.0,6652.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55521575639945,
+                39.06094975080867
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55541152757137,
+                39.05803588214825
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55989738041582,
+                39.05822017295496
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5597016092439,
+                39.061134041615375
               ]
             }
           }
@@ -11490,15 +8945,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11517,34 +8972,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6423.0,7795.0 6255.0,7183.1 1796.1,7188.6 1786.6,7795.0 563.5,7768.3 669.0,492.7 6210.6,542.8 6423.0,692.6 6423.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6423.0,666.7 6423.0,6641.0 6278.8,6641.7 6279.3,7147.7 1827.7,7183.1 1822.3,7795.0 611.2,7777.1 671.7,505.7 6190.4,518.7 6423.0,666.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0512/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2111.7,
-                2539.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.556886,
-                39.057436
+                -94.55535206159558,
+                39.05833985697908
               ]
             }
           },
@@ -11552,20 +9010,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6255.0,
-                7183.1
+                6423.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5596779,
-                39.055644
+                -94.55551875813381,
+                39.05543495020746
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56005865150219,
+                39.05559203918895
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55989195496396,
+                39.05849694596057
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p513",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3405.6,7591.4 3400.9,7791.3 198.1,7745.7 406.2,229.4 5615.0,289.4 5618.7,48.1 5618.7,46.3 6477.0,58.0 6477.0,7634.0 3405.6,7591.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55100448552794,
+                39.06089969445757
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55111080297952,
+                39.057877167719404
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55576392198218,
+                39.057977250769106
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5556576045306,
+                39.06099977750727
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p514",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6423
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6423.0,7795.0 6198.6,7652.8 976.4,7627.3 862.1,16.5 6288.2,8.9 6283.3,442.8 6423.0,441.4 6423.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55111387336977,
+                39.0582779457601
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55127610334107,
+                39.05529523000706
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55590493111984,
+                39.055449188812574
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55574270114855,
+                39.058431904565616
               ]
             }
           }
@@ -11583,15 +9359,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11610,34 +9386,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"458.1,7266.1 490.7,7795.0 -0.0,7795.0 -0.0,1223.2 6265.0,942.8 6089.1,7197.8 458.1,7266.1\" /></svg>"
+          "value": "<svg><polygon points=\"6055.5,7194.2 422.3,7213.6 448.3,7795.0 -0.0,7795.0 -0.0,1208.1 2209.5,1129.0 2210.9,623.0 6302.8,634.4 6055.5,7194.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0515/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2184.3,
-                4963.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.6062441,
-                39.05535
+                -94.60736911780286,
+                39.05762502740912
               ]
             }
           },
@@ -11645,20 +9424,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2184.3,
-                615.9
+                6477.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.606109,
-                39.057299
+                -94.60363032741553,
+                39.057494011129656
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60383201391585,
+                39.053974279666306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60757080430318,
+                39.05410529594577
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p516",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6423
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1734.1,7795.0 1734.6,7083.5 -0.0,7093.0 112.4,639.0 6423.0,623.5 6423.0,7042.1 3603.4,7074.7 3608.3,7795.0 1734.1,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60379575655334,
+                39.05750672133919
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60002660768878,
+                39.05736906940726
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60024022390596,
+                39.053792027915506
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60400937277052,
+                39.053929679847435
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p517",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"81.4,1558.2 229.4,1990.1 5171.5,479.8 6477.0,4534.5 6455.7,5944.4 5546.5,5847.1 5344.1,7763.0 2432.2,7457.9 2396.4,7795.0 1453.5,7795.0 1502.1,7360.4 768.7,7283.5 1056.0,4402.3 -0.0,4293.9 -0.0,1273.8 92.6,1554.7 5018.6,4.8 5021.3,13.3 81.4,1558.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59773145600377,
+                39.0547387080967
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59749110377757,
+                39.05183800694222
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60195627543304,
+                39.05161172861562
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60219662765924,
+                39.0545124297701
               ]
             }
           }
@@ -11676,11 +9773,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -11699,8 +9796,8 @@
           "value": "7796.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11719,34 +9816,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6241.3 363.1,4910.5 319.7,173.0 1067.4,182.4 1066.8,326.9 6438.0,373.8 6438.0,1532.6 6246.3,1496.5 5508.0,3161.5 5640.1,3323.2 3461.9,7746.4 -0.0,6241.3\" /></svg>"
+          "value": "<svg><polygon points=\"3461.9,7746.4 -0.0,6241.3 365.5,5150.4 319.7,173.0 2155.7,188.7 2240.2,-0.0 2610.0,336.8 3018.7,410.7 2813.2,214.6 6438.0,195.9 6438.0,1532.6 6236.6,1494.7 5503.1,3155.5 5640.1,3323.2 3461.9,7746.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0518__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3854.8,
-                6884.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.60044,
-                39.049913
+                -94.59752139960452,
+                39.05265355397526
               ]
             }
           },
@@ -11754,20 +9854,1182 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4386.6,
-                176.0
+                6438.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.596697,
-                39.05078
+                -94.59617230583372,
+                39.04994710005932
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60039116442559,
+                39.04867880666405
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60174025819639,
+                39.05138526057999
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0518__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p518 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "5151.6"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "4801.6"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1286.4"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2994.4"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0518__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0518/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6438.0,7796.0 5151.6,6918.0 5151.6,5761.4 5403.2,5784.3 5151.6,4801.6 6438.0,4801.6 6438.0,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0518__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5151.6,
+                4801.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59705710998465,
+                39.05057495137913
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                4801.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59697306792025,
+                39.05028981352643
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59782115434125,
+                39.05013692905753
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5151.6,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59790519640565,
+                39.05042206691023
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p519",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6433
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"758.9,7795.0 497.4,7795.0 485.5,5957.9 -0.0,5967.3 -0.0,823.2 452.1,805.9 459.5,1950.5 4664.2,3769.4 5170.1,2598.4 5888.8,7363.3 2879.4,7483.4 2873.5,6698.8 1732.5,6705.9 758.9,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59903071221459,
+                39.054925334939774
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6433.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59553804538265,
+                39.055943311668415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6433.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59394915257067,
+                39.05265591584549
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5974418194026,
+                39.05163793911685
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p520",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5695.3 -0.0,5311.0 173.6,5310.3 123.4,1721.3 -0.0,1851.6 -0.0,1520.5 331.8,1153.0 143.4,1070.1 403.3,1071.7 1372.8,0.0 2507.1,0.0 2511.9,776.3 5895.9,714.2 5944.8,4052.1 4331.2,7789.1 182.6,5983.5 179.7,5771.2 -0.0,5695.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5974712163071,
+                39.05214928425065
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5939633425769,
+                39.05319096227079
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59235092876449,
+                39.049869931734335
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59585880249469,
+                39.0488282537142
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p521",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5375.9 -0.0,523.4 370.5,0.0 1008.0,0.0 6332.4,3226.0 6481.0,7521.5 90.6,7728.6 382.2,5471.9 -0.0,5375.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59586708077936,
+                39.05488855575723
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59257413339324,
+                39.05633483826622
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59034915633059,
+                39.053236662613635
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5936421037167,
+                39.05179038010465
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p522",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6121.5,7412.9 568.9,7518.9 540.2,3427.2 107.9,2451.1 3718.2,0.0 5957.3,0.0 6438.0,857.7 4972.9,1851.8 6129.1,3532.4 6121.5,7412.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59360383454698,
+                39.052949171436595
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58987601923862,
+                39.05279786233075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59011023099958,
+                39.04926861025337
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59383804630795,
+                39.04941991935922
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p523",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2634.1,4825.4 2076.5,4021.9 -0.0,3928.2 4815.0,587.4 5097.9,746.5 6481.0,710.0 6481.0,6213.5 6316.1,5985.9 4377.1,7320.1 3782.4,6456.4 2274.6,7547.8 1106.8,5878.3 2634.1,4825.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59121876897562,
+                39.054687609557426
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58746437810656,
+                39.05451312938892
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58773279587754,
+                39.05098074513174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5914871867466,
+                39.05115522530024
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p524",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6370.5,7796.0 922.5,7796.0 921.7,7560.3 -0.0,7560.7 -0.0,3781.0 1567.8,2693.4 2136.2,3557.6 4075.1,2281.8 4232.9,2509.7 4284.7,1229.8 6423.5,1232.7 6370.5,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59011136409494,
+                39.052926247685065
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58632469353265,
+                39.05281258589275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58650063078436,
+                39.04922761077211
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59028730134665,
+                39.04934127256442
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p525",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6143.1,253.1 6061.9,5628.6 4673.7,5641.7 4392.6,5477.3 1065.4,7712.1 -0.0,6116.9 -0.0,5176.4 159.3,5178.2 167.4,237.2 6143.1,253.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5908537012024,
+                39.056851924972904
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58710855796468,
+                39.056727642220345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58729975872322,
+                39.05320406872928
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59104490196094,
+                39.05332835148184
               ]
             }
           }
@@ -11785,11 +11047,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -11808,8 +11070,8 @@
           "value": "7796.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11828,34 +11090,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"183.1,6883.1 196.8,268.4 2275.3,260.0 2273.5,0.0 3883.4,0.0 3907.3,5594.7 2303.3,5608.0 2308.7,6860.3 183.1,6883.1\" /></svg>"
+          "value": "<svg><polygon points=\"2307.5,6795.6 201.5,6813.4 229.9,260.0 3870.8,252.6 3914.0,5545.1 2304.9,5554.9 2307.5,6795.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2275.3,
-                260.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.586105,
-                39.056576
+                -94.58743716290478,
+                39.05674285872382
               ]
             }
           },
@@ -11863,20 +11128,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2303.3,
-                5608.0
+                6438.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.586246,
-                39.054169
+                -94.58367023309148,
+                39.056601097522766
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58389122878775,
+                39.05306003966824
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58765815860104,
+                39.053201800869296
               ]
             }
           }
@@ -11894,11 +11201,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -11917,8 +11224,8 @@
           "value": "2832.8"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11937,34 +11244,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6323.5,4259.6 4290.3,4259.6 4323.5,1426.8 6341.8,1426.8 6323.5,4259.6\" /></svg>"
+          "value": "<svg><polygon points=\"6323.5,4259.6 4290.3,4259.6 4320.2,1426.8 6341.8,1426.8 6323.5,4259.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4410.0,
-                2665.4
+                4290.3,
+                1426.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.587506,
-                39.053048
+                -94.58754889067004,
+                39.0536448187427
               ]
             }
           },
@@ -11972,20 +11282,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6334.2,
-                2665.4
+                6438.0,
+                1426.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.586315,
-                39.053011
+                -94.58622015597615,
+                39.05360353983114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                4259.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58629020993226,
+                39.052243781384526
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4290.3,
+                4259.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58761894462614,
+                39.052285060296086
               ]
             }
           }
@@ -11993,7 +11345,7 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
@@ -12003,15 +11355,31 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6481.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12020,7 +11388,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527__1/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527/info.json",
@@ -12030,34 +11398,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6040.4,7795.0 262.4,7795.0 643.2,6060.7 653.5,1307.4 1878.6,242.2 774.6,-0.0 6481.0,-0.0 6481.0,1302.0 6000.9,1299.8 6040.4,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6002.0,1148.5 6000.5,7795.0 584.6,7795.0 636.7,1244.8 -0.0,1236.6 0.0,-0.0 6481.0,-0.0 6481.0,1148.4 6002.0,1148.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                644.1,
-                5359.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.583775,
-                39.056491
+                -94.58070740996925,
+                39.0566630191002
               ]
             }
           },
@@ -12065,20 +11436,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6000.9,
-                1299.8
+                6481.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5815891,
-                39.0540216
+                -94.58085666963913,
+                39.053785173550274
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58531530178426,
+                39.053924618235186
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58516604211438,
+                39.05680246378511
               ]
             }
           }
@@ -12096,15 +11509,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12123,34 +11536,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6456.0,-0.0 6456.0,188.2 5884.0,184.0 5874.3,7637.8 915.3,7605.1 921.3,138.8 1362.8,143.6 1363.7,-0.0 6456.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6456.0,-0.0 6456.0,188.2 5884.0,184.0 5874.3,7637.8 915.3,7605.1 922.2,-0.0 6456.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0529/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5884.0,
-                3903.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.584061,
-                39.051691
+                -94.58147959498356,
+                39.05446508506846
               ]
             }
           },
@@ -12158,20 +11574,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5884.0,
-                184.0
+                6456.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.581741,
-                39.051619
+                -94.5816405037924,
+                39.05133841666393
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5865025252978,
+                39.0514893069865
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58634161648897,
+                39.05461597539102
               ]
             }
           }
@@ -12189,15 +11647,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12216,34 +11674,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6454.0,2075.5 5898.4,2077.5 5922.5,7683.4 914.5,7655.0 919.8,212.8 1490.6,216.7 1490.5,28.7 6454.0,-0.0 6454.0,2075.5\" /></svg>"
+          "value": "<svg><polygon points=\"5539.4,7661.7 539.8,7640.0 535.2,210.3 1105.1,213.4 1104.7,25.8 6303.0,-0.0 6301.7,209.4 6454.0,209.9 6454.0,2137.9 5507.9,2065.3 5539.4,7661.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5894.2,
-                5832.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5853774,
-                39.0493156
+                -94.58159538740071,
+                39.05187486702129
               ]
             }
           },
@@ -12251,20 +11712,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5894.2,
-                216.0
+                6454.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5818691,
-                39.0492051
+                -94.58176462374682,
+                39.048737781934996
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58664269231822,
+                39.04889648622071
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58647345597211,
+                39.05203357130701
               ]
             }
           }
@@ -12282,15 +11785,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12309,34 +11812,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6456.0,7795.0 -0.0,7795.0 -0.0,6271.0 208.6,6269.1 183.3,850.6 6456.0,814.6 6456.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6456.0,7795.0 -0.0,7795.0 -0.0,6268.3 208.6,6266.1 183.3,850.6 6456.0,814.6 6456.0,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0531/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                196.0,
-                4863.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5768,
-                39.056253
+                -94.57396958843245,
+                39.056230202648855
               ]
             }
           },
@@ -12344,20 +11850,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4096.0,
-                827.9
+                6456.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.574571,
-                39.054402
+                -94.57415963065166,
+                39.05331880865879
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57868695571257,
+                39.053497016173694
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57849691349335,
+                39.05640841016376
               ]
             }
           }
@@ -12375,15 +11923,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12409,27 +11957,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0532/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2375.3,
-                6932.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5782019,
-                39.0527124
+                -94.57409577528942,
+                39.05363481911408
               ]
             }
           },
@@ -12437,20 +11988,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6330.0,
-                868.0
+                6454.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.574781,
-                39.050789
+                -94.57427879532814,
+                39.050713786940406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57882095264156,
+                39.050885415449294
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57863793260285,
+                39.05380644762297
               ]
             }
           }
@@ -12468,15 +12061,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12502,27 +12095,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0533/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4140.0,
-                2951.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.572228,
-                39.054322
+                -94.57040681006559,
+                39.05613162075306
               ]
             }
           },
@@ -12530,20 +12126,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4140.0,
-                6983.1
+                6456.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.574571,
-                39.054402
+                -94.57057176432768,
+                39.053218323959676
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57510202920865,
+                39.05337300649936
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57493707494656,
+                39.056286303292744
               ]
             }
           }
@@ -12561,15 +12199,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12595,27 +12233,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0534/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6342.0,
-                6992.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.574781,
-                39.050789
+                -94.5705587697965,
+                39.0535078060679
               ]
             }
           },
@@ -12623,20 +12264,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6342.0,
-                772.0
+                6454.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.571171,
-                39.050664
+                -94.57072584049868,
+                39.050598005722826
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57525052860157,
+                39.05075467774854
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5750834578994,
+                39.053664478093616
               ]
             }
           }
@@ -12654,15 +12337,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12681,34 +12364,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5168.9,7605.0 458.5,7577.4 502.8,296.9 5207.3,322.1 5168.9,7605.0\" /></svg>"
+          "value": "<svg><polygon points=\"5168.9,7605.0 458.5,7577.4 471.2,4095.2 502.8,318.2 5207.0,380.2 5168.9,7605.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0535/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4192.0,
-                376.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.566448,
-                39.054085
+                -94.56610778849551,
+                39.05611430153802
               ]
             }
           },
@@ -12716,20 +12402,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4088.0,
-                7599.0
+                6456.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.570965,
-                39.054276
+                -94.5662694531706,
+                39.05297776205668
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57114692200221,
+                39.05312935814913
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57098525732712,
+                39.05626589763047
               ]
             }
           }
@@ -12747,15 +12475,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12774,34 +12502,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7631.8 -0.0,309.8 1123.5,203.0 6384.1,202.7 6386.0,7624.0 -0.0,7631.8\" /></svg>"
+          "value": "<svg><polygon points=\"6386.0,360.0 6386.0,7624.0 -0.0,7631.8 -0.0,368.3 6386.0,360.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0536/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6386.0,
-                7624.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.571171,
-                39.050664
+                -94.56624693537131,
+                39.05358390620038
               ]
             }
           },
@@ -12809,20 +12540,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6386.0,
-                360.0
+                6454.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.566651,
-                39.050505
+                -94.56642890787627,
+                39.050464261331044
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57127994311858,
+                39.05063490615484
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57109797061362,
+                39.05375455102418
               ]
             }
           }
@@ -12840,15 +12613,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12867,34 +12640,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5814.0,-0.0 5797.1,3846.5 6456.0,3847.2 6456.0,7795.0 193.1,7795.0 193.6,436.1 372.5,434.0 373.5,-0.0 5814.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6456.0,3847.2 6456.0,7795.0 193.1,7795.0 228.8,1840.4 471.7,-0.0 5803.9,35.8 5789.1,3846.5 6456.0,3847.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0537/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4160.0,
-                5823.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5652667,
-                39.054048
+                -94.56178018995192,
+                39.05581959527111
               ]
             }
           },
@@ -12902,20 +12678,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                208.0,
-                5823.3
+                6456.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5651728,
-                39.0558331
+                -94.56193358529605,
+                39.05290345012941
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5664683138816,
+                39.05304729243405
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56631491853747,
+                39.05596343757575
               ]
             }
           }
@@ -12933,15 +12751,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12960,34 +12778,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6472.0,1943.7 6320.8,1944.4 6326.3,7795.0 677.8,7795.0 660.8,3945.0 -0.0,3947.1 0.0,-0.0 6082.0,-0.0 6082.1,523.4 6472.0,522.7 6472.0,1943.7\" /></svg>"
+          "value": "<svg><polygon points=\"6319.3,1819.3 6322.1,7795.0 683.1,7766.5 667.7,3813.7 -0.0,3815.5 0.0,-0.0 6081.9,-0.0 6081.7,400.6 6472.0,400.0 6472.0,1818.6 6319.3,1819.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0538/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2356.0,
-                3939.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.564213,
-                39.052211
+                -94.56193892676255,
+                39.05319866252734
               ]
             }
           },
@@ -12995,20 +12816,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6320.0,
-                3939.5
+                6472.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.564317,
-                39.050426
+                -94.5621070942701,
+                39.050279405211505
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56663530043049,
+                39.050436714699366
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56646713292294,
+                39.053355972015204
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p539",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,6337.4 5525.3,7242.6 5525.9,7795.0 271.1,7795.0 205.8,4.5 6456.0,39.4 6456.0,6337.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57360624287398,
+                39.05084644312973
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57376421789382,
+                39.04778649299784
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57848886518052,
+                39.047935686528824
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57833089016067,
+                39.050995636660716
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p540",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7188.8 921.4,6299.2 927.8,114.7 6090.8,146.0 6132.5,1271.2 6472.0,956.9 6472.0,5831.8 6274.9,5931.2 6285.6,7666.3 6472.0,7667.0 6472.0,7795.0 -0.0,7795.0 -0.0,7188.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57369459770283,
+                39.0482297318119
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57385282913883,
+                39.04512805927844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57866365192366,
+                39.04527608459488
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57850542048766,
+                39.04837775712834
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p541",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,659.5 6456.0,7124.9 139.6,7106.4 155.0,677.0 6456.0,659.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5695183279105,
+                39.050675346909166
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56967748249781,
+                39.047788560329835
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57416623518878,
+                39.04793781391686
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57400708060148,
+                39.05082460049619
               ]
             }
           }
@@ -13026,15 +13303,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13053,34 +13330,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6392.1,665.2 6439.8,7100.7 -0.0,7113.7 -0.0,2884.2 667.3,2882.6 635.1,684.8 6392.1,665.2\" /></svg>"
+          "value": "<svg><polygon points=\"6392.1,665.2 6440.8,7100.7 637.0,7111.9 607.0,684.9 6392.1,665.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0542/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2048.0,
-                2879.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.571368,
-                39.0472
+                -94.56964388112353,
+                39.04805953217766
               ]
             }
           },
@@ -13088,20 +13368,890 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2048.0,
-                679.9
+                6472.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.570094,
-                39.047153
+                -94.56982191503039,
+                39.04514884039887
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57433650775769,
+                39.04531539130797
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57415847385083,
+                39.04822608308676
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p543",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,159.8 6456.0,2147.9 5617.5,2148.2 5590.3,7648.4 149.0,7668.9 154.6,152.9 6456.0,159.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56537771483825,
+                39.05053331665216
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56554403007193,
+                39.04755089098249
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57014896627884,
+                39.04770796149408
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56998265104515,
+                39.05069038716375
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p544",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6241.3,463.1 6472.0,462.4 6472.0,4033.1 6235.3,4037.0 6252.5,7581.3 -0.0,7607.4 -0.0,2140.1 833.4,2135.7 823.6,159.6 6239.1,128.2 6241.3,463.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56551981608861,
+                39.04793323099057
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.565706547094,
+                39.04492589411135
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57033829126125,
+                39.04510181629051
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57015156025587,
+                39.04810915316973
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p545",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7795.0 106.1,0.0 177.3,196.7 314.0,197.5 316.0,0.0 2167.8,0.0 2272.5,209.5 6456.0,234.9 6275.3,7737.2 6456.0,7785.3 -0.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57876244846099,
+                39.045367747733586
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57502822570376,
+                39.045270659845556
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57517811984914,
+                39.04174372674189
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57891234260637,
+                39.04184081462992
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p546",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6324.7,0.0 6193.7,7734.1 260.0,7700.8 364.4,401.9 1355.6,398.3 1028.3,49.6 1379.9,0.1 6324.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5752390438335,
+                39.04535853946365
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57139199684585,
+                39.04522904297576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57159143217469,
+                39.04160452689566
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57543847916234,
+                39.04173402338355
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p547",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6433
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"280.2,7662.7 517.8,0.0 6179.8,27.3 6179.1,262.9 6433.0,267.8 6433.0,7795.0 280.2,7662.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57178975747725,
+                39.045223611628714
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6433.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56794674923545,
+                39.045136339393636
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6433.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56808199168827,
+                39.041493114631514
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57192499993008,
+                39.04158038686659
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p551",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6206.0,185.0 6398.2,7795.0 -0.0,7795.0 -0.0,292.2 6206.0,185.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57654528678508,
+                39.04192207881425
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57284184747586,
+                39.04175973596061
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57309466968357,
+                39.03823109963071
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57679810899279,
+                39.03839344248435
               ]
             }
           }
@@ -13119,11 +14269,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -13142,8 +14292,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13162,34 +14312,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6472.0,7795.0 -0.0,7795.0 -0.0,7642.9 382.5,7634.8 213.9,445.4 6472.0,390.9 6472.0,5355.9 4718.3,6389.1 6472.0,6325.7 6472.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"213.9,445.4 6472.0,390.9 6472.0,7795.0 -0.0,7795.0 382.9,7694.3 213.9,445.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0552__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2224.0,
-                4235.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.571855,
-                39.039828
+                -94.573076287263,
+                39.04189806749326
               ]
             }
           },
@@ -13197,20 +14350,216 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                248.0,
-                4235.5
+                6472.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5730642,
-                39.0398786
+                -94.569115790097,
+                39.04173233712888
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5693728495417,
+                39.0380273656362
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5733333467077,
+                39.038193096000576
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0552__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p552 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3288.8"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "4706.6"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3183.2"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3088.4"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0552__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0552/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3483.9,4706.6 6472.0,4706.6 6472.0,7795.0 3288.8,7795.0 3288.8,6386.5 3450.5,6390.3 3483.9,4706.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0552__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3288.8,
+                4706.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58023772335773,
+                39.05909979572691
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                4706.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.578374207565,
+                39.059064181771255
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57841843450728,
+                39.05764904235022
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3288.8,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58028195029999,
+                39.057684656305874
               ]
             }
           }
@@ -13228,15 +14577,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13255,34 +14604,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6400.0,5617.9 6400.0,7795.0 1277.3,7795.0 1283.9,7440.1 767.8,7458.2 803.4,1930.9 -0.0,1932.0 -0.0,1838.5 803.9,1846.7 814.9,133.6 2447.5,-0.0 2446.6,154.9 5300.0,192.0 5300.0,5647.3 6400.0,5617.9\" /></svg>"
+          "value": "<svg><polygon points=\"5300.0,5647.3 6400.0,5617.9 6400.0,7795.0 1335.2,7795.0 1338.8,7438.1 767.8,7458.2 814.9,133.6 2447.6,-0.0 2446.6,154.2 5300.0,192.0 5300.0,5647.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5300.0,
-                7299.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.6073122,
-                39.0522711
+                -94.60287580699165,
+                39.05459184518402
               ]
             }
           },
@@ -13290,20 +14642,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5300.0,
-                192.0
+                6400.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.6031001,
-                39.052156
+                -94.60300926091605,
+                39.05164669288909
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60762905995938,
+                39.05177293368819
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60749560603497,
+                39.05471808598312
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p554",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6512
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"950.5,151.7 5500.5,154.4 5404.4,7471.0 6512.0,7481.6 6512.0,7795.0 2074.5,7795.0 2068.8,5633.0 928.7,5666.1 950.5,151.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60299020728957,
+                39.05258919934367
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6512.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60313364961378,
+                39.04960334168056
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6512.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60770437187311,
+                39.04973764181872
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6075609295489,
+                39.052723499481836
               ]
             }
           }
@@ -13321,11 +14853,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -13344,8 +14876,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13364,34 +14896,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1260.2,7579.1 1264.0,0.0 3178.4,0.0 3184.0,2927.6 5097.8,2926.5 5098.3,3840.7 5332.1,3820.8 5098.3,3905.5 5100.3,7714.1 1260.2,7579.1\" /></svg>"
+          "value": "<svg><polygon points=\"1260.2,7579.1 1264.7,0.0 3178.4,0.0 5097.8,2926.5 5098.3,3840.7 5098.3,3922.8 5100.3,7714.1 1260.2,7579.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0555__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3184.0,
-                2927.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.60198,
-                39.05212
+                -94.60374838422922,
+                39.05349193203013
               ]
             }
           },
@@ -13399,20 +14934,354 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1244.0,
-                2927.6
+                6400.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.6031001,
-                39.052156
+                -94.60005320897143,
+                39.05337316914355
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60023949679181,
+                39.04987762301525
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6039346720496,
+                39.04999638590183
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0555__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p555 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3328.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3072.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2698.1"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0555__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0555/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3468.1,169.1 6400.0,184.6 6400.0,2698.1 3482.1,2698.1 3468.1,169.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0555__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3328.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6031782722892,
+                39.052235417675284
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60138756064201,
+                39.052185554083174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                2698.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60144359921597,
+                39.05095469807404
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3328.0,
+                2698.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60323431086316,
+                39.05100456166615
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p556",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6512
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6512.0,7795.0 655.6,7795.0 629.4,205.5 6512.0,180.9 6512.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5935206191058,
+                39.04962563794776
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6512.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5897358917944,
+                39.04952215523877
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6512.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58989429455117,
+                39.04597847501453
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59367902186257,
+                39.04608195772352
               ]
             }
           }
@@ -13430,15 +15299,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13457,34 +15326,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6022.8,922.5 6117.4,7795.0 -0.0,7795.0 -0.0,953.1 6022.8,922.5\" /></svg>"
+          "value": "<svg><polygon points=\"6400.0,4320.9 6052.6,4320.5 6090.1,7795.0 -0.0,7795.0 -0.0,953.1 6400.0,921.3 6400.0,4320.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0557/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4288.0,
-                5919.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.6065223,
-                39.0482767
+                -94.60298638535563,
+                39.05007607587495
               ]
             }
           },
@@ -13492,20 +15364,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4288.0,
-                927.9
+                6400.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.6036385,
-                39.0481718
+                -94.60315955493584,
+                39.04720476764214
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60766318169864,
+                39.04736858983767
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60749001211843,
+                39.05023989807047
               ]
             }
           }
@@ -13523,15 +15437,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13550,34 +15464,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,918.6 2368.0,943.9 2373.9,115.6 6512.0,150.9 6512.0,7795.0 -0.0,7795.0 -0.0,918.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,4319.2 345.1,4323.3 381.5,945.4 2369.7,960.7 2373.1,134.2 6512.0,157.2 6512.0,7795.0 -0.0,7795.0 -0.0,4319.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0558/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6360.0,
-                3243.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.605154,
-                39.044561
+                -94.60313388990879,
+                39.04738108280583
               ]
             }
           },
@@ -13585,20 +15502,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2368.0,
-                943.9
+                6512.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.6037424,
-                39.0463263
+                -94.60327039487704,
+                39.04443952738339
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6512.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60780474303304,
+                39.044566446052045
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60766823806479,
+                39.04750800147448
               ]
             }
           }
@@ -13616,15 +15575,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13643,34 +15602,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5855.4,5069.7 6048.3,6743.3 -0.0,6754.8 160.6,1334.0 6400.0,1302.6 6400.0,5068.0 5855.4,5069.7\" /></svg>"
+          "value": "<svg><polygon points=\"6048.3,6743.3 -0.0,6754.8 160.6,1334.0 5421.8,1307.6 6048.3,6743.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0559/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4316.0,
-                6743.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.6036385,
-                39.0481718
+                -94.5996727901502,
+                39.04995850312459
               ]
             }
           },
@@ -13678,20 +15640,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                136.0,
-                2883.6
+                6400.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.601326,
-                39.049954
+                -94.59983257144293,
+                39.0471151870275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60429233351687,
+                39.047266342229264
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60413255222413,
+                39.050109658326356
               ]
             }
           }
@@ -13709,11 +15713,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "29"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -13732,8 +15736,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13752,34 +15756,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6436.7 -0.0,4770.1 535.6,4830.1 962.2,1129.5 1241.7,1159.8 2674.1,1464.0 3002.2,1349.5 6522.0,1781.6 6522.0,2566.8 5484.9,4376.0 6037.4,4692.4 6522.0,4748.1 6522.0,6343.1 2473.0,5885.2 2380.7,6711.1 -0.0,6436.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1023.6 2674.1,1464.0 3002.2,1349.5 5970.1,1719.4 5576.3,4639.4 6522.0,4748.1 6522.0,6343.2 2473.1,5885.2 2380.7,6711.1 -0.0,6436.7 -0.0,1023.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0560__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                936.3,
-                2071.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.601122,
-                39.047122
+                -94.59996523019048,
+                39.04760780204661
               ]
             }
           },
@@ -13787,20 +15794,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2380.7,
-                6711.1
+                6522.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.6037424,
-                39.0463263
+                -94.5996971120611,
+                39.044684379550645
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60419797928621,
+                39.044435396357
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6044660974156,
+                39.04735881885297
               ]
             }
           }
@@ -13818,11 +15867,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -13841,8 +15890,8 @@
           "value": "1657.4"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13861,34 +15910,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3158.2,7795.0 3158.2,7224.1 3334.7,7130.3 3158.2,6720.2 3158.2,6137.6 6522.0,6137.6 6522.0,7795.0 3158.2,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"3158.2,7795.0 3158.2,7098.4 3516.1,7061.5 3498.1,6137.6 6522.0,6137.6 6522.0,7795.0 3158.2,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0560__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5038.1,
-                7575.3
+                3158.2,
+                6137.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.601592,
-                39.043973
+                -94.60261671376652,
+                39.04496995178707
               ]
             }
           },
@@ -13896,20 +15948,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3526.2,
-                7575.3
+                6522.0,
+                6137.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.602452,
-                39.044295
+                -94.6006186340179,
+                39.04487222664741
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.600680726466,
+                39.044106481000256
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3158.2,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60267880621461,
+                39.04420420613991
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p561",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6400.0,6903.7 -0.0,6951.9 35.4,3824.9 192.0,2967.7 -0.0,2869.4 -0.0,1052.1 6400.0,948.7 6400.0,6903.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59641407901859,
+                39.049766535006476
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59658585185485,
+                39.046868183726986
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60110008465303,
+                39.047031829679575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60092831181676,
+                39.049930180959066
               ]
             }
           }
@@ -13927,15 +16159,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13954,34 +16186,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6315.7,6939.7 2314.2,6898.1 2030.9,7051.0 544.4,6904.0 595.6,943.1 6484.8,974.8 6522.0,6390.9 6315.7,6939.7\" /></svg>"
+          "value": "<svg><polygon points=\"5307.1,6775.6 5303.5,6929.2 2314.2,6898.1 2030.9,7051.0 546.8,6904.0 589.1,943.1 6522.0,975.0 6522.0,6804.0 5307.1,6775.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0562/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2336.7,
-                2975.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5983515,
-                39.0461391
+                -94.59657596232502,
+                39.04713596980775
               ]
             }
           },
@@ -13989,20 +16224,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6337.9,
-                2975.6
+                6522.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5984431,
-                39.0443415
+                -94.59672527032502,
+                39.04420588180776
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60123637562467,
+                39.044344534800075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60108706762466,
+                39.04727462280006
               ]
             }
           }
@@ -14020,15 +16297,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14047,34 +16324,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6400.0,2527.5 5752.6,2526.3 5733.9,7220.3 102.2,7224.1 -0.0,5798.3 198.3,5711.9 248.0,535.9 6400.0,475.3 6400.0,2527.5\" /></svg>"
+          "value": "<svg><polygon points=\"5741.9,5208.9 6400.0,5211.6 6400.0,7225.4 -0.0,7268.6 -0.0,5798.3 198.3,5711.9 248.0,535.9 6400.0,475.2 6400.0,2527.5 5752.6,2526.3 5741.9,5208.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0563/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5344.0,
-                5207.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5959535,
-                39.047324
+                -94.59284555843143,
+                39.04962407867167
               ]
             }
           },
@@ -14082,20 +16362,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                248.0,
-                535.9
+                6400.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.593159,
-                39.0495222
+                -94.59298168454208,
+                39.0467664670911
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5974638999359,
+                39.046895243296426
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59732777382526,
+                39.04975285487699
               ]
             }
           }
@@ -14113,15 +16435,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14140,34 +16462,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,2558.4 640.4,2557.1 632.3,527.7 2192.4,537.9 2189.5,-0.0 6413.2,-0.0 6522.0,7224.3 -0.0,7200.2 -0.0,2558.4\" /></svg>"
+          "value": "<svg><polygon points=\"650.9,5211.3 -0.0,5211.2 -0.0,2558.4 640.4,2557.1 632.3,527.7 2189.8,537.9 2186.7,-0.0 6413.2,-0.0 6522.0,7224.3 658.9,7202.6 650.9,5211.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0564/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2408.7,
-                5211.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5960203,
-                39.0460592
+                -94.59293311607078,
+                39.04704994373889
               ]
             }
           },
@@ -14175,20 +16500,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6394.0,
-                5211.3
+                6522.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5961152,
-                39.0442605
+                -94.5930884243037,
+                39.044106288116396
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6522.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59762037236607,
+                39.044250514603085
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59746506413315,
+                39.04719417022558
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p565",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6392
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3382.9,7616.6 3050.6,7795.0 583.8,7795.0 552.4,263.3 6392.0,213.5 6392.0,7795.0 5275.3,7795.0 4625.1,6566.0 4095.4,6778.5 3382.9,7616.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58685485206477,
+                39.04947154994569
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6392.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58307064158303,
+                39.049340355436186
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6392.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58327523268171,
+                39.04573062859962
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58705944316345,
+                39.04586182310913
               ]
             }
           }
@@ -14206,11 +16711,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -14229,8 +16734,8 @@
           "value": "7796.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14249,34 +16754,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6517.0,0.0 6517.0,7796.0 290.8,7431.2 288.4,7796.0 -0.0,7796.0 -0.0,-0.0 6517.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6517.0,0.0 6517.0,7796.0 295.8,7293.8 290.4,7796.0 -0.0,7796.0 -0.0,-0.0 6517.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0566__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1200.2,
-                2232.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.606755,
-                39.066151
+                -94.60747180958602,
+                39.06712153023219
               ]
             }
           },
@@ -14284,20 +16792,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1200.2,
-                5676.0
+                6517.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.606746,
-                39.064612
+                -94.60370501801728,
+                39.067146784067155
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6036663758636,
+                39.063622920271364
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60743316743233,
+                39.0635976664364
               ]
             }
           }
@@ -14315,15 +16865,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14342,34 +16892,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"550.5,7795.0 545.3,4967.8 -0.0,4847.7 -0.0,9.8 6360.0,118.1 6360.0,7795.0 550.5,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"572.2,7795.0 -0.0,7795.0 -0.0,89.5 6360.0,197.1 6360.0,7795.0 3627.3,7795.0 3586.0,6021.1 566.0,6031.5 572.2,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0567/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3592.0,
-                188.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5782135,
-                39.061706
+                -94.58028291336069,
+                39.06186648169904
               ]
             }
           },
@@ -14377,20 +16930,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                560.0,
-                188.0
+                6360.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.579959,
-                39.061768
+                -94.57660264679929,
+                39.06172910390508
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6360.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5768179962087,
+                39.05820148583673
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5804982627701,
+                39.058338863630695
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p568",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6517
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"472.9,7693.9 344.3,285.8 -0.0,291.4 -0.0,-0.0 6517.0,0.0 6517.0,7796.0 472.9,7693.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54844730103716,
+                39.06975878966545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54455003845183,
+                39.06959309790403
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54480358181172,
+                39.06594732299724
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54870084439705,
+                39.066113014758656
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p569",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6360
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2229.7,124.5 1802.4,0.0 6360.0,0.0 6360.0,7795.0 2197.8,7795.0 2205.9,5877.6 247.7,5891.2 247.5,6320.8 -0.0,6319.8 -0.0,-0.0 2229.7,124.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5511267756214,
+                39.06113935335651
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6360.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54742551788942,
+                39.06102788943898
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6360.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54760147410533,
+                39.057504923482604
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55130273183731,
+                39.05761638740013
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p570",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6517
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6836.2 439.8,6846.0 499.1,0.0 2444.5,0.0 2423.2,1904.7 6517.0,1933.1 6517.0,7796.0 -0.0,7796.0 -0.0,6836.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55140803933887,
+                39.05847971206097
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54758949116814,
+                39.05838534925609
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54773488227724,
+                39.05483768285266
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55155343044797,
+                39.05493204565754
               ]
             }
           }
@@ -14408,15 +17417,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14435,34 +17444,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6360.0,7429.7 4188.5,7429.0 4188.8,7795.0 190.0,7795.0 184.0,240.0 4165.5,238.0 4166.2,389.0 5585.4,389.3 5584.7,0.0 6360.0,0.0 6360.0,7429.7\" /></svg>"
+          "value": "<svg><polygon points=\"189.7,7427.9 184.0,240.0 4165.5,238.0 4166.2,390.7 5585.4,390.3 5584.7,0.0 6360.0,0.0 6360.0,7429.7 189.7,7427.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0571/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                184.0,
-                4215.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.565576,
-                39.048672
+                -94.56557256704423,
+                39.050576967068146
               ]
             }
           },
@@ -14470,20 +17482,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                184.0,
-                240.0
+                6360.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.565472,
-                39.050465
+                -94.56187945640868,
+                39.05044777293552
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6360.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56208337592577,
+                39.04693212203009
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56577648656132,
+                39.04706131616272
               ]
             }
           }
@@ -14501,15 +17555,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14528,34 +17582,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1777.4,7378.3 826.0,7315.6 -0.0,7796.0 -0.0,4786.5 338.5,4785.5 324.7,362.5 4273.6,361.4 4273.2,0.0 6517.0,0.0 6517.0,7683.8 2245.6,7796.0 1777.4,7378.3\" /></svg>"
+          "value": "<svg><polygon points=\"338.5,4785.5 324.3,0.0 6517.0,0.0 6517.0,7796.0 -0.0,7796.0 -0.0,4786.5 338.5,4785.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0572/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2304.4,
-                4784.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.56462,
-                39.044997
+                -94.56584745230634,
+                39.04722975048439
               ]
             }
           },
@@ -14563,20 +17620,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2304.4,
-                808.0
+                6517.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.564514,
-                39.046813
+                -94.5620153611619,
+                39.04709483702473
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56222320220819,
+                39.0435340885338
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56605529335263,
+                39.04366900199346
               ]
             }
           }
@@ -14594,11 +17693,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -14617,8 +17716,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14637,34 +17736,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,5525.7 345.2,5519.9 341.4,3395.8 3017.0,3376.6 2991.0,0.0 5762.2,0.0 5769.8,3398.0 6165.0,3399.3 6163.2,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,5525.7 345.2,5519.9 341.4,3394.4 3015.9,3374.2 2988.8,0.0 5762.2,0.0 5769.8,3399.8 6169.6,3400.6 6146.3,7735.1 6360.0,7736.2 6360.0,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0573__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                68.0,
-                5519.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5934061,
-                39.0441666
+                -94.59321196165084,
+                39.04912226072382
               ]
             }
           },
@@ -14672,20 +17774,216 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5756.0,
-                991.9
+                6360.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5866108,
-                39.0480113
+                -94.58586396400443,
+                39.04887823927271
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6360.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58624910595941,
+                39.04188295105337
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59359710360582,
+                39.04212697250448
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p574 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6517.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7796.0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6517
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1029.5,3386.2 1415.8,2909.9 1660.9,2844.4 1995.2,3474.5 2564.8,3472.5 2550.9,88.6 3590.2,82.1 3589.7,0.0 6517.0,0.0 6517.0,5558.3 6467.5,5559.0 6517.0,7796.0 -0.0,7796.0 -0.0,3481.5 860.3,3478.5 1029.5,3386.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58605741691973,
+                39.04897184255251
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57849507849446,
+                39.048689105533015
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57893064627653,
+                39.04166219303825
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5864929847018,
+                39.041944930057745
               ]
             }
           }
@@ -14703,11 +18001,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -14726,8 +18024,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14746,7 +18044,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6360.0,0.0 6360.0,7795.0 1720.0,7795.0 1720.0,-0.0 6360.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6360.0,7795.0 1720.0,7795.0 1720.0,-0.0 6360.0,0.0 6360.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -14775,8 +18073,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.60286279855877,
-                39.06662862564035
+                -94.60282879457428,
+                39.066569646375115
               ]
             }
           },
@@ -14796,8 +18094,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.60015602833141,
-                39.066829916256836
+                -94.60014526600517,
+                39.0668142316267
               ]
             }
           },
@@ -14817,8 +18115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5997200629785,
-                39.063301899458544
+                -94.599619694473,
+                39.06328879952136
               ]
             }
           },
@@ -14838,8 +18136,83 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.60242683320587,
-                39.063100608842056
+                -94.60230322304211,
+                39.06304421426977
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p576",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6491
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6491.0,7723.5 -0.0,7795.0 -0.0,0.0 6491.0,0.0 6491.0,7723.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59926643060297,
+                39.07158737073351
               ]
             }
           },
@@ -14847,20 +18220,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2208.0,
-                679.9
+                6491.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.602541,
-                39.066342
+                -94.59533757190927,
+                39.07140902044919
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6491.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59561150138747,
+                39.067720195185935
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59954036008116,
+                39.06789854547026
               ]
             }
           }
@@ -14878,11 +18293,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -14901,8 +18316,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T17:11:46Z",
-      "modified": "2026-08-07T17:11:46Z",
+      "created": "2026-08-15T00:41:17Z",
+      "modified": "2026-08-15T00:41:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14921,34 +18336,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5711.8,4520.9 5555.4,5545.7 4689.7,7795.0 -0.0,7795.0 -0.0,314.5 5706.7,306.4 5711.8,4520.9\" /></svg>"
+          "value": "<svg><polygon points=\"1216.5,336.7 5706.6,306.4 5721.0,4400.3 5691.4,4400.8 5689.9,4803.5 5112.5,6889.8 4673.7,7795.0 -0.0,7795.0 -0.0,335.5 1212.5,342.9 1216.5,336.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0577__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1080.2,
-                4427.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.598811,
-                39.066002
+                -94.59930897359204,
+                39.06804106077026
               ]
             }
           },
@@ -14956,20 +18374,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1080.2,
-                304.0
+                6337.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5986846,
-                39.0678771
+                -94.59559850505255,
+                39.06789034317702
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6337.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59583735679844,
+                39.064345658501935
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59954782533794,
+                39.06449637609518
               ]
             }
           }

--- a/gallery/los_angeles_ca_1949_vol_14.iiif.json
+++ b/gallery/los_angeles_ca_1949_vol_14.iiif.json
@@ -7,25 +7,41 @@
   "label": "Mosaic of main content, Los Angeles, Calif. | 1949 | Vol. 14",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499J",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1401 [2]",
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
           "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5672.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -34,21 +50,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401__2/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401/info.json",
           "type": "ImageService2",
-          "height": 8150,
-          "width": 5607
+          "height": 8149,
+          "width": 5672
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5607.0,-0.0 5607.0,6944.2 5112.8,6940.8 5112.7,6942.7 196.4,6948.1 235.2,281.8 -0.0,280.0 -0.0,-0.0 5607.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,-0.0 5672.0,0.0 5672.0,933.8 5082.8,1292.6 4868.6,1610.2 4224.3,4068.1 3895.4,5899.8 3228.3,8149.0 -0.0,8149.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -73,8 +89,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1765205,
-                34.0407679
+                -118.22916396020243,
+                34.05485736256264
               ]
             }
           },
@@ -82,7 +98,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5607.0,
+                5672.0,
                 0.0
               ],
               "creator": {
@@ -94,8 +110,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1764584,
-                34.0356476
+                -118.22567197610702,
+                34.05485492612436
               ]
             }
           },
@@ -103,8 +119,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5607.0,
-                8150.0
+                5672.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -115,8 +131,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1854403,
-                34.0355728
+                -118.22567619970087,
+                34.05069797306295
               ]
             }
           },
@@ -125,7 +141,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8150.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -136,8 +152,624 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1855024,
-                34.0406931
+                -118.22916818379628,
+                34.05070040950124
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1402 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2750.9"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"542.2,89.1 2576.7,406.5 2002.2,4740.2 2010.1,5497.1 2316.1,5484.3 2476.0,8040.1 -0.0,8149.0 -0.0,3897.3 542.2,89.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2255560501259,
+                34.04769858985998
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2750.9,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22397742266111,
+                34.04776539390482
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2750.9,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22373870964425,
+                34.043892714969544
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22531733710905,
+                34.04382591092471
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1402 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "1756.3"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3932.7"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1836.7,7823.4 1893.0,8149.0 1756.3,8149.0 1756.3,-0.0 2075.5,0.0 2207.7,1738.0 5513.0,1486.6 5176.9,3544.4 5091.1,7466.7 3411.5,7478.6 3227.8,7580.8 3234.1,7769.8 1836.7,7823.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1756.3,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22935203715976,
+                34.05155034748869
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5689.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2270764533423,
+                34.0514053447916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5689.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22743910055459,
+                34.04749819918749
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1756.3,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22971468437204,
+                34.04764320188458
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1404 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3222.2"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"415.2,8149.0 360.3,-0.0 2855.9,135.0 2926.0,8149.0 415.2,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21163105036693,
+                34.04858019967206
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3222.2,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21006374465385,
+                34.04787751738888
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3222.2,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21221101991371,
+                34.04459342552146
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21377832562679,
+                34.04529610780464
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1404 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3217.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2472.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5360.6,7933.2 3546.9,7937.7 3477.0,4184.5 3477.0,380.0 5322.1,363.2 5360.6,7933.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3217.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20333985059384,
+                34.04106548841055
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5689.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20211199946858,
+                34.0405141084563
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5689.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20430536224461,
+                34.03716066239951
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3217.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20553321336986,
+                34.03771204235376
               ]
             }
           }
@@ -162,8 +794,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -182,7 +814,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2035.0,7429.8 537.1,8150.0 0.0,8150.0 0.0,-0.0 4766.0,224.8 5146.8,393.2 5676.0,1000.3 5676.0,8150.0 3647.7,8150.0 3409.7,7457.8 2698.2,6934.4 2029.2,7237.6 2035.0,7429.8\" /></svg>"
+          "value": "<svg><polygon points=\"529.6,8150.0 0.0,8150.0 0.0,0.0 2021.8,0.0 4774.3,218.4 5155.4,387.5 5676.0,983.6 5676.0,8150.0 3633.5,8150.0 3301.9,7438.0 2694.7,6931.4 2027.6,7244.8 2033.0,7429.1 529.6,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -211,8 +843,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22677482541586,
-                34.05184846970732
+                -118.226768799971,
+                34.051846097759295
               ]
             }
           },
@@ -232,8 +864,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22619983998999,
-                34.05447382983539
+                -118.22619764681716,
+                34.05446888748471
               ]
             }
           },
@@ -253,8 +885,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22168074707454,
-                34.053784800012494
+                -118.22168298547774,
+                34.05378444896482
               ]
             }
           },
@@ -274,8 +906,454 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22225573250041,
-                34.05115943988442
+                -118.22225413863158,
+                34.051161659239405
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1407",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5650
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"492.4,652.9 2588.9,669.9 3691.0,834.2 3696.3,892.7 5000.1,1155.1 4670.7,5367.5 2395.5,6193.6 2740.5,7143.3 1906.1,6782.7 879.2,7927.4 461.7,7972.2 504.1,5154.7 778.4,5150.3 610.8,4063.2 490.3,4063.3 492.4,652.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2285093910883,
+                34.047459271062785
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22795455862872,
+                34.05252248942101
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21913882282759,
+                34.051859292324174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21969365528716,
+                34.04679607396595
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1408 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5676.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8150.0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5676
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"177.7,2947.4 174.8,1191.5 -0.0,1115.7 -0.0,349.7 740.6,0.0 5676.0,0.0 5633.4,3854.5 3824.0,3863.1 3833.9,5691.0 4516.4,5702.1 3837.8,6411.9 3838.0,6444.1 2289.7,8150.0 -0.0,8150.0 -0.0,3328.3 177.7,2947.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22270663930557,
+                34.05266193334207
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5676.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21971500956847,
+                34.053315432763036
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5676.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21858221739785,
+                34.04975546243377
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22157384713495,
+                34.04910196301281
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1408 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3859.6"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "6321.2"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1816.4"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "1828.8"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5676
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5267.1,8150.0 4912.2,7824.8 4619.7,8150.0 3937.5,8150.0 3892.5,6358.5 5676.0,6321.2 5676.0,8150.0 5267.1,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3859.6,
+                6321.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22017675678916,
+                34.05142788827928
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5676.0,
+                6321.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21920172312842,
+                34.051626854084
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5676.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2189616930614,
+                34.05080793579944
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3859.6,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21993672672214,
+                34.05060896999472
               ]
             }
           }
@@ -300,8 +1378,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +1398,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1643.2,0.0 4464.8,153.1 4524.3,7772.9 797.3,7810.4 759.0,5496.1 -0.0,5494.8 -0.0,3262.5 701.6,2864.7 1643.2,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1643.7,0.0 3426.7,0.0 3614.4,198.4 5165.2,127.2 5206.3,2752.8 4482.9,2746.7 4526.0,7772.4 1474.1,7805.5 1436.0,634.1 1643.7,0.0\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +1427,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22141512557933,
-                34.04795090859035
+                -118.22141972925765,
+                34.047953194410205
               ]
             }
           },
@@ -370,8 +1448,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21993193223591,
-                34.05021214975328
+                -118.21993314868826,
+                34.050215445747725
               ]
             }
           },
@@ -391,8 +1469,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21599822012344,
-                34.04841569525736
+                -118.2159976792506,
+                34.048414888619234
               ]
             }
           },
@@ -412,8 +1490,974 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21748141346686,
-                34.046154454094435
+                -118.21748425982,
+                34.046152637281715
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1410",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5676
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"706.3,197.8 2862.5,217.5 2858.3,699.7 3133.4,1002.5 4010.4,211.2 4010.4,211.2 4244.5,0.0 5676.0,0.0 5676.0,8150.0 5522.0,8150.0 5521.1,7841.2 -0.0,7827.5 -0.0,2810.7 724.9,2818.7 706.3,197.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22027260243928,
+                34.04976486407289
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5676.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21878052071483,
+                34.05204997023478
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5676.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21481948502787,
+                34.05027441655943
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21631156675232,
+                34.04798931039754
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1411",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5615
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"570.0,7806.4 599.2,279.8 5027.5,255.4 5021.5,2577.9 4896.6,2775.3 4288.0,2784.5 4288.7,5301.2 5006.5,5290.6 5025.5,7811.9 570.0,7806.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21772778819758,
+                34.04636923317236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5615.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21625859803052,
+                34.048635489338395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5615.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21228845139552,
+                34.046868415862555
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21375764156258,
+                34.044602159696524
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1412",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5631
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"727.4,5357.6 -0.0,5368.2 -0.0,2817.8 616.7,2808.7 743.3,2608.7 750.0,255.2 5631.0,292.3 5631.0,8150.0 5233.1,8150.0 5248.0,7891.2 746.1,7912.6 727.4,5357.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21660415194933,
+                34.0480988189905
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5631.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21515084570474,
+                34.050341832927536
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5631.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21123251286839,
+                34.04859885921237
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21268581911298,
+                34.046355845275336
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1413",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5615
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5300.7,7851.5 2159.5,7882.7 1467.8,8150.0 247.5,8150.0 212.1,283.2 -0.0,284.0 0.0,-0.0 5290.7,-0.0 5300.7,7851.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21030631298532,
+                34.048064428104844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5615.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20757458051536,
+                34.046834133180326
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5615.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20971477955399,
+                34.04352535710928
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21244651202396,
+                34.0447556520338
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1414",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5631
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"258.4,-0.0 5631.0,-0.0 5631.0,7932.6 235.2,7963.4 258.4,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20784212173268,
+                34.046984345952474
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5631.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20511522829534,
+                34.045768297700675
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5631.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20722460124757,
+                34.04247471440545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20995149468492,
+                34.04369076265725
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1415",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5615
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5408.8,7938.3 583.2,7918.2 604.5,-0.0 5615.0,-0.0 5615.0,269.1 5413.6,267.0 5408.8,7938.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20541787361896,
+                34.045884410873306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5615.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2026817392875,
+                34.04468885364005
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5615.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20477594518222,
+                34.04139759090321
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20751207951368,
+                34.04259314813647
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1416",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5631
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"169.1,242.4 370.8,242.5 368.4,-0.0 5631.0,-0.0 5631.0,7909.8 240.0,7922.1 169.1,242.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20286702186381,
+                34.04475780479265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5631.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20014037761064,
+                34.0435380002341
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5631.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20227114247663,
+                34.04026771033004
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2049977867298,
+                34.041487514888594
               ]
             }
           }
@@ -438,8 +2482,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +2502,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8150.0 193.8,6653.1 -0.0,6625.8 -0.0,5943.0 1051.0,78.4 5024.4,745.1 4811.9,3482.1 5510.8,3489.1 5615.0,3927.2 5615.0,8150.0 -0.0,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8150.0 199.0,6667.1 -0.0,6639.2 -0.0,5982.5 1053.0,80.3 5033.8,745.4 4822.8,3487.3 5523.0,3493.8 5615.0,3879.4 5615.0,8150.0 -0.0,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +2531,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22525464849419,
-                34.04814705802944
+                -118.2252532591889,
+                34.04814724353955
               ]
             }
           },
@@ -508,8 +2552,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22496228145796,
-                34.045613276673514
+                -118.22496355714925,
+                34.045617672597494
               ]
             }
           },
@@ -529,8 +2573,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22937003135874,
-                34.045259153179295
+                -118.22936398547658,
+                34.04526677725108
               ]
             }
           },
@@ -550,8 +2594,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22966239839496,
-                34.047792934535224
+                -118.22965368751623,
+                34.04779634819314
               ]
             }
           }
@@ -576,8 +2620,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +2640,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"899.1,8150.0 886.0,5094.6 186.5,5066.7 536.6,1824.5 2269.3,1566.0 2320.7,95.1 5016.1,94.9 4848.3,5756.8 5034.0,6733.0 5631.0,6693.1 5631.0,8150.0 899.1,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"893.1,8150.0 974.4,5477.8 894.2,5090.0 195.5,5062.3 480.8,2415.7 4933.3,2747.1 4858.8,5785.7 5037.8,6725.8 5631.0,6686.0 5631.0,8150.0 893.1,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +2669,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22417313102211,
-                34.04619605803524
+                -118.22417298784414,
+                34.046199872363815
               ]
             }
           },
@@ -646,8 +2690,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22378970376137,
-                34.04366738417155
+                -118.22378967452443,
+                34.0436682700204
               ]
             }
           },
@@ -667,8 +2711,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22817596985762,
-                34.04320427446742
+                -118.22818102167234,
+                34.043205298070816
               ]
             }
           },
@@ -688,8 +2732,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22855939711835,
-                34.045732948331114
+                -118.22856433499206,
+                34.045736900414234
               ]
             }
           }
@@ -714,8 +2758,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +2778,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"850.3,8150.0 808.9,6751.3 214.2,6808.8 -0.0,5840.0 -0.0,184.0 5298.1,32.8 5465.0,8074.7 5615.0,8150.0 850.3,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"834.8,8150.0 795.8,6742.5 204.7,6798.6 -0.0,5865.0 -0.0,179.3 5299.2,37.5 5413.0,8063.1 5615.0,8150.0 834.8,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +2807,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22378311706177,
-                34.043946133685985
+                -118.22378575898692,
+                34.04394714255965
               ]
             }
           },
@@ -784,8 +2828,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22349003503982,
-                34.04141245029887
+                -118.22348706237459,
+                34.041411684351324
               ]
             }
           },
@@ -805,8 +2849,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22789739773826,
-                34.04105744333286
+                -118.22789751238847,
+                34.04104987649494
               ]
             }
           },
@@ -826,8 +2870,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22819047976022,
-                34.043591126719974
+                -118.2281962090008,
+                34.043585334703266
               ]
             }
           }
@@ -852,8 +2896,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +2916,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5100.3,2833.2 5631.0,5181.8 5631.0,8150.0 -0.0,8150.0 -0.0,168.0 5254.3,115.7 5469.7,-0.0 5100.3,2833.2\" /></svg>"
+          "value": "<svg><polygon points=\"5500.8,4475.9 5631.0,8150.0 -0.0,8150.0 -0.0,188.2 5244.3,110.8 5458.0,-0.0 5103.5,2825.6 5500.8,4475.9\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +2945,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22343299386827,
-                34.041562959196256
+                -118.2234216010423,
+                34.04156226651261
               ]
             }
           },
@@ -922,8 +2966,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22307324741554,
-                34.039008052714735
+                -118.22307611323696,
+                34.03900268323584
               ]
             }
           },
@@ -943,8 +2987,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22750477657326,
-                34.038573521512696
+                -118.22751575437641,
+                34.03858537479485
               ]
             }
           },
@@ -964,8 +3008,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22786452302599,
-                34.04112842799422
+                -118.22786124218176,
+                34.04114495807161
               ]
             }
           }
@@ -990,8 +3034,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1010,7 +3054,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4830.7,8150.0 351.8,8150.0 442.4,6248.6 21.3,3780.3 548.6,841.4 1265.3,715.4 1350.6,-0.0 5615.0,-0.0 5435.3,1891.1 5615.0,2061.8 4627.6,1906.2 4830.7,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"4921.5,8150.0 302.7,8150.0 20.9,3789.4 539.6,850.6 4754.2,-0.0 5615.0,-0.0 5425.3,1905.9 5615.0,2055.4 4625.8,1902.1 4921.5,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -1039,8 +3083,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22263591787404,
-                34.03938637606773
+                -118.22262898699877,
+                34.039382243782384
               ]
             }
           },
@@ -1060,8 +3104,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22213918839391,
-                34.036890525986955
+                -118.22214046364681,
+                34.036883942842046
               ]
             }
           },
@@ -1081,8 +3125,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22648050479398,
-                34.03628881057523
+                -118.22648604310616,
+                34.03629216795929
               ]
             }
           },
@@ -1102,8 +3146,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22697723427412,
-                34.038784660656006
+                -118.22697456645813,
+                34.03879046889963
               ]
             }
           }
@@ -1128,8 +3172,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1148,7 +3192,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,769.2 963.3,953.3 792.5,780.1 1193.8,997.3 5619.0,1842.7 5619.0,8150.0 -0.0,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,705.8 5619.0,1859.6 5619.0,8150.0 -0.0,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -1177,8 +3221,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22282681172966,
-                34.03725784137564
+                -118.22286215716626,
+                34.03725298593728
               ]
             }
           },
@@ -1198,8 +3242,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22222133656598,
-                34.03472732031757
+                -118.2222182997937,
+                34.03475551643758
               ]
             }
           },
@@ -1219,8 +3263,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.2266197111869,
-                34.03399437802334
+                -118.2265899147807,
+                34.03398158289276
               ]
             }
           },
@@ -1240,8 +3284,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22722518635058,
-                34.03652489908141
+                -118.22723377215327,
+                34.03647905239246
               ]
             }
           }
@@ -1266,8 +3310,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1286,7 +3330,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4977.1,143.4 5097.4,3924.8 5293.1,3957.9 5402.8,8150.0 4587.5,8150.0 212.9,7560.7 119.8,8150.0 -0.0,8150.0 -0.0,490.7 596.9,-0.0 5425.8,-0.0 5424.1,152.2 4977.1,143.4\" /></svg>"
+          "value": "<svg><polygon points=\"524.7,5410.5 902.1,3168.4 1226.6,3373.6 5300.6,3953.2 5421.0,8150.0 4648.1,8150.0 -0.0,7477.2 -0.0,5338.2 524.7,5410.5\" /></svg>"
         }
       },
       "body": {
@@ -1315,8 +3359,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21988700909556,
-                34.04789645600162
+                -118.2198852310669,
+                34.047891554488054
               ]
             }
           },
@@ -1336,8 +3380,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21968513858458,
-                34.04528469505084
+                -118.2196915185456,
+                34.04528342887723
               ]
             }
           },
@@ -1357,8 +3401,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22423501128067,
-                34.04503983417798
+                -118.22423506207215,
+                34.04504846351937
               ]
             }
           },
@@ -1378,8 +3422,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22443688179165,
-                34.047651595128755
+                -118.22442877459345,
+                34.0476565891302
               ]
             }
           }
@@ -1404,8 +3448,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1424,7 +3468,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"197.1,3974.7 -0.0,3934.9 -0.0,102.5 4886.2,316.3 5102.0,-0.0 5492.7,-0.0 5219.0,6138.4 5559.2,7742.2 174.5,7902.5 197.1,3974.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,3942.3 -0.0,107.2 5202.0,320.3 4908.4,7757.3 179.4,7910.9 191.3,3980.4 -0.0,3942.3\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +3497,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21973155234441,
-                34.04557832870732
+                -118.21972871507158,
+                34.04557079613362
               ]
             }
           },
@@ -1474,8 +3518,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21943350624336,
-                34.043001067196094
+                -118.21943928483023,
+                34.04299460417195
               ]
             }
           },
@@ -1495,8 +3539,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22391356814232,
-                34.04264031114092
+                -118.22391748825734,
+                34.0426442768409
               ]
             }
           },
@@ -1516,8 +3560,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22421161424337,
-                34.04521757265215
+                -118.2242069184987,
+                34.04522046880257
               ]
             }
           }
@@ -1542,8 +3586,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1562,7 +3606,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"269.3,6249.2 164.8,414.9 3506.0,428.9 5607.0,784.0 5607.0,7387.2 712.4,7837.5 269.3,6249.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,363.3 3639.0,449.1 5607.0,822.1 5607.0,7496.1 3615.7,7639.9 3615.7,7637.5 -0.0,7908.7 -0.0,363.3\" /></svg>"
         }
       },
       "body": {
@@ -1591,8 +3635,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21940432216383,
-                34.04313097197726
+                -118.21943870134693,
+                34.043180983267966
               ]
             }
           },
@@ -1612,8 +3656,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21930235648509,
-                34.04056336554174
+                -118.21927223849308,
+                34.040648511614116
               ]
             }
           },
@@ -1633,8 +3677,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22377506409966,
-                34.04043967847416
+                -118.22371490957839,
+                34.040448004355284
               ]
             }
           },
@@ -1654,8 +3698,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.2238770297784,
-                34.04300728490968
+                -118.22388137243225,
+                34.042980476009134
               ]
             }
           }
@@ -1680,8 +3724,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1700,7 +3744,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5619.0,-0.0 5619.0,6681.5 4945.0,6884.6 4736.7,7098.5 1978.9,7323.7 2061.9,829.2 3230.0,1042.0 3825.6,-0.0 5619.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"3797.7,-0.0 5619.0,-0.0 5619.0,6699.3 4926.6,6904.3 4717.2,7117.0 1932.2,7330.8 1911.2,807.9 3205.6,1049.6 3797.7,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -1729,8 +3773,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21932299525265,
-                34.04152866812597
+                -118.21932393707345,
+                34.041537001521114
               ]
             }
           },
@@ -1750,8 +3794,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.2191790625094,
-                34.03891396285018
+                -118.21916456781472,
+                34.038921520031245
               ]
             }
           },
@@ -1771,8 +3815,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22372399432962,
-                34.038739737765525
+                -118.2237108423636,
+                34.03872860935868
               ]
             }
           },
@@ -1792,8 +3836,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22386792707287,
-                34.04135444304131
+                -118.22387021162234,
+                34.04134409084855
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1427/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1427",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1427/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1427/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5607
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1881.7,-0.0 3547.4,370.8 4230.5,-0.0 5607.0,-0.0 5607.0,745.4 4638.5,6019.5 1875.9,8150.0 1664.9,8150.0 -0.0,3450.1 -0.0,-0.0 1881.7,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1427/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21820596909689,
+                34.03842509410289
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5607.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21909943605469,
+                34.0359230493319
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5607.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22345771722033,
+                34.03700690302134
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22256425026252,
+                34.039508947792335
               ]
             }
           }
@@ -1818,8 +4000,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,7 +4020,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5619.0,-0.0 5619.0,7215.9 5400.6,6812.4 1185.8,8150.0 738.0,8150.0 -0.0,6482.8 -0.0,1380.1 472.7,1480.7 691.0,300.1 5619.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5619.0,-0.0 5619.0,7232.6 5373.7,6791.9 1066.1,8150.0 682.8,8150.0 -0.0,6422.7 -0.0,3659.5 421.5,1320.7 417.1,572.7 -0.0,576.7 -0.0,358.1 3671.8,-0.0 5619.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -1867,8 +4049,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21867366860192,
-                34.03603730882894
+                -118.21872682410019,
+                34.03602947495259
               ]
             }
           },
@@ -1888,8 +4070,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21960170870643,
-                34.03352490080845
+                -118.219643134341,
+                34.033552905379736
               ]
             }
           },
@@ -1909,8 +4091,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22396858498695,
-                34.034648319740434
+                -118.22397816593507,
+                34.03465433440521
               ]
             }
           },
@@ -1930,8 +4112,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22304054488242,
-                34.03716072776092
+                -118.22306185569425,
+                34.03713090397807
               ]
             }
           }
@@ -1939,7 +4121,7 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
@@ -1954,10 +4136,26 @@
         {
           "label": "intersections",
           "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5541.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8150.0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1966,7 +4164,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429__1/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429/info.json",
@@ -1976,11 +4174,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5541.0,6771.1 3263.3,8150.0 2148.4,8150.0 -0.0,4690.9 -0.0,201.9 5541.0,132.3 5541.0,6771.1\" /></svg>"
+          "value": "<svg><polygon points=\"2272.4,3635.1 2435.3,143.9 5541.0,293.6 5541.0,6963.6 3657.3,7839.9 3627.5,7152.8 1669.6,7238.6 1689.3,7694.8 -0.0,4651.6 -0.0,4161.9 1016.7,3588.5 2272.4,3635.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -2005,8 +4203,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21850769584958,
-                34.04712739176668
+                -118.21862325916398,
+                34.047105013639985
               ]
             }
           },
@@ -2026,8 +4224,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21580137661704,
-                34.04588655731367
+                -118.21583869684724,
+                34.04597947498417
               ]
             }
           },
@@ -2047,8 +4245,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21798949330082,
-                34.042563550724104
+                -118.21783749048711,
+                34.04258433089495
               ]
             }
           },
@@ -2068,8 +4266,576 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22069581253335,
-                34.04380438517711
+                -118.22062205280385,
+                34.04370986955076
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1429 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "6486.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1982.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "1664.0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5541
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"599.6,8150.0 -0.0,6946.6 -0.0,6486.0 1982.0,6486.0 1982.0,8150.0 599.6,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                6486.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21955950933528,
+                34.0437504212665
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1982.0,
+                6486.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21855453619612,
+                34.043388421860065
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1982.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21892281123364,
+                34.042687367423255
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2199277843728,
+                34.04304936682969
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1430",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5628
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1142.5,442.8 5521.1,476.7 5472.5,6968.0 5214.9,6965.8 5201.4,8150.0 3267.3,8150.0 3250.6,6951.5 1497.9,7061.2 1315.2,7152.6 1142.5,442.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.216356470913,
+                34.04628243535502
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5628.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21360135110874,
+                34.045078633386346
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5628.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21569095264768,
+                34.0417485721269
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21844607245194,
+                34.04295237409557
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1431",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5640
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"319.5,7848.7 295.9,549.5 2826.9,544.6 2828.4,435.9 4092.4,423.3 4334.2,278.5 4758.1,166.0 5440.7,169.7 5390.5,7833.7 319.5,7848.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21357607268156,
+                34.0454908493413
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5640.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21085740326134,
+                34.04426628455942
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5640.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21297745704528,
+                34.04098884175601
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2156961264655,
+                34.04221340653789
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1432",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5591
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5113.6,201.1 5221.4,7791.8 357.7,7783.8 402.6,233.3 5113.6,201.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21113423652106,
+                34.04442473349895
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5591.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20837983272182,
+                34.04319964866915
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5591.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2105340563067,
+                34.039874043323245
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21328846010594,
+                34.04109912815304
               ]
             }
           }
@@ -2094,8 +4860,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2114,7 +4880,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5510.9,7926.1 50.3,7884.5 157.6,186.7 5472.4,179.9 5510.9,7926.1\" /></svg>"
+          "value": "<svg><polygon points=\"58.4,7884.3 -0.0,187.9 5470.7,173.6 5518.7,7919.1 58.4,7884.3\" /></svg>"
         }
       },
       "body": {
@@ -2143,8 +4909,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20862067277513,
-                34.043298262405614
+                -118.20861979091553,
+                34.04329811445108
               ]
             }
           },
@@ -2164,8 +4930,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20593713458446,
-                34.0421105478038
+                -118.2059378046542,
+                34.04210754678179
               ]
             }
           },
@@ -2185,8 +4951,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20803045371137,
-                34.03881697744422
+                -118.20803615216546,
+                34.0388158810163
               ]
             }
           },
@@ -2206,8 +4972,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21071399190204,
-                34.04000469204603
+                -118.2107181384268,
+                34.04000644868559
               ]
             }
           }
@@ -2232,8 +4998,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2252,7 +5018,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"36.9,289.4 5606.0,240.4 5606.0,7907.6 154.9,7956.8 36.9,289.4\" /></svg>"
+          "value": "<svg><polygon points=\"145.8,7944.9 -0.0,287.5 5606.0,237.6 5606.0,7900.9 145.8,7944.9\" /></svg>"
         }
       },
       "body": {
@@ -2281,8 +5047,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20595701974808,
-                34.04217773723939
+                -118.20595606062729,
+                34.0421780603425
               ]
             }
           },
@@ -2302,8 +5068,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20322927925672,
-                34.040939888753066
+                -118.20322228169735,
+                34.04094029274626
               ]
             }
           },
@@ -2323,8 +5089,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20538553260538,
-                34.0376309929941
+                -118.20537839461679,
+                34.03762407276927
               ]
             }
           },
@@ -2344,8 +5110,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20811327309674,
-                34.03886884148043
+                -118.20811217354672,
+                34.03886184036551
               ]
             }
           }
@@ -2370,8 +5136,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2390,7 +5156,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"910.7,7862.6 1018.3,-0.0 4750.1,-0.0 4748.7,174.3 4936.8,175.5 4947.4,7879.2 910.7,7862.6\" /></svg>"
+          "value": "<svg><polygon points=\"678.1,158.9 1052.0,164.6 1054.4,-0.0 4734.9,39.7 4692.7,7866.4 596.4,7812.9 678.1,158.9\" /></svg>"
         }
       },
       "body": {
@@ -2419,8 +5185,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20266225285017,
-                34.04064309350515
+                -118.20268671667068,
+                34.04065690476559
               ]
             }
           },
@@ -2440,8 +5206,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19998288157657,
-                34.03945922978072
+                -118.19996338194147,
+                34.03947940693423
               ]
             }
           },
@@ -2461,8 +5227,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20208555434135,
-                34.03614512768283
+                -118.20206950404831,
+                34.0361345268194
               ]
             }
           },
@@ -2482,8 +5248,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20476492561495,
-                34.03732899140726
+                -118.20479283877752,
+                34.03731202465077
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1436",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5606
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7925.5 -0.0,0.0 4944.4,14.1 4937.3,7971.4 -0.0,7925.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20035246645965,
+                34.03962691622642
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5606.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19761802049159,
+                34.03842897485411
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5606.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1997194065734,
+                34.03513506741601
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20245385254145,
+                34.03633300878832
               ]
             }
           }
@@ -2508,8 +5412,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2528,7 +5432,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7961.3 0.0,-0.0 5510.0,-0.0 5510.0,7930.7 -0.0,7961.3\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7953.0 0.0,-0.0 5510.0,-0.0 5510.0,7935.8 -0.0,7953.0\" /></svg>"
         }
       },
       "body": {
@@ -2557,8 +5461,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19794108766877,
-                34.03857258406848
+                -118.19794435873736,
+                34.03856464611244
               ]
             }
           },
@@ -2578,8 +5482,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19527228980995,
-                34.03737725750356
+                -118.19527538256747,
+                34.03737623495261
               ]
             }
           },
@@ -2599,8 +5503,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19739064873183,
-                34.03408334066869
+                -118.19738148600158,
+                34.03408209804044
               ]
             }
           },
@@ -2620,8 +5524,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20005944659064,
-                34.03527866723362
+                -118.20005046217146,
+                34.035270509200274
               ]
             }
           }
@@ -2646,8 +5550,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2666,7 +5570,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"648.4,7945.7 657.5,-0.0 1256.4,-0.0 1258.9,285.7 5671.0,272.8 5429.0,323.2 5527.0,7870.2 648.4,7945.7\" /></svg>"
+          "value": "<svg><polygon points=\"744.4,7943.4 629.8,13.8 1225.3,6.7 1232.6,336.0 4896.2,342.3 5256.8,7893.3 744.4,7943.4\" /></svg>"
         }
       },
       "body": {
@@ -2695,8 +5599,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19560147316594,
-                34.037497802249945
+                -118.19557743964933,
+                34.03751895886587
               ]
             }
           },
@@ -2716,8 +5620,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19287637145354,
-                34.03628057156651
+                -118.19283240533173,
+                34.0362712931294
               ]
             }
           },
@@ -2737,8 +5641,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19497267114934,
-                34.03301199897741
+                -118.19499627643263,
+                34.033001874464404
               ]
             }
           },
@@ -2758,8 +5662,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19769777286174,
-                34.034229229660845
+                -118.19774131075023,
+                34.03424954020087
               ]
             }
           }
@@ -2784,8 +5688,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2804,7 +5708,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7745.3 0.0,-0.0 650.2,-0.0 1452.5,-0.0 5510.0,7628.5 5510.0,8150.0 338.0,8075.8 340.4,7794.8 -0.0,7745.3\" /></svg>"
+          "value": "<svg><polygon points=\"5510.0,7613.9 5510.0,8150.0 338.1,8083.1 340.7,7756.1 -0.0,7752.0 0.0,0.0 1457.2,-0.0 5510.0,7613.9\" /></svg>"
         }
       },
       "body": {
@@ -2833,8 +5737,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19319284208521,
-                34.04050774830819
+                -118.19319356896962,
+                34.04050345552431
               ]
             }
           },
@@ -2854,8 +5758,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19047539767568,
-                34.03934387941056
+                -118.1904820022956,
+                34.03934123959552
               ]
             }
           },
@@ -2875,8 +5779,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19253805178657,
-                34.03598999378154
+                -118.19254172695027,
+                34.0359946083017
               ]
             }
           },
@@ -2896,8 +5800,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1952554961961,
-                34.03715386267917
+                -118.19525329362429,
+                34.037156824230486
               ]
             }
           }
@@ -2922,8 +5826,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2942,7 +5846,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5635.3,7847.7 581.5,7891.2 298.0,7721.8 456.7,254.5 1538.1,193.4 1541.4,-0.0 1693.9,-0.0 5635.3,7847.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7758.9 -0.0,206.1 1528.2,233.2 1532.0,16.6 1703.3,21.3 5627.8,7839.9 1175.3,7904.2 -0.0,7758.9\" /></svg>"
         }
       },
       "body": {
@@ -2971,8 +5875,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19323963557184,
-                34.03640056335347
+                -118.19324137551301,
+                34.03640113516023
               ]
             }
           },
@@ -2992,8 +5896,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19043699338185,
-                34.0352498911194
+                -118.19043447899193,
+                34.035250052521114
               ]
             }
           },
@@ -3013,8 +5917,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1924186404513,
-                34.031888269119065
+                -118.19241683284646,
+                34.031883327674265
               ]
             }
           },
@@ -3034,8 +5938,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1952212826413,
-                34.033038941353134
+                -118.19522372936754,
+                34.033034410313384
               ]
             }
           }
@@ -3060,8 +5964,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3080,7 +5984,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2745.2,7816.8 -0.0,7852.3 -0.0,214.6 3575.6,112.3 5534.0,3633.1 5534.0,8150.0 2748.0,8150.0 2745.2,7816.8\" /></svg>"
+          "value": "<svg><polygon points=\"2743.6,7818.8 451.5,7848.6 394.5,200.0 3575.9,108.2 5534.0,3629.8 5534.0,8150.0 2746.4,8150.0 2743.6,7818.8\" /></svg>"
         }
       },
       "body": {
@@ -3109,8 +6013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19404391071558,
-                34.02882626548193
+                -118.19404388190178,
+                34.02882375342362
               ]
             }
           },
@@ -3130,8 +6034,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1913461969131,
-                34.02760284500918
+                -118.19134812468428,
+                34.027601659884226
               ]
             }
           },
@@ -3151,8 +6055,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19350469580112,
-                34.02428729206346
+                -118.19350428244414,
+                34.02428851162695
               ]
             }
           },
@@ -3172,8 +6076,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1962024096036,
-                34.02551071253621
+                -118.19620003966163,
+                34.025510605166346
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1442 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5669
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1855.9,1289.4 4037.5,243.2 5669.0,222.7 5669.0,8150.0 3068.8,8150.0 1999.9,5052.4 536.4,2331.6 1909.1,2255.3 1855.9,1289.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21930805136024,
+                34.044010938103504
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5669.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21649189306132,
+                34.04283851677328
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5669.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21852686582828,
+                34.039482293601054
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22134302412721,
+                34.04065471493128
               ]
             }
           }
@@ -3198,8 +6240,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3218,7 +6260,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,223.1 5323.6,209.7 5320.6,8000.6 513.4,7980.6 513.6,8150.0 -0.0,8150.0 -0.0,223.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,217.9 5325.0,208.0 5316.9,8003.5 506.9,7980.3 507.0,8150.0 -0.0,8150.0 -0.0,217.9\" /></svg>"
         }
       },
       "body": {
@@ -3247,8 +6289,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.215532322114,
-                34.042411062664215
+                -118.21553291859384,
+                34.04240857646891
               ]
             }
           },
@@ -3268,8 +6310,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21285945904296,
-                34.041208601229755
+                -118.21286070455501,
+                34.04120827325444
               ]
             }
           },
@@ -3289,8 +6331,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21498131907352,
-                34.03792411599212
+                -118.2149787561967,
+                34.037924585564845
               ]
             }
           },
@@ -3310,8 +6352,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21765418214456,
-                34.03912657742658
+                -118.21765097023552,
+                34.03912488877931
               ]
             }
           }
@@ -3336,8 +6378,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3356,7 +6398,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5307.5,8047.8 288.6,8030.2 423.1,232.0 5441.7,301.2 5307.5,8047.8\" /></svg>"
+          "value": "<svg><polygon points=\"5375.1,296.6 5165.5,8033.1 302.4,8019.0 428.4,233.9 5375.1,296.6\" /></svg>"
         }
       },
       "body": {
@@ -3385,8 +6427,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21316313485207,
-                34.04135294756762
+                -118.21316525477863,
+                34.04135528728704
               ]
             }
           },
@@ -3406,8 +6448,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21042068630406,
-                34.040168506026305
+                -118.21041962679165,
+                34.040166369585165
               ]
             }
           },
@@ -3427,8 +6469,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21247363949922,
-                34.03685826631662
+                -118.21248033836729,
+                34.036852292171716
               ]
             }
           },
@@ -3448,8 +6490,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21521608804723,
-                34.03804270785793
+                -118.21522596635427,
+                34.03804120987359
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1445",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5605
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,217.9 5421.0,252.0 5421.0,7969.0 -0.0,8024.3 -0.0,217.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2105348129235,
+                34.040174180724755
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5605.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20783297902493,
+                34.03897438207712
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5605.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20993819582121,
+                34.035719194829845
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21264002971978,
+                34.03691899347748
               ]
             }
           }
@@ -3474,8 +6654,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3494,7 +6674,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5576.4,237.0 5669.0,7949.9 1166.4,7930.5 1166.8,8150.0 144.3,8150.0 140.6,7942.1 -0.0,7944.7 51.8,281.7 5576.4,237.0\" /></svg>"
+          "value": "<svg><polygon points=\"3837.1,8150.0 76.7,8150.0 44.9,285.0 5561.0,229.9 5669.0,7930.9 3837.5,7923.4 3837.1,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -3523,8 +6703,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20793812533246,
-                34.03903761559812
+                -118.20793357397508,
+                34.03903754724414
               ]
             }
           },
@@ -3544,8 +6724,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20520931171305,
-                34.03780194808117
+                -118.20520339587566,
+                34.03779568597041
               ]
             }
           },
@@ -3565,8 +6745,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20733890192281,
-                34.03452667043329
+                -118.20734366061043,
+                34.03451877059585
               ]
             }
           },
@@ -3586,8 +6766,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21006771554222,
-                34.03576233795024
+                -118.21007383870986,
+                34.035760631869586
               ]
             }
           }
@@ -3612,8 +6792,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3632,7 +6812,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5137.8,7939.2 296.0,7924.4 241.4,249.0 5070.8,241.1 5137.8,7939.2\" /></svg>"
+          "value": "<svg><polygon points=\"293.5,7924.4 233.6,243.4 5085.8,232.7 5149.3,7936.5 293.5,7924.4\" /></svg>"
         }
       },
       "body": {
@@ -3661,8 +6841,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20536812415124,
-                34.037880159484324
+                -118.20536565281655,
+                34.03787608243619
               ]
             }
           },
@@ -3682,8 +6862,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20264866087773,
-                34.036663014355554
+                -118.20264900806728,
+                34.03665856255278
               ]
             }
           },
@@ -3703,8 +6883,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20476921605649,
-                34.033363258766954
+                -118.20477021615763,
+                34.033362226919174
               ]
             }
           },
@@ -3724,8 +6904,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20748867933,
-                34.034580403895724
+                -118.2074868609069,
+                34.034579746802585
               ]
             }
           }
@@ -3750,8 +6930,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3770,7 +6950,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5516.5,8010.8 -0.0,7982.0 -0.0,248.6 5547.6,302.6 5516.5,8010.8\" /></svg>"
+          "value": "<svg><polygon points=\"5502.5,8009.2 -0.0,7986.2 -0.0,256.7 5525.6,304.7 5502.5,8009.2\" /></svg>"
         }
       },
       "body": {
@@ -3799,8 +6979,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20290720862369,
-                34.036782098898975
+                -118.20289562650117,
+                34.03678116155765
               ]
             }
           },
@@ -3820,8 +7000,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20017003021373,
-                34.03558248623794
+                -118.20015860716452,
+                34.0355785976656
               ]
             }
           },
@@ -3841,8 +7021,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20224667244571,
-                34.03228239233801
+                -118.2022403582547,
+                34.032278695553245
               ]
             }
           },
@@ -3862,8 +7042,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20498385085565,
-                34.033482004999044
+                -118.20497737759135,
+                34.033481259445296
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1449",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5605
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4174.5,7990.5 494.2,7967.2 452.5,247.7 5206.0,246.7 5179.2,7505.5 4174.5,7990.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.200447039131,
+                34.03567617949156
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5605.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19772578880136,
+                34.03447305016378
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5605.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1998366628357,
+                34.03119417956294
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20255791316534,
+                34.032397308890715
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1450",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5639
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2198.7,7973.3 -0.0,7961.2 148.5,7339.8 124.7,167.8 4978.5,175.5 5040.5,7489.0 2198.9,7450.8 2198.7,7973.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19800057919882,
+                34.03455310514653
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5639.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19527659283227,
+                34.03335364114221
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5639.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1973675856033,
+                34.030092395961475
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20009157196985,
+                34.03129185996579
               ]
             }
           }
@@ -3888,8 +7344,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3908,7 +7364,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2569.8,7955.2 2328.3,8149.0 -0.0,8149.0 -0.0,7483.7 598.5,7485.7 608.9,6074.6 -0.0,6068.3 -0.0,159.7 1355.3,110.0 1646.4,273.5 2248.9,280.5 5048.8,177.4 5047.0,7955.1 2587.1,7955.1 2569.8,7955.2\" /></svg>"
+          "value": "<svg><polygon points=\"2601.1,7954.2 2608.5,7497.9 -0.0,7456.0 -0.0,154.0 1365.3,105.9 1656.2,269.8 2258.9,277.5 5061.3,177.5 5054.7,7957.0 2601.1,7954.2\" /></svg>"
         }
       },
       "body": {
@@ -3937,8 +7393,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19559560610642,
-                34.03348608686597
+                -118.19560174420782,
+                34.03348589328673
               ]
             }
           },
@@ -3958,8 +7414,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19289262955702,
-                34.03230031329929
+                -118.19289779534759,
+                34.03230293374421
               ]
             }
           },
@@ -3979,8 +7435,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1949584189315,
-                34.029020389222794
+                -118.19495868228424,
+                34.02902182981818
               ]
             }
           },
@@ -4000,8 +7456,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1976613954809,
-                34.03020616278947
+                -118.19766263114447,
+                34.030204789360695
               ]
             }
           }
@@ -4026,8 +7482,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4046,7 +7502,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1685.7,214.1 5639.0,7609.2 5639.0,8001.3 5516.5,8035.4 -0.0,7996.4 -0.0,298.2 1685.7,214.1\" /></svg>"
+          "value": "<svg><polygon points=\"1684.0,210.5 5639.0,7617.9 5639.0,7998.3 5510.9,8033.9 -0.0,7992.1 -0.0,293.7 1684.0,210.5\" /></svg>"
         }
       },
       "body": {
@@ -4075,8 +7531,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1931294320329,
-                34.03246784091654
+                -118.19312980259078,
+                34.032465685561064
               ]
             }
           },
@@ -4096,8 +7552,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19038137883666,
-                34.031261591879584
+                -118.19038106575366,
+                34.0312606194006
               ]
             }
           },
@@ -4117,8 +7573,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1924694016435,
-                34.02794821597442
+                -118.19246704226629,
+                34.027946421236365
               ]
             }
           },
@@ -4138,8 +7594,974 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19521745483974,
-                34.029154465011366
+                -118.1952157791034,
+                34.02915148739683
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1453",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5582
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"943.5,7241.6 728.1,7287.1 566.6,6401.2 -0.0,5732.0 -0.0,302.9 228.8,300.8 226.2,131.4 5582.0,99.3 5582.0,7757.6 1220.1,7858.2 943.5,7241.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21743624328596,
+                34.03918607423054
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5582.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2147383579845,
+                34.03794812764615
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5582.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21691818880515,
+                34.034685903329915
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21961607410661,
+                34.035923849914305
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1454",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5639
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"529.5,7766.5 722.8,155.5 5639.0,173.3 5639.0,7784.3 529.5,7766.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21508117413329,
+                34.03812561080968
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5639.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.212302579912,
+                34.03692595814999
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5639.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21439397243539,
+                34.03359944740234
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21717256665667,
+                34.034799100062024
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1455",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5582
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"611.6,7772.0 639.3,56.5 4178.8,73.4 4002.3,7836.8 611.6,7772.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21264420781837,
+                34.03701131171908
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5582.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20992544549694,
+                34.03584772908038
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5582.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21197426935326,
+                34.03256015858419
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2146930316747,
+                34.033723741222886
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1456",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5650
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5282.0,7876.1 -0.0,7925.8 -0.0,229.3 1325.5,197.7 1326.4,412.7 5078.4,399.9 5282.0,7876.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21056665023895,
+                34.03620282061095
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20784464424577,
+                34.03495463856797
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2100022886876,
+                34.031677462361365
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21272429468078,
+                34.03292564440435
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1457",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5582
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5582.0,7871.0 493.3,7806.6 389.3,7572.6 412.7,75.8 5582.0,174.9 5582.0,7871.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2083482295469,
+                34.035129399046674
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5582.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20562364240958,
+                34.03394384370688
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5582.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20771120437777,
+                34.03064930679129
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2104357915151,
+                34.031834862131085
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1458",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5650
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5650.0,8049.7 878.2,7990.7 904.8,170.9 5650.0,223.2 5650.0,8049.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20606035042704,
+                34.03412877367937
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20334599716324,
+                34.03295729667719
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20538529399201,
+                34.029712164753306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2080996472558,
+                34.03088364175549
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1459",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5555
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4599.4,7885.7 999.3,7860.4 852.7,192.5 4589.7,170.6 4599.4,7885.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20376475661311,
+                34.03313293323047
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5555.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20106867669082,
+                34.03191435161061
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5555.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20322602679656,
+                34.02863588607148
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20592210671884,
+                34.02985446769134
               ]
             }
           }
@@ -4164,8 +8586,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4184,7 +8606,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5393.5,128.1 5421.2,7905.9 -0.0,7953.4 -0.0,175.1 5393.5,128.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7941.4 -0.0,186.1 2283.9,166.4 2619.0,-0.0 3231.7,-0.0 3195.3,158.5 5390.1,139.6 5417.0,7894.4 -0.0,7941.4\" /></svg>"
         }
       },
       "body": {
@@ -4213,8 +8635,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20153040416473,
-                34.03212472261455
+                -118.20153343724743,
+                34.032132016042084
               ]
             }
           },
@@ -4234,8 +8656,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19882813454707,
-                34.030889577599524
+                -118.19882304159405,
+                34.03089342074838
               ]
             }
           },
@@ -4255,8 +8677,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.2009631431068,
-                34.027636011215165
+                -118.20096401160741,
+                34.027630066671634
               ]
             }
           },
@@ -4276,8 +8698,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20366541272446,
-                34.028871156230196
+                -118.20367440726079,
+                34.02886866196534
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1461",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5555
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5271.2,655.7 5260.1,8150.0 255.3,8150.0 239.9,-0.0 5555.0,-0.0 5525.9,444.9 5271.2,655.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19896802581547,
+                34.031157153405424
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5555.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19623960325961,
+                34.02991640099392
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5555.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19842085911743,
+                34.02657526605125
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2011492816733,
+                34.02781601846276
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1462",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5650
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"257.5,8057.6 383.3,499.9 595.9,370.3 5650.0,372.9 5650.0,8082.0 257.5,8057.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19656823407692,
+                34.030018251798126
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19380809678742,
+                34.02880633231137
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19591770027787,
+                34.02550631451211
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19867783756737,
+                34.026718233998864
               ]
             }
           }
@@ -4302,8 +9000,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4322,7 +9020,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5167.7,7319.5 -0.0,7275.3 323.5,1814.5 5215.2,667.6 5167.7,7319.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7285.6 336.2,1718.1 5217.5,661.5 5172.7,7327.6 -0.0,7285.6\" /></svg>"
         }
       },
       "body": {
@@ -4351,8 +9049,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.22057440242709,
-                34.033769118212255
+                -118.2205694944407,
+                34.03377174962542
               ]
             }
           },
@@ -4372,8 +9070,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21919583912295,
-                34.03604203268378
+                -118.21919273221452,
+                34.036039323225246
               ]
             }
           },
@@ -4393,8 +9091,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21518824366431,
-                34.03434911927679
+                -118.21519455768085,
+                34.03434861993476
               ]
             }
           },
@@ -4414,8 +9112,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21656680696846,
-                34.032076204805264
+                -118.21657131990702,
+                34.03208104633494
               ]
             }
           }
@@ -4440,8 +9138,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4460,7 +9158,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,373.0 5364.9,330.4 5316.7,7679.6 -0.0,7594.7 -0.0,373.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,369.8 5353.6,318.3 5317.5,7672.6 -0.0,7596.4 -0.0,369.8\" /></svg>"
         }
       },
       "body": {
@@ -4489,8 +9187,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21722141172422,
-                34.03226990117846
+                -118.21721572976391,
+                34.03227541637605
               ]
             }
           },
@@ -4510,8 +9208,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.2157767182156,
-                34.034554297003
+                -118.2157675225592,
+                34.03455625672758
               ]
             }
           },
@@ -4531,8 +9229,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21182790899634,
-                34.032814920529106
+                -118.21182486053823,
+                34.03281264931527
               ]
             }
           },
@@ -4552,8 +9250,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.21327260250497,
-                34.03053052470457
+                -118.21327306774293,
+                34.03053180896374
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1465",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5510
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,-0.0 5251.1,0.0 5272.6,8149.0 -0.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21354991732046,
+                34.030635572301435
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5510.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21207111611338,
+                34.03288609187139
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5510.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20805681597633,
+                34.03107447493222
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20953561718342,
+                34.02882395536226
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1466",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5650
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5287.7,2330.5 5264.5,7382.7 -0.0,7318.8 -0.0,2257.1 5287.7,2330.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21059606747137,
+                34.0293494523807
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2091560940645,
+                34.031615147239314
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20521215534515,
+                34.02989352288687
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20665212875203,
+                34.02762782802826
               ]
             }
           }
@@ -4578,8 +9552,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4598,7 +9572,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5329.0,0.0 5337.9,8149.0 -0.0,8149.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8149.0 0.0,-0.0 5316.0,0.0 5330.1,8149.0 4134.6,8149.0 4123.4,7629.2 229.5,7749.8 233.5,8149.0 -0.0,8149.0\" /></svg>"
         }
       },
       "body": {
@@ -4627,8 +9601,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20709706718966,
-                34.027739416111686
+                -118.20709203669195,
+                34.027744975427616
               ]
             }
           },
@@ -4648,8 +9622,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20563608337835,
-                34.02997548814886
+                -118.2056297929593,
+                34.02997950159252
               ]
             }
           },
@@ -4669,8 +9643,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20167565054408,
-                34.02817300105082
+                -118.20167209810629,
+                34.02817546006797
               ]
             }
           },
@@ -4690,8 +9664,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20313663435539,
-                34.025936929013646
+                -118.20313434183893,
+                34.025940933903065
               ]
             }
           }
@@ -4716,8 +9690,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4736,7 +9710,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,853.9 5337.8,993.5 5263.8,7577.7 -0.0,7508.0 -0.0,853.9\" /></svg>"
+          "value": "<svg><polygon points=\"188.4,844.2 195.6,440.8 4135.6,428.4 4132.5,953.9 5338.7,987.5 5308.9,2462.0 5249.5,2461.6 5112.5,7573.3 -0.0,7500.4 -0.0,839.0 188.4,844.2\" /></svg>"
         }
       },
       "body": {
@@ -4765,8 +9739,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.2035392948272,
-                34.026136129815875
+                -118.20353091388566,
+                34.026134375012276
               ]
             }
           },
@@ -4786,8 +9760,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.20213384337431,
-                34.02842787576906
+                -118.20212961516931,
+                34.02842490879871
               ]
             }
           },
@@ -4807,8 +9781,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1981585364791,
-                34.0267296105193
+                -118.19815641092205,
+                34.026731661472624
               ]
             }
           },
@@ -4828,8 +9802,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19956398793197,
-                34.0244378645661
+                -118.1995577096384,
+                34.02444112768619
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1469",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5510
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5221.4,8149.0 -0.0,8149.0 11.2,456.6 5253.2,441.6 5221.4,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.20009959890157,
+                34.02466899343031
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5510.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19867760499558,
+                34.02689830573762
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5510.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19470145215716,
+                34.02515614106909
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19612344606315,
+                34.02292682876178
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1470/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1470 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1470/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1470/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5629
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3369.7 -0.0,1120.6 2507.9,0.0 2901.1,0.0 4165.1,3008.2 4876.9,2606.0 5629.0,355.3 5629.0,7568.5 1385.7,7571.2 1375.2,6290.1 616.6,5074.7 995.2,4845.6 -0.0,3369.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1470/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.22238185440482,
+                34.04622313001251
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5629.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2209044188804,
+                34.048468926817534
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5629.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21698087949716,
+                34.04669639171805
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.21845831502158,
+                34.04445059491302
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1471",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5510
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,308.1 4499.7,288.2 4532.2,7512.2 4298.9,8149.0 -0.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18827655077823,
+                34.048131016265884
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5510.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18827054297888,
+                34.04562470373334
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5510.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19274207815486,
+                34.04561734543121
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19274808595421,
+                34.04812365796376
               ]
             }
           }
@@ -4854,8 +10242,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4874,7 +10262,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"683.4,274.3 4055.6,447.0 4548.5,2040.0 4978.2,7756.1 4835.0,8028.2 5662.0,8007.4 5662.0,8150.0 487.0,8106.0 713.7,7601.6 683.4,274.3\" /></svg>"
+          "value": "<svg><polygon points=\"720.4,7614.5 687.3,-0.0 3519.8,-0.0 3533.4,500.5 4062.3,451.1 4556.5,2045.5 4989.2,7767.1 4788.0,8150.0 493.6,8119.5 720.4,7614.5\" /></svg>"
         }
       },
       "body": {
@@ -4903,8 +10291,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18827935529144,
-                34.046398314317685
+                -118.18827633045169,
+                34.04639941478344
               ]
             }
           },
@@ -4924,8 +10312,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18827410393975,
-                34.04379588649259
+                -118.18827254231682,
+                34.04379962209861
               ]
             }
           },
@@ -4945,8 +10333,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19276282267373,
-                34.043789579689694
+                -118.192756715909,
+                34.043795072599494
               ]
             }
           },
@@ -4966,8 +10354,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19276807402542,
-                34.04639200751479
+                -118.19276050404386,
+                34.04639486528432
               ]
             }
           }
@@ -4992,8 +10380,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5012,7 +10400,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4175.0,-0.0 4762.4,2008.3 4952.2,8150.0 1112.4,8150.0 1263.5,7879.7 975.6,2116.1 519.7,500.5 -0.0,535.6 -0.0,0.0 4175.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"4938.1,8150.0 1106.6,8150.0 1262.2,7872.5 983.4,2128.0 671.8,1017.6 2125.6,1048.6 2148.1,-0.0 4292.3,66.9 4757.6,2025.9 4938.1,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -5041,8 +10429,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18825571818542,
-                34.044777159309
+                -118.18824626165615,
+                34.04478387659353
               ]
             }
           },
@@ -5062,8 +10450,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18817368544526,
-                34.042224035464045
+                -118.188159597083,
+                34.04222218956046
               ]
             }
           },
@@ -5083,8 +10471,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19263078758723,
-                34.04212431611292
+                -118.19263164878527,
+                34.04211683974318
               ]
             }
           },
@@ -5104,8 +10492,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19271282032739,
-                34.04467743995787
+                -118.19271831335841,
+                34.044678526776245
               ]
             }
           }
@@ -5130,8 +10518,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5150,7 +10538,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"735.0,8150.0 487.8,2025.1 -0.0,56.8 5070.8,80.9 5033.5,7969.4 5614.0,7974.3 5519.9,8150.0 735.0,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"741.3,8150.0 490.4,2024.0 -0.0,57.6 5068.3,78.6 5036.0,7960.4 5626.6,7965.0 5527.6,8150.0 741.3,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -5179,8 +10567,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18818549965388,
-                34.042817364170304
+                -118.18818503240054,
+                34.04281822153768
               ]
             }
           },
@@ -5200,8 +10588,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18813128418688,
-                34.040242800801586
+                -118.18813266278984,
+                34.04024143068316
               ]
             }
           },
@@ -5221,8 +10609,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19257175542852,
-                34.04017768602127
+                -118.19257697588161,
+                34.04017853284451
               ]
             }
           },
@@ -5242,8 +10630,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1926259708955,
-                34.04275224938999
+                -118.1926293454923,
+                34.042755323699026
               ]
             }
           }
@@ -5268,8 +10656,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5288,7 +10676,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5470.0,7903.0 261.3,7935.7 226.8,107.1 5498.3,79.0 5470.0,7903.0\" /></svg>"
+          "value": "<svg><polygon points=\"5471.5,7902.5 258.8,7938.2 219.8,103.7 5495.3,72.5 5471.5,7902.5\" /></svg>"
         }
       },
       "body": {
@@ -5317,8 +10705,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18812323385285,
-                34.04061533940632
+                -118.18812503387161,
+                34.040612008372364
               ]
             }
           },
@@ -5338,8 +10726,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18809728279368,
-                34.03805182234181
+                -118.18810087531597,
+                34.0380504241297
               ]
             }
           },
@@ -5359,8 +10747,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1925723336664,
-                34.03802027474699
+                -118.192572571851,
+                34.038021055734475
               ]
             }
           },
@@ -5380,8 +10768,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19259828472558,
-                34.0405837918115
+                -118.19259673040665,
+                34.04058263997714
               ]
             }
           }
@@ -5406,8 +10794,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5426,7 +10814,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5061.3,7910.8 4789.0,8051.0 4532.7,7918.1 409.8,7957.8 405.5,69.1 4983.8,62.8 5061.3,7910.8\" /></svg>"
+          "value": "<svg><polygon points=\"5048.1,7924.2 4867.0,7927.6 4785.1,8080.6 4497.1,7930.0 396.7,7957.0 416.2,68.7 4994.4,76.3 5048.1,7924.2\" /></svg>"
         }
       },
       "body": {
@@ -5455,8 +10843,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18810442729958,
-                34.03828023252489
+                -118.18810533169344,
+                34.038285224151714
               ]
             }
           },
@@ -5476,8 +10864,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18809122919367,
-                34.035706661815375
+                -118.18808279768521,
+                34.03571158414452
               ]
             }
           },
@@ -5497,8 +10885,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19252975138903,
-                34.035690809555966
+                -118.19252143939512,
+                34.03568451852264
               ]
             }
           },
@@ -5518,8 +10906,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19254294949494,
-                34.03826438026548
+                -118.19254397340335,
+                34.038258158529835
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1477",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5595
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5595.0,7972.3 1049.8,7976.0 967.0,232.9 5595.0,153.5 5595.0,7972.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18800034801475,
+                34.03645749175108
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5595.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18798933046565,
+                34.03389835994834
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5595.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19248799027227,
+                34.03388505946492
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19249900782137,
+                34.03644419126766
               ]
             }
           }
@@ -5544,8 +11070,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5564,7 +11090,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1283.4,7965.8 1395.8,-0.0 4939.0,-0.0 4789.6,7996.0 1283.4,7965.8\" /></svg>"
+          "value": "<svg><polygon points=\"4794.1,7999.3 1307.4,7970.3 1395.1,1127.2 4919.6,1166.8 4794.1,7999.3\" /></svg>"
         }
       },
       "body": {
@@ -5593,8 +11119,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18796650484808,
-                34.034552089348544
+                -118.1879624483107,
+                34.034553758609874
               ]
             }
           },
@@ -5614,8 +11140,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18791392460035,
-                34.03192071456654
+                -118.18791085592339,
+                34.0319215438723
               ]
             }
           },
@@ -5635,8 +11161,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19245193335523,
-                34.03185755751319
+                -118.19245031324641,
+                34.03185957339292
               ]
             }
           },
@@ -5656,4861 +11182,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19250451360296,
-                34.0344889322952
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1480",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5684
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5023.6,-0.0 4953.3,8025.2 614.4,8045.2 674.3,-0.0 5023.6,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18797424018972,
-                34.03058050583161
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5684.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18793795685707,
-                34.02798685041847
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5684.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.19239497238338,
-                34.027943419851084
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.19243125571603,
-                34.03053707526422
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1481",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5595
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4975.6,7995.0 1263.0,8024.9 1199.3,8150.0 516.8,8026.6 633.1,8025.0 627.0,-0.0 4982.3,-0.0 4975.6,7995.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18794479167967,
-                34.028574280511066
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5595.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18793819314224,
-                34.02602146366364
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5595.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.19239391165985,
-                34.0260134409272
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.19240051019727,
-                34.02856625777463
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1484/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1484",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1484/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1484/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5636
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3950.5,-0.0 4741.4,-0.0 4686.9,5046.2 4974.6,5049.3 4973.7,8149.0 -0.0,8120.0 -0.0,5990.3 1179.1,6028.0 1309.0,667.8 3766.1,726.3 3950.5,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1484/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1879442005088,
-                34.022252664115435
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5636.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18789870844029,
-                34.019660744758355
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5636.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.19238802951716,
-                34.01960584927997
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.19243352158566,
-                34.02219776863706
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1487",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5609
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4525.1,7008.4 1783.5,7021.2 -0.0,574.2 4526.8,566.7 4525.1,7008.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18435896529547,
-                34.04470080734485
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5609.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1843461863505,
-                34.04212005863656
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5609.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18883966642588,
-                34.04210456533661
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18885244537086,
-                34.04468531404489
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1488",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5636
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4548.0,544.6 4550.6,6940.1 -0.0,6980.9 -0.0,540.2 4548.0,544.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18436324381881,
-                34.04261786807044
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5636.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18435122721382,
-                34.04002377556823
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5636.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18884539243764,
-                34.040009278563495
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18885740904263,
-                34.0426033710657
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1489",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5605
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"106.0,7274.2 191.4,-0.0 5422.1,-0.0 5363.3,7285.1 106.0,7274.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18417728455537,
-                34.04061268025429
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5605.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18412837921916,
-                34.03803781377731
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5605.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18861459839856,
-                34.03797847531856
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18866350373477,
-                34.04055334179555
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1491",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5605
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5605.0,7213.0 1006.0,7294.3 984.9,-0.0 5605.0,-0.0 5605.0,7213.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18411487404047,
-                34.036487489095
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5605.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18410501370667,
-                34.03391366091041
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5605.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18858921415315,
-                34.033901696482445
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18859907448694,
-                34.03647552466703
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1498",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5651
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4936.7,542.4 5100.1,538.2 5214.8,6011.4 5003.6,6016.3 5034.1,7312.6 4271.9,7338.8 4118.2,8044.7 -0.0,8091.4 -0.0,4453.6 1756.3,4404.0 1668.8,73.8 1370.9,-0.0 4922.7,-0.0 4936.7,542.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1836712377196,
-                34.02240430637776
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5651.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18373465597506,
-                34.01970948641328
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5651.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18839128890534,
-                34.0197858341343
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18832787064986,
-                34.022480654098786
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499F",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5615
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7295.6 -0.0,800.2 5615.0,812.6 5615.0,7289.3 -0.0,7295.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18067010635929,
-                34.04520235809897
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5615.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18065755767908,
-                34.042627664925796
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5615.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18513413718497,
-                34.042612472571726
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18514668586518,
-                34.0451871657449
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499G",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5641
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"945.7,7346.3 875.6,1325.6 5401.0,1280.8 5474.0,7297.7 945.7,7346.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18059244493946,
-                34.04302494947469
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5641.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18061604264305,
-                34.040421025584855
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5641.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18512627601761,
-                34.040449487829505
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18510267831402,
-                34.04305341171934
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499I",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5641
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5458.9,8150.0 918.2,8150.0 917.5,7740.7 -0.0,7740.3 -0.0,5526.6 590.5,5518.2 493.4,-0.0 5447.0,-0.0 5458.9,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1768355082409,
-                34.0430566402898
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5641.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.17682820905819,
-                34.04046129177465
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5641.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18132359032298,
-                34.04045248790665
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.18133088950567,
-                34.04304783642179
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1401 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5672.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8149.0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5672
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8149.0 0.0,-0.0 5672.0,0.0 5672.0,933.8 5082.8,1292.6 4868.6,1610.2 3885.6,5895.2 3223.2,8149.0 -0.0,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4456.0,
-                3144.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2264214,
-                34.0532505
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4032.0,
-                4788.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2266838,
-                34.0524126
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1402 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "2750.9"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8149.0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5689
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"133.2,3838.9 756.3,0.0 2750.9,382.3 2049.5,4727.7 2027.5,5540.1 927.7,5540.7 622.9,3875.1 133.2,3838.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                927.6,
-                5540.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2248614,
-                34.045088
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1919.2,
-                5540.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2243038,
-                34.0451302
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1402 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "1756.3"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "3932.7"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8149.0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5689
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1877.4,8149.0 1756.3,8149.0 1756.3,-0.0 2075.5,0.0 2207.7,1738.0 5513.0,1486.6 5176.9,3544.4 5091.1,7466.7 3228.0,7585.4 3234.1,7769.8 1822.3,7831.6 1877.4,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5176.9,
-                3544.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2275305,
-                34.0497248
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3248.6,
-                3544.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2286463,
-                34.0497959
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1404 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "3217.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "2472.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8149.0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5689
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3529.0,7937.7 3517.3,379.7 5689.0,362.8 5689.0,7932.2 3529.0,7937.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3477.0,
-                4184.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.204337,
-                34.0392855
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3477.0,
-                380.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.203313,
-                34.0408511
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1407",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5650
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2588.9,669.9 3704.2,852.3 3708.4,908.7 5029.3,1190.6 4577.3,5456.7 4860.3,5486.0 2344.5,6358.1 2634.4,7233.6 1806.1,6862.4 1043.2,7688.8 479.7,3728.1 417.3,3736.9 463.2,622.7 2588.9,669.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2588.9,
-                668.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2275305,
-                34.0497248
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3441.2,
-                7664.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2199908,
-                34.0500061
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1408 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5676.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8150.0"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5676
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"292.7,8150.0 181.4,1276.9 -0.0,1201.3 -0.0,446.4 787.2,0.0 5676.0,0.0 5676.0,4413.2 2343.7,8150.0 292.7,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3824.0,
-                3863.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2201542,
-                34.0514148
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                292.0,
-                6922.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2216392,
-                34.049668
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1410",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5676
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5676.0,8150.0 5522.0,8150.0 5521.1,7841.2 -0.0,7827.5 -0.0,227.9 4113.3,209.8 4343.5,0.0 5676.0,0.0 5676.0,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2840.0,
-                2767.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2181801,
-                34.0503049
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                700.0,
-                7822.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2162879,
-                34.048343
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1411",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5615
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"569.9,7806.4 599.2,279.8 4287.4,259.5 4288.7,5301.2 5006.5,5290.6 5024.4,8046.2 5615.0,8046.0 5615.0,8150.0 1858.8,8150.0 1857.4,7819.2 569.9,7806.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2835.5,
-                5322.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.214393,
-                34.0463596
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2835.5,
-                271.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2168534,
-                34.0474547
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1412",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5631
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5368.2 -0.0,259.1 750.0,255.2 5631.0,292.3 5631.0,8150.0 744.9,8150.0 727.4,5357.6 -0.0,5368.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2895.5,
-                5358.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.213282,
-                34.0481058
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2891.5,
-                259.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2157324,
-                34.0491958
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1413",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5615
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3037.9,7694.5 -0.0,7698.9 -0.0,0.0 5263.1,-0.0 5258.2,7888.4 3038.2,7893.4 3037.9,7694.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2911.5,
-                4570.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2100721,
-                34.0455732
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                228.0,
-                4570.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2113887,
-                34.0461553
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1414",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5631
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5631.0,7904.7 315.0,7906.7 334.5,54.4 5631.0,-0.0 5631.0,7904.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                335.9,
-                4139.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2087915,
-                34.0452512
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5399.0,
-                4139.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2062938,
-                34.0441516
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1415",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5615
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5408.6,7938.6 587.3,7918.2 611.9,-0.0 5615.0,-0.0 5615.0,269.4 5413.4,267.4 5408.6,7938.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                363.9,
-                5998.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2067819,
-                34.0433845
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                363.9,
-                4099.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2062938,
-                34.0441516
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1416",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5631
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"149.1,211.4 352.1,211.9 350.4,-0.0 5631.0,-0.0 5631.0,7931.3 205.2,7933.1 149.1,211.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2727.5,
-                6002.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2031058,
-                34.0417568
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5239.1,
-                4095.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2013998,
-                34.0419793
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1430",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5628
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4764.5,8150.0 3406.0,8150.0 1206.6,7156.4 1257.3,437.1 5502.2,441.1 5534.8,6971.5 5275.5,8150.0 4764.5,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3008.0,
-                2623.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2155605,
-                34.0445658
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3008.0,
-                6974.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2166958,
-                34.0428103
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1431",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5640
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5640.0,-0.0 5640.0,200.3 4994.3,247.6 4992.1,7848.6 293.1,7819.1 300.1,-0.0 5640.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2820.0,
-                3496.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2131108,
-                34.043468
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2820.0,
-                7841.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.214237,
-                34.0417129
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1432",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5591
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5207.5,7799.8 -0.0,7772.0 -0.0,243.8 5281.0,191.8 5207.5,7799.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5267.1,
-                4016.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2096012,
-                34.0416315
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2887.5,
-                3488.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2106349,
-                34.0423637
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1436",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5606
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"264.6,7935.2 188.6,182.8 -0.0,182.1 -0.0,0.0 4935.2,-0.0 4957.8,7950.4 264.6,7935.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                199.9,
-                2115.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2008004,
-                34.0387292
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3374.8,
-                188.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.198757,
-                34.0388192
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1442 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5669
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3971.8,257.6 5669.0,219.3 5669.0,8150.0 3105.4,8150.0 1999.9,5052.4 402.4,2162.1 692.3,1988.9 482.4,1662.9 1202.8,1683.9 2797.1,731.3 3971.8,257.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2000.4,
-                5050.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2195761,
-                34.0415167
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5292.9,
-                219.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2166958,
-                34.0428103
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1445",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5605
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,218.1 5421.0,252.0 5421.0,7969.0 -0.0,8024.4 -0.0,218.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5421.0,
-                252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2079868,
-                34.0389131
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5421.0,
-                7969.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2099804,
-                34.0358305
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1449",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5605
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4167.8,7998.4 489.2,7966.2 466.1,250.2 5217.4,260.6 5173.2,7516.0 4167.8,7998.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3228.6,
-                5896.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2004047,
-                34.0326129
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                500.1,
-                5896.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2017317,
-                34.0331962
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1450",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5639
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"124.7,167.8 4988.1,175.6 5031.6,6094.9 5639.0,6100.3 5639.0,7514.0 2198.9,7507.7 2198.7,7973.3 -0.0,7961.2 -0.0,7958.2 124.7,167.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2199.6,
-                4100.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1979902,
-                34.0324442
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2199.6,
-                6092.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1985014,
-                34.0316469
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1453",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5582
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5582.0,7757.6 -0.0,7883.7 -0.0,302.6 228.8,300.7 226.2,131.4 5008.3,111.6 5078.2,2592.3 5582.0,2588.5 5582.0,7757.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2687.0,
-                4348.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2172998,
-                34.0368489
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5078.2,
-                2592.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2156753,
-                34.0370221
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1454",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5639
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"529.5,7766.5 660.0,2629.3 159.1,2620.4 152.2,153.2 5639.0,173.3 5639.0,7784.3 529.5,7766.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2811.5,
-                6184.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2152831,
-                34.0350028
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2811.5,
-                192.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2137451,
-                34.0374491
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1455",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5582
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"611.6,7772.0 639.3,56.5 5582.0,80.6 5582.0,7867.2 611.6,7772.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1143.6,
-                4400.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2131941,
-                34.0349968
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2923.0,
-                7817.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2131859,
-                34.0332484
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1456",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5650
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2412.4,83.8 5106.4,99.3 5297.7,7933.5 1540.2,7939.3 1381.5,303.5 2413.5,306.2 2412.4,83.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2252.8,
-                5668.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.210974,
-                34.0334196
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5137.8,
-                3788.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2091083,
-                34.0335439
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1457",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5582
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5582.0,7871.0 493.3,7806.6 389.3,7572.6 412.7,75.8 5582.0,174.9 5582.0,7871.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3794.6,
-                152.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.206535,
-                34.034262
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                399.9,
-                1856.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2086276,
-                34.0342936
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1458",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5650
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4618.1,8022.8 878.2,7990.8 904.8,170.9 4837.4,214.2 4618.1,8022.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1468.5,
-                5856.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2068205,
-                34.031492
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1468.5,
-                180.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2053999,
-                34.0337526
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1459",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5555
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7874.2 -0.0,260.3 4520.8,191.6 4598.5,7865.2 -0.0,7874.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5279.0,
-                2159.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2017404,
-                34.0310929
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2295.6,
-                7898.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2047403,
-                34.0294518
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1461",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5555
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"250.0,8026.0 282.3,-0.0 3044.1,-0.0 3050.0,647.2 5329.4,620.6 5228.8,7999.7 250.0,8026.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5275.1,
-                2947.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1971658,
-                34.0287702
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                252.0,
-                8026.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2010089,
-                34.0277831
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1462",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5650
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"383.3,499.9 595.9,370.3 5251.1,377.7 5194.9,7796.9 261.8,7801.2 383.3,499.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                320.1,
-                2912.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1971658,
-                34.0287702
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5309.9,
-                2912.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1947282,
-                34.0276999
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1465",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5510
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,-0.0 5251.1,0.0 5272.6,8149.0 -0.0,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                239.9,
-                4304.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2113656,
-                34.0297758
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5262.1,
-                2204.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2110518,
-                34.0322948
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1466",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5650
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5287.7,2330.5 5264.5,7376.9 -0.0,7316.5 -0.0,2257.1 5287.7,2330.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2953.0,
-                3900.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2079557,
-                34.0297096
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5249.9,
-                5772.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.2064637,
-                34.0302359
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1469",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5510
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5221.4,8149.0 -0.0,8149.0 -0.0,433.4 5510.0,446.1 5510.0,5506.5 5232.3,5505.5 5221.4,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2663.0,
-                5468.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.196744,
-                34.0245773
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2663.0,
-                432.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1992025,
-                34.0256545
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1471",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5510
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,308.1 4499.7,288.2 4532.2,7512.2 4298.9,8149.0 -0.0,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1411.5,
-                4552.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1907731,
-                34.0474846
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4530.4,
-                4552.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1907697,
-                34.0460662
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1477",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5595
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5595.0,8064.8 1017.2,8042.1 978.5,210.8 5595.0,157.7 5595.0,8064.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                959.8,
-                6082.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1913317,
-                34.0359985
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                959.8,
-                2187.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -118.1892059,
-                34.0360149
+                -118.19250190563372,
+                34.034491788130495
               ]
             }
           }
@@ -10528,15 +11201,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10555,7 +11228,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4874.5,1109.8 4903.1,8010.0 520.3,8021.8 529.4,-0.0 2702.0,-0.0 2692.8,1118.5 4874.5,1109.8\" /></svg>"
+          "value": "<svg><polygon points=\"4899.0,7985.8 543.9,8010.0 529.8,-0.0 2689.0,-0.0 2689.0,-0.0 4843.5,-0.0 4899.0,7985.8\" /></svg>"
         }
       },
       "body": {
@@ -10584,8 +11257,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18793790228703,
-                34.03249908235298
+                -118.18791899408926,
+                34.03250082829016
               ]
             }
           },
@@ -10605,8 +11278,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18794072989284,
-                34.0299371382742
+                -118.18793079738698,
+                34.02992262309376
               ]
             }
           },
@@ -10626,8 +11299,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19244775190363,
-                34.029940549196
+                -118.19246278689901,
+                34.029936872766015
               ]
             }
           },
@@ -10647,8 +11320,83 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19244492429782,
-                34.032502493274784
+                -118.19245098360129,
+                34.032515077962415
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1480",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5684
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5001.3,-0.0 4960.8,8019.6 620.5,8055.6 650.6,-0.0 5001.3,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18796856555268,
+                34.030569654410925
               ]
             }
           },
@@ -10656,20 +11404,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4903.1,
-                8010.0
+                5684.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.19237,
-                34.0302573
+                -118.18794380995537,
+                34.027976737687446
               ]
             }
           },
@@ -10677,20 +11425,179 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4903.1,
-                8010.0
+                5684.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1923547,
-                34.0299325
+                -118.19239955609514,
+                34.027947105634404
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19242431169245,
+                34.03054002235788
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1481",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5595
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4958.8,7938.1 1242.4,7966.2 1162.2,8122.5 490.1,7967.7 611.9,7966.0 609.3,920.1 4969.6,945.9 4958.8,7938.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18795094746983,
+                34.02856571328236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5595.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18794305527645,
+                34.02601551161635
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5595.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19242554588693,
+                34.02600598308899
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19243343808031,
+                34.028556184755004
               ]
             }
           }
@@ -10708,15 +11615,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10735,34 +11642,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"283.9,7995.5 269.6,968.0 5496.4,947.7 5520.9,7441.8 5280.2,8149.0 283.9,7995.5\" /></svg>"
+          "value": "<svg><polygon points=\"285.5,-0.0 5476.3,-0.0 5466.4,7415.2 5223.1,8117.5 1020.9,8150.0 637.1,7940.8 260.0,7938.1 285.5,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1482/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2444.0,
-                4251.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1902474,
-                34.0253088
+                -118.18790853504355,
+                34.0264322798123
               ]
             }
           },
@@ -10770,20 +11680,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2444.0,
-                755.8
+                5684.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1883215,
-                34.0253077
+                -118.18789418651431,
+                34.02382052804123
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5684.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19241374288477,
+                34.02380347257167
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.192428091414,
+                34.02641522434274
               ]
             }
           }
@@ -10801,15 +11753,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10828,34 +11780,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4461.9,8150.0 493.4,8150.0 727.0,7442.6 642.0,758.7 5595.0,689.2 5595.0,2413.2 5595.0,6035.9 4410.1,6027.0 4461.9,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"5128.7,7947.7 5021.3,8150.0 485.9,8150.0 725.0,7438.9 688.7,711.8 5595.0,678.4 5595.0,6059.2 4397.2,6037.6 4438.5,7962.1 5128.7,7947.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1483/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3851.3,
-                5874.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1911571,
-                34.0224675
+                -118.1879218186944,
+                34.024229220378245
               ]
             }
           },
@@ -10863,20 +11818,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                683.9,
-                4263.0
+                5595.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1902498,
-                34.0239107
+                -118.18792899613703,
+                34.02166554247369
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5595.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.192403441979,
+                34.021674269511635
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19239626453637,
+                34.02423794741619
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1484/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1484",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1484/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1484/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5636
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4780.9,-0.0 4703.6,5062.2 4991.0,5066.5 4976.3,8149.0 575.8,8095.3 686.9,7896.3 -0.0,7895.9 -0.0,5980.0 1191.1,6027.0 1306.0,672.8 3803.5,743.2 3995.8,-0.0 4780.9,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1484/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1879441361153,
+                34.02227346956498
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5636.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18788469070246,
+                34.01967869051177
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5636.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19237895701009,
+                34.01960695734568
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19243840242294,
+                34.02220173639889
               ]
             }
           }
@@ -10894,15 +12029,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10921,34 +12056,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5169.3,1641.2 4649.7,3038.0 4636.8,7388.9 174.1,7410.3 174.4,8149.0 -0.0,8149.0 -0.0,-0.0 4514.1,-0.0 4514.1,30.2 5609.0,37.5 5609.0,616.6 5173.1,617.6 5169.3,1641.2\" /></svg>"
+          "value": "<svg><polygon points=\"174.1,7410.3 174.4,8149.0 -0.0,8149.0 -0.0,0.0 4514.1,-0.0 4514.0,55.0 5609.0,49.2 5609.0,7389.1 174.1,7410.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1485/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4636.8,
-                4936.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1870723,
-                34.0460858
+                -118.18434369128715,
+                34.04821603094081
               ]
             }
           },
@@ -10956,20 +12094,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4636.8,
-                7388.9
+                5609.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1884298,
-                34.046084
+                -118.18433872267025,
+                34.045643551523554
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5609.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18884969738475,
+                34.04563757012062
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18885466600166,
+                34.04821004953787
               ]
             }
           }
@@ -10987,15 +12167,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11014,34 +12194,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3481.9,7693.4 1654.3,7461.3 573.2,7455.4 609.3,3032.9 1144.8,1615.8 1154.1,575.4 3680.2,582.7 5488.6,7115.5 3471.1,7155.5 3481.9,7693.4\" /></svg>"
+          "value": "<svg><polygon points=\"2576.4,579.5 3680.2,582.7 5482.0,7095.0 5636.0,7091.8 5636.0,8149.0 4160.2,8149.0 4006.8,7647.7 3468.4,7694.6 3457.4,7188.9 1562.6,7178.3 1600.0,-0.0 2581.7,-0.0 2576.4,579.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1486/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2540.0,
-                4944.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1870552,
-                34.045205
+                -118.18437192140148,
+                34.04636557837448
               ]
             }
           },
@@ -11049,20 +12232,476 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4228.0,
-                2768.3
+                5636.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1858638,
-                34.0444497
+                -118.18435100926992,
+                34.04382217981911
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5636.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18878872919899,
+                34.04379712952064
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18880964133055,
+                34.04634052807601
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1487",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5609
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4517.1,7009.4 1774.7,6997.7 0.3,568.8 4531.4,568.1 4517.1,7009.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18436196046866,
+                34.04470463375202
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5609.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18434452453808,
+                34.04212372907496
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5609.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18883827616635,
+                34.04210258960657
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18885571209694,
+                34.04468349428363
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1488",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5636
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4549.6,546.0 4555.1,6940.2 -0.0,6983.0 -0.0,543.6 4549.6,546.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18436130216747,
+                34.042618973916625
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5636.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18435065215783,
+                34.04002433015161
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5636.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1888457724231,
+                34.040011481827115
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18885642243274,
+                34.04260612559213
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1489",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5605
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"119.0,7281.6 176.1,-0.0 5398.5,-0.0 5367.9,7272.2 119.0,7281.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1841664597892,
+                34.04060592177012
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5605.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1841294046832,
+                34.038026800675546
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5605.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18862303673122,
+                34.0379818404923
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1886600918372,
+                34.04056096158688
               ]
             }
           }
@@ -11080,15 +12719,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11107,34 +12746,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5054.5,-0.0 5043.9,7281.5 486.6,7272.5 484.8,-0.0 5054.5,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"492.0,7268.9 471.0,-0.0 4057.7,-0.0 4029.0,7266.5 492.0,7268.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1490/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                492.0,
-                5232.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1870172,
-                34.0381004
+                -118.18413040544846,
+                34.03833728244387
               ]
             }
           },
@@ -11142,20 +12784,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                492.0,
-                3068.4
+                5636.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1858248,
-                34.0381079
+                -118.18411503931488,
+                34.0357591375593
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5636.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18861284736988,
+                34.03574072852199
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18862821350346,
+                34.03831887340656
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1491",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5605
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5605.0,7154.2 -0.0,7249.5 -0.0,70.7 963.1,66.9 967.9,1005.1 5605.0,961.7 5605.0,7154.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18407981635174,
+                34.0364811374622
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5605.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18407674872158,
+                34.033886197565224
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5605.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18862960799574,
+                34.03388250139586
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1886326756259,
+                34.03647744129283
               ]
             }
           }
@@ -11173,15 +12995,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11200,34 +13022,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4742.0,3112.4 4739.0,6977.2 1139.6,7018.5 1152.6,46.8 4035.1,-0.0 4110.4,3109.8 4742.0,3112.4\" /></svg>"
+          "value": "<svg><polygon points=\"2623.4,-0.0 4089.1,-0.0 4115.3,688.5 5636.0,695.6 5636.0,6984.2 4739.0,6976.2 4730.6,8149.0 1148.7,8149.0 1208.9,969.2 2609.4,1047.3 2623.4,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1492/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4744.0,
-                6036.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1874015,
-                34.0322575
+                -118.18408241499594,
+                34.03444111331596
               ]
             }
           },
@@ -11235,20 +13060,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4744.0,
-                3112.4
+                5636.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1857872,
-                34.0322643
+                -118.18406659901738,
+                34.03186251126258
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5636.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18856499723904,
+                34.03184356242537
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1885808132176,
+                34.03442216447875
               ]
             }
           }
@@ -11266,15 +13133,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11293,34 +13160,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,833.0 5600.2,852.2 5313.8,762.7 5605.0,761.0 5605.0,7087.8 4969.9,7093.2 4969.6,8149.0 2790.9,8149.0 2804.5,7031.2 634.9,7022.6 630.2,3135.3 -0.0,3134.0 -0.0,833.0\" /></svg>"
+          "value": "<svg><polygon points=\"5605.0,7082.5 1530.1,6996.1 1517.3,722.5 2803.0,725.8 2808.3,269.2 4394.7,451.3 5075.7,809.6 5605.0,807.9 5605.0,7082.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1493/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                636.1,
-                6052.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1874015,
-                34.0322575
+                -118.18405339413283,
+                34.03255766480548
               ]
             }
           },
@@ -11328,20 +13198,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4952.9,
-                6052.7
+                5605.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1873942,
-                34.0302781
+                -118.1840439156342,
+                34.0299875634153
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5605.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.188553025277,
+                34.02997614239772
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18856250377563,
+                34.032546243787905
               ]
             }
           }
@@ -11359,15 +13271,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11386,34 +13298,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1238.4,7108.6 1236.5,799.9 2743.1,790.9 2743.3,-0.0 4881.7,-0.0 4888.0,4060.5 5636.0,4063.6 5636.0,6203.8 4912.1,6208.3 4911.7,7076.1 1238.4,7108.6\" /></svg>"
+          "value": "<svg><polygon points=\"1175.8,7103.7 1236.5,846.6 2743.1,841.4 2743.3,-0.0 4881.7,-0.0 4888.0,4060.5 5636.0,4063.6 5636.0,6203.8 4912.1,6208.3 4911.7,7084.4 1175.8,7103.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1494/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                588.0,
-                6076.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1873942,
-                34.0302781
+                -118.18402302327753,
+                34.03055622213065
               ]
             }
           },
@@ -11421,20 +13336,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4888.0,
-                4060.5
+                5636.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1862688,
-                34.0283029
+                -118.18401443105799,
+                34.02796399359075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5636.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18853642776104,
+                34.02795369901429
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18854501998058,
+                34.030545927554186
               ]
             }
           }
@@ -11452,15 +13409,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11479,34 +13436,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"940.4,7210.8 943.0,6336.3 1669.6,6333.6 1675.0,4185.5 924.2,4180.5 928.2,-0.0 5289.9,-0.0 5277.4,7224.3 940.4,7210.8\" /></svg>"
+          "value": "<svg><polygon points=\"983.0,8149.0 902.7,-0.0 5273.2,-0.0 5329.4,8149.0 983.0,8149.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1495/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                924.2,
-                4180.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1862688,
-                34.0283029
+                -118.18395797561011,
+                34.02872386939491
               ]
             }
           },
@@ -11514,20 +13474,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5260.9,
-                4180.5
+                5605.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1862562,
-                34.0263159
+                -118.18396839215914,
+                34.026160890187946
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5605.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18846471346042,
+                34.02617344231698
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18845429691139,
+                34.028736421523945
               ]
             }
           }
@@ -11545,15 +13547,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11572,34 +13574,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5253.2,-0.0 5264.0,8150.0 50.9,8150.0 50.3,-0.0 5253.2,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"135.0,-0.0 5347.6,-0.0 5320.2,7193.6 100.3,7173.7 135.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1496/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5264.0,
-                7942.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1883135,
-                34.0239144
+                -118.1839524273766,
+                34.02637434485558
               ]
             }
           },
@@ -11607,20 +13612,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5264.0,
-                1923.5
+                5652.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1849884,
-                34.0239232
+                -118.18392636550163,
+                34.02379185529486
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5652.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18842056656318,
+                34.02376070115473
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18844662843814,
+                34.02634319071545
               ]
             }
           }
@@ -11638,15 +13685,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11665,34 +13712,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"730.1,39.7 5635.0,15.9 5635.0,4348.7 3865.6,4362.7 3791.6,8001.2 763.1,8032.9 730.1,39.7\" /></svg>"
+          "value": "<svg><polygon points=\"730.1,39.7 5635.0,15.9 5635.0,4348.7 3858.2,4362.8 3799.7,8001.2 763.1,8032.9 730.1,39.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1497/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3703.3,
-                8001.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1882943,
-                34.0225219
+                -118.18372486005767,
+                34.024277992897986
               ]
             }
           },
@@ -11700,20 +13750,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                747.9,
-                2212.3
+                5635.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1849884,
-                34.0239232
+                -118.18372302738663,
+                34.0216092056223
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5635.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18837822868818,
+                34.021607009684274
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18838006135921,
+                34.02427579695996
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1498",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5651
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1695.6,65.6 4898.9,-0.0 4940.5,652.0 5128.0,639.9 5217.8,6021.3 5006.6,6025.4 5031.1,7301.0 4288.4,7259.1 4112.4,8050.9 -0.0,8080.1 -0.0,4440.7 1764.8,4398.4 1695.6,65.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18367975827071,
+                34.02241696971246
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5651.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18372942025384,
+                34.01972333503301
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5651.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18838400584667,
+                34.019783121896126
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18833434386354,
+                34.02247675657558
               ]
             }
           }
@@ -11731,15 +13961,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11758,34 +13988,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,0.0 4260.2,-0.0 4330.7,7735.5 5635.0,8149.0 -0.0,8149.0\" /></svg>"
+          "value": "<svg><polygon points=\"4266.3,7850.1 2837.7,7688.7 2833.6,8149.0 -0.0,8149.0 -0.0,350.7 1570.1,329.7 1575.6,-0.0 4250.9,-0.0 4296.0,7861.3 4266.3,7850.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2851.5,
-                6360.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.183517,
-                34.0312758
+                -118.17997709553337,
+                34.032571716016896
               ]
             }
           },
@@ -11793,20 +14026,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1743.7,
-                320.0
+                5635.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1801461,
-                34.0317872
+                -118.17997576334754,
+                34.0299890357753
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5635.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18444962758548,
+                34.029987428416916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18445095977131,
+                34.03257010865851
               ]
             }
           }
@@ -11824,15 +14099,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11851,34 +14126,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4961.8,7372.4 2824.0,7359.5 2819.0,8150.0 761.3,8150.0 -0.0,7813.3 -0.0,2858.3 0.0,0.0 5651.0,-0.0 5651.0,344.6 4992.8,344.9 4961.8,7372.4\" /></svg>"
+          "value": "<svg><polygon points=\"2815.7,8150.0 799.4,8150.0 -0.0,7786.5 0.0,-0.0 5651.0,-0.0 5651.0,354.1 4951.5,356.2 4938.3,7323.6 2818.8,7316.2 2815.7,8150.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499A/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                915.8,
-                2859.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1815297,
-                34.0301904
+                -118.17993175546842,
+                34.03062364495271
               ]
             }
           },
@@ -11886,20 +14164,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2831.5,
-                2859.3
+                5651.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1815204,
-                34.0293091
+                -118.1799120734775,
+                34.028001319819964
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5651.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18447586613657,
+                34.027977793516506
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18449554812749,
+                34.030600118649254
               ]
             }
           }
@@ -11917,15 +14237,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11944,34 +14264,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"612.0,7323.8 615.9,395.2 4967.1,376.0 4957.8,7322.2 612.0,7323.8\" /></svg>"
+          "value": "<svg><polygon points=\"616.1,395.1 1322.0,392.0 1321.5,34.5 4658.2,70.2 4661.8,377.4 4967.1,376.0 4957.6,7363.6 612.1,7327.6 616.1,395.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499B/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2783.5,
-                4852.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1825808,
-                34.0273181
+                -118.17989653519858,
+                34.02860914676784
               ]
             }
           },
@@ -11979,20 +14302,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4967.1,
-                376.0
+                5635.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1800916,
-                34.026324
+                -118.17988117802015,
+                34.02601770120792
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5635.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18440162317265,
+                34.025999300590854
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18441698035107,
+                34.028590746150776
               ]
             }
           }
@@ -12010,15 +14375,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12037,34 +14402,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"213.5,7200.9 303.9,307.9 -0.0,305.7 0.0,0.0 5469.8,-0.0 5368.5,7270.3 213.5,7200.9\" /></svg>"
+          "value": "<svg><polygon points=\"213.4,7231.4 303.9,307.9 -0.0,305.7 0.0,-0.0 5469.6,-0.0 5368.4,7274.0 213.4,7231.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499C/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5371.0,
-                6950.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1837473,
-                34.0239322
+                -118.17992277019101,
+                34.026466775170086
               ]
             }
           },
@@ -12072,20 +14440,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                303.9,
-                307.9
+                5651.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1800916,
-                34.026324
+                -118.17987041339525,
+                34.02385624781526
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5651.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1844134564493,
+                34.02379366162857
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18446581324507,
+                34.02640418898339
               ]
             }
           }
@@ -12103,15 +14513,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12130,34 +14540,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,359.4 -0.0,0.0 4558.0,-0.0 4556.5,668.4 5615.0,671.5 5615.0,7386.2 821.9,7404.9 815.2,347.1 -0.0,359.4\" /></svg>"
+          "value": "<svg><polygon points=\"815.2,347.3 -0.0,359.6 -0.0,0.0 4557.6,-0.0 4556.1,668.4 5615.0,671.5 5615.0,7386.2 821.9,7404.9 815.2,347.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499D/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                823.9,
-                7404.9
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1837473,
-                34.0239322
+                -118.17968207360272,
+                34.02431140668031
               ]
             }
           },
@@ -12165,20 +14578,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                819.9,
-                696.1
+                5615.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1800647,
-                34.0239368
+                -118.17967742562412,
+                34.02175532127486
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5615.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18415189994559,
+                34.0217497321308
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18415654792419,
+                34.02430581753625
               ]
             }
           }
@@ -12196,15 +14651,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12223,7 +14678,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"228.0,28.2 5116.9,-0.0 4945.9,312.3 4995.9,7344.8 1295.6,7275.6 1280.6,692.6 228.0,691.8 228.0,28.2\" /></svg>"
+          "value": "<svg><polygon points=\"228.0,28.9 5111.7,-0.0 4607.0,696.9 4935.8,7330.7 1295.1,7351.9 1279.9,692.6 228.0,691.8 228.0,28.9\" /></svg>"
         }
       },
       "body": {
@@ -12252,8 +14707,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.17966261552817,
-                34.02234104052989
+                -118.17966217890407,
+                34.022341159349104
               ]
             }
           },
@@ -12273,8 +14728,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.17966499510936,
-                34.01975895217542
+                -118.17966456120025,
+                34.01975612495914
               ]
             }
           },
@@ -12294,8 +14749,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18417201769012,
-                34.0197618002544
+                -118.18417672607154,
+                34.019758976287626
               ]
             }
           },
@@ -12315,8 +14770,83 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.18416963810891,
-                34.02234388860886
+                -118.18417434377535,
+                34.02234401067759
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499F",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5615
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5742.2 292.6,5680.1 409.3,5458.4 284.0,4861.2 1796.8,3874.9 1779.2,2269.6 2241.5,2287.7 2241.4,776.9 5615.0,767.4 5615.0,7268.9 -0.0,7311.1 -0.0,5742.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18067655875973,
+                34.045193157416385
               ]
             }
           },
@@ -12324,20 +14854,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                228.0,
-                691.8
+                5615.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1800453,
-                34.0222369
+                -118.18068395942305,
+                34.0426456197243
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5615.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18514396298389,
+                34.04265451795993
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18513656232057,
+                34.04520205565202
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499G",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5641
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5460.7,7298.6 843.8,7341.1 821.1,907.4 564.2,909.0 546.1,-0.0 5384.1,-0.0 5460.7,7298.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18059946924909,
+                34.043022753897446
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5641.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18061793683512,
+                34.04042045619011
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5641.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18512535351141,
+                34.040442730770785
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18510688592538,
+                34.04304502847812
               ]
             }
           }
@@ -12355,15 +15065,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12382,34 +15092,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4984.8,7758.9 -0.0,7699.0 -0.0,-0.0 5607.0,1.1 5607.0,5537.1 5010.7,5538.6 4984.8,7758.9\" /></svg>"
+          "value": "<svg><polygon points=\"4984.5,7757.9 2507.6,7724.1 2511.8,5635.8 -0.0,5497.1 -0.0,-0.0 5069.8,-0.0 4984.5,7757.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499H/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2623.5,
-                2067.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1779939,
-                34.0441604
+                -118.17687745120882,
+                34.045368670755174
               ]
             }
           },
@@ -12417,20 +15130,646 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2507.6,
-                7726.1
+                5607.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1811047,
-                34.0441771
+                -118.17683423197424,
+                34.04281458364965
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5607.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18131495906644,
+                34.04276252695192
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18135817830102,
+                34.04531661405744
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499I",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5641
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"606.3,6833.4 616.3,7744.8 -0.0,7743.2 -0.0,0.0 5451.6,-0.0 5456.2,6876.7 606.3,6833.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17683230428811,
+                34.043059289612685
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5641.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17682296363111,
+                34.0404634157175
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5641.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18131925452403,
+                34.04045214953586
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18132859518103,
+                34.04304802343105
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499J",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5607
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5151.0,6892.3 2893.8,6912.9 2893.8,6914.3 294.3,6956.1 239.1,375.0 -0.0,376.7 -0.0,-0.0 4166.9,-0.0 5390.8,3894.2 5376.2,4527.2 5149.1,5459.2 5151.0,6892.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17640386214191,
+                34.040770134393746
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5607.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17642995988194,
+                34.035587161986804
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5607.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18552187771986,
+                34.035618598808156
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18549577997983,
+                34.0408015712151
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499K [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5587.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8150.0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5587
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4167.5,6753.7 4171.8,7263.2 1202.7,7301.6 1177.5,5431.0 1389.4,4512.1 1373.4,3820.5 145.5,76.7 -0.0,78.5 -0.0,0.0 2859.6,-0.0 2865.2,318.2 4087.6,296.7 4082.4,-0.0 5587.0,-0.0 5587.0,3277.8 4822.0,3300.9 4880.5,6738.3 4167.5,6753.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17633353024074,
+                34.03705395042945
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5587.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17643864821306,
+                34.03180093592917
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5587.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18568600909019,
+                34.031928017716844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18558089111787,
+                34.03718103221713
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499K [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "4180.9"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "1628.8"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1406.1"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "1248.1"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5587
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5587.0,2876.9 4180.9,2876.9 4180.9,1628.8 5587.0,1628.8 5587.0,2876.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4180.9,
+                1628.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17551881864696,
+                34.03436594353968
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5587.0,
+                1628.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17551748755452,
+                34.03321632337162
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5587.0,
+                2876.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17674709854904,
+                34.03321534564213
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4180.9,
+                2876.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17674842964149,
+                34.03436496581019
               ]
             }
           }
@@ -12448,15 +15787,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "11"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12475,34 +15814,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4718.7,7374.1 1403.1,7332.5 1398.3,8150.0 -0.0,8150.0 0.0,0.0 5607.0,-0.0 5607.0,570.0 4573.4,576.8 4598.5,4420.4 4728.7,4420.8 4718.7,7374.1\" /></svg>"
+          "value": "<svg><polygon points=\"4706.8,6861.9 4701.5,7353.1 1409.2,7308.2 1403.4,8150.0 -0.0,8150.0 0.0,0.0 5607.0,-0.0 5607.0,574.5 4575.6,580.2 4590.6,3314.6 5607.0,3320.4 5607.0,3369.7 3663.3,3310.8 3575.1,5050.2 5607.0,5152.1 5607.0,5976.2 4852.3,6427.2 4911.2,6723.6 4816.5,6851.7 4706.8,6861.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499L/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3675.3,
-                6878.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1838248,
-                34.0461454
+                -118.17627932051953,
+                34.04956371582691
               ]
             }
           },
@@ -12510,20 +15852,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4855.1,
-                1603.6
+                5607.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.178006,
-                34.0451047
+                -118.17622646424266,
+                34.04442864439265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5607.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18523456674892,
+                34.044364976266124
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18528742302578,
+                34.049500047700384
               ]
             }
           }
@@ -12541,11 +15925,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -12564,8 +15948,8 @@
           "value": "8150.0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12584,34 +15968,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,514.6 174.0,201.8 -0.0,201.6 0.0,-0.0 2784.3,-0.0 2784.3,6664.7 2563.5,6663.6 2547.2,8150.0 -0.0,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"2784.3,-0.0 2784.3,6695.5 2618.5,6687.6 2540.3,8150.0 -0.0,8150.0 -0.0,885.2 668.4,-0.0 2784.3,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499M__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2568.3,
-                3183.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1812961,
-                34.0188994
+                -118.17955699488502,
+                34.02025010465585
               ]
             }
           },
@@ -12619,20 +16006,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2568.3,
-                895.8
+                2784.3,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1800381,
-                34.018906
+                -118.17948146288046,
+                34.0189654184043
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2784.3,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1840200351461,
+                34.01878210310496
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18409556715066,
+                34.02006678935651
               ]
             }
           }
@@ -12650,11 +16079,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -12673,8 +16102,8 @@
           "value": "8150.0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12693,34 +16122,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5157.0,7175.4 2781.5,7181.5 2781.5,1497.3 5153.4,1485.4 5162.3,-0.0 5587.0,-0.0 5587.0,8150.0 5162.2,8150.0 5157.0,7175.4\" /></svg>"
+          "value": "<svg><polygon points=\"5157.0,7175.4 2781.5,7181.5 2781.5,1596.0 5153.4,1483.5 5162.3,-0.0 5587.0,-0.0 5587.0,8150.0 5162.2,8150.0 5157.0,7175.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499M__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5155.4,
-                7286.2
+                2781.5,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1872204,
-                34.0188903
+                -118.18321187931527,
+                34.01997828314356
               ]
             }
           },
@@ -12728,20 +16160,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5155.4,
-                927.8
+                5587.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1837208,
-                34.0188941
+                -118.18320985512737,
+                34.01869763106938
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5587.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18769550594496,
+                34.01869276037756
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2781.5,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18769753013285,
+                34.01997341245174
               ]
             }
           }
@@ -12759,11 +16233,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -12782,8 +16256,8 @@
           "value": "6536.8"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12802,34 +16276,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"653.4,8150.0 -0.0,8150.0 0.0,1613.2 2653.5,1613.2 2656.8,2609.0 2857.9,2609.5 2857.9,7345.2 647.2,7367.5 653.4,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"2857.9,7344.8 647.5,7367.5 653.7,8150.0 -0.0,8150.0 -0.0,1613.2 2653.5,1613.2 2656.8,2609.0 2857.9,2609.5 2857.9,7344.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499N__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2662.0,
-                3704.2
+                0.0,
+                1613.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1882858,
-                34.0188822
+                -118.18716492618884,
+                34.02007472271565
               ]
             }
           },
@@ -12837,20 +16314,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2662.0,
-                7346.4
+                2857.9,
+                1613.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1902479,
-                34.0188759
+                -118.1871589605396,
+                34.0187983447375
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2857.9,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19068040236179,
+                34.01878703793178
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19068636801103,
+                34.02006341590993
               ]
             }
           }
@@ -12868,11 +16387,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -12891,8 +16410,8 @@
           "value": "6561.2"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12911,34 +16430,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2852.7,8150.0 2852.7,2547.2 3207.7,2550.9 3209.7,1772.9 5408.1,1773.9 5410.1,1588.8 5607.0,1588.8 5607.0,8150.0 2852.7,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"2852.7,8150.0 2852.7,2547.2 3208.0,2550.9 3210.0,1772.9 5408.1,1773.5 5410.1,1588.8 5607.0,1588.8 5607.0,8150.0 2852.7,8150.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499N__3/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5203.2,
-                3596.0
+                2852.7,
+                1588.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1912355,
-                34.0188686
+                -118.1901665601989,
+                34.01993725979659
               ]
             }
           },
@@ -12946,20 +16468,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5203.2,
-                5491.1
+                5607.0,
+                1588.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1922622,
-                34.0188563
+                -118.19014498893999,
+                34.018700301829476
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5607.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19369945033237,
+                34.01865771891809
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2852.7,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.19372102159129,
+                34.01989467688521
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499O/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499O",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499O/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499O/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5587
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4235.8,5534.3 4792.5,6345.8 5587.0,5829.3 5587.0,7968.9 4207.6,7977.1 4216.5,8150.0 -0.0,8150.0 0.0,-0.0 5587.0,0.0 5587.0,3735.1 4122.9,3434.6 3972.6,3403.8 4087.4,5638.2 4235.8,5534.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499O/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1929885,
+                34.063413
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5587.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1870647,
+                34.0633328
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5587.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1872059,
+                34.0561735
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1931297,
+                34.0562537
               ]
             }
           }
@@ -12977,15 +16679,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "11"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13004,34 +16706,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,-0.0 5607.0,0.0 5607.0,3079.2 5021.8,3319.6 5115.6,3580.3 5170.8,3687.9 3502.3,4220.8 4585.5,5197.3 4802.8,5517.1 5005.5,6091.7 5117.2,7357.4 5350.6,8150.0 -0.0,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"681.5,5993.8 156.7,5137.9 -0.0,5235.9 -0.0,2953.6 1627.9,3375.6 1801.4,0.0 4469.9,0.0 4582.7,559.4 3584.9,692.1 3800.7,1445.7 4359.0,1536.8 5170.8,3687.9 3502.3,4220.8 4585.5,5197.3 4802.8,5517.1 5005.5,6091.7 5117.2,7357.4 5350.6,8150.0 -0.0,8150.0 -0.0,7625.1 1406.2,7689.0 1518.2,5509.2 681.5,5993.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499P/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4359.2,
-                1535.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1843599,
-                34.0617167
+                -118.18894288299917,
+                34.0629080190848
               ]
             }
           },
@@ -13039,20 +16744,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2887.5,
-                7522.2
+                5607.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1856691,
-                34.0565202
+                -118.18311972400662,
+                34.06307705899136
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5607.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18282320171726,
+                34.05606245949732
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18864636070981,
+                34.05589341959076
               ]
             }
           }
@@ -13070,11 +16817,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -13093,8 +16840,8 @@
           "value": "4672.9"
         }
       ],
-      "created": "2026-08-07T16:54:51Z",
-      "modified": "2026-08-07T16:54:51Z",
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13113,34 +16860,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1036.5,2513.1 1066.8,1915.3 988.8,1543.5 369.4,251.6 2083.9,390.3 2086.0,0.0 5587.0,0.0 5587.0,4672.9 -0.0,4672.9 -0.0,4273.4 581.7,4512.5 665.6,3705.0 1036.5,2513.1\" /></svg>"
+          "value": "<svg><polygon points=\"1066.8,1915.3 988.8,1543.5 369.4,251.6 5473.1,769.6 5509.3,1072.6 5587.0,1081.3 5587.0,4672.9 -0.0,4672.9 -0.0,4273.4 581.7,4512.5 665.6,3705.0 1036.5,2513.1 1066.8,1915.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2103.6,
-                3004.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1822797,
-                34.0578091
+                -118.18561780985628,
+                34.05944826323413
               ]
             }
           },
@@ -13148,20 +16898,354 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3075.4,
-                512.1
+                5587.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -118.1824292,
-                34.0601503
+                -118.18023147616907,
+                34.06146769685371
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5587.0,
+                4672.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17819402150798,
+                34.057735816110124
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                4672.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18358035519519,
+                34.055716382490544
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499Q [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "4627.3"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5587.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3522.7"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5587
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4268.5,4627.3 4437.2,8150.0 -0.0,8150.0 -0.0,4712.5 4268.5,4627.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                4627.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17985645547223,
+                34.046181183247704
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5587.0,
+                4627.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17998743699583,
+                34.04357301902667
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5587.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18195855691427,
+                34.043641946273034
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18182757539068,
+                34.04625011049407
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499R/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499R",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T00:56:32Z",
+      "modified": "2026-08-15T00:56:32Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499R/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499R/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5607
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5316.5,4141.9 5315.1,7477.6 3113.7,7658.5 2896.7,8150.0 2128.8,8150.0 2270.1,7193.5 1780.9,7151.6 1723.6,7149.7 1437.2,8150.0 -0.0,8150.0 -0.0,-0.0 1475.9,-0.0 5607.0,-0.0 5607.0,4073.9 5316.5,4141.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499R/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17751943493019,
+                34.06649141777905
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5607.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17564671859736,
+                34.061710650367786
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5607.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18403292825938,
+                34.05945476914292
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18590564459221,
+                34.06423553655418
               ]
             }
           }

--- a/gallery/nashville_tn_1957_vol1a.iiif.json
+++ b/gallery/nashville_tn_1957_vol1a.iiif.json
@@ -7,144 +7,6 @@
   "label": "Mosaic of main content, Nashville, Tenn. | 1957 | Vol. 1a",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p66",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"943.2,8040.0 943.0,6472.6 400.0,6480.1 410.3,5445.2 735.2,4869.8 508.3,4204.9 490.4,1885.5 4756.9,1896.9 4761.9,-0.0 6600.0,-0.0 6600.0,8040.0 943.2,8040.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7731276,
-                36.159746
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7697556,
-                36.1611711
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7676055,
-                36.1578546
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7709775,
-                36.1564296
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0010/georef",
       "type": "Annotation",
       "@context": [
@@ -162,8 +24,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -182,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5270.8,6872.4 3180.5,6898.4 3196.0,4918.4 -0.0,4875.9 0.0,0.0 4467.1,0.0 4478.9,467.3 5084.3,862.5 5592.3,896.4 5676.5,6355.3 5238.0,6347.1 5270.8,6872.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6995.2 0.0,0.0 4498.1,0.0 4511.8,607.9 5109.4,998.0 5609.4,1029.8 5681.8,6424.9 5249.8,6418.3 5281.2,6937.3 -0.0,6995.2\" /></svg>"
         }
       },
       "body": {
@@ -211,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78415708628553,
-                36.16856471603541
+                -86.78425546566034,
+                36.16861056703517
               ]
             }
           },
@@ -232,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7807637916037,
-                36.169979249872206
+                -86.78080319319174,
+                36.170037900323905
               ]
             }
           },
@@ -253,8 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77864426226212,
-                36.16661862752978
+                -86.77865047198208,
+                36.16664112441867
               ]
             }
           },
@@ -274,8 +136,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78203755694395,
-                36.16520409369298
+                -86.78210274445067,
+                36.16521379112993
               ]
             }
           }
@@ -300,8 +162,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +182,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1035.8,6773.0 1094.9,1591.0 591.3,1544.6 -0.0,1136.9 0.0,0.0 6600.0,0.0 6600.0,8040.0 4037.7,8040.0 3990.8,6774.2 3935.7,6769.9 1035.8,6773.0\" /></svg>"
+          "value": "<svg><polygon points=\"4005.1,7027.9 3995.4,6772.1 1042.2,6773.4 1097.0,1593.9 593.6,1547.9 -0.0,1139.4 0.0,0.0 6600.0,0.0 6553.0,6921.7 4005.1,7027.9\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78204762145555,
-                36.169801273867996
+                -86.78204956733018,
+                36.16980291103033
               ]
             }
           },
@@ -370,8 +232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7786774564934,
-                36.17129498180766
+                -86.77867616933595,
+                36.171295094237195
               ]
             }
           },
@@ -391,8 +253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77643924863523,
-                36.16795733283709
+                -86.77644024306962,
+                36.167954248066
               ]
             }
           },
@@ -412,8 +274,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77980941359738,
-                36.166463624897425
+                -86.77981364106384,
+                36.16646206485914
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0012/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p12 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0012/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0012/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4014.7,462.5 6600.0,315.8 6600.0,6952.6 4165.7,6934.6 4185.9,4286.7 4188.6,4172.8 4014.7,462.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0012/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7802097473892,
+                36.167107903613896
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77685999294614,
+                36.168537704885786
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77470250593318,
+                36.165243393197485
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77805226037623,
+                36.163813591925596
               ]
             }
           }
@@ -438,8 +438,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +458,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1803.9,8040.0 -0.0,8040.0 -0.0,424.3 4948.4,853.8 4978.8,5880.7 3995.3,5877.6 3993.5,6476.7 1790.6,6463.5 1803.9,8040.0\" /></svg>"
+          "value": "<svg><polygon points=\"1808.1,8040.0 -0.0,8040.0 -0.0,429.0 4942.2,847.9 4988.0,6494.4 1792.0,6467.0 1808.1,8040.0\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +487,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.80089666526341,
-                36.157935831073274
+                -86.80089181130457,
+                36.157939427715
               ]
             }
           },
@@ -508,8 +508,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79760741516871,
-                36.159566561087516
+                -86.79760135966639,
+                36.159564389467484
               ]
             }
           },
@@ -529,8 +529,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79516426306219,
-                36.15630854907942
+                -86.79516684954243,
+                36.1563051873274
               ]
             }
           },
@@ -550,8 +550,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79845351315689,
-                36.15467781906517
+                -86.7984573011806,
+                36.154680225574914
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p14",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1677.0,0.0 3925.4,0.0 4900.3,0.0 6600.0,7115.0 6600.0,8040.0 -0.0,8040.0 -0.0,1600.4 1677.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79887050959609,
+                36.15535295853029
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79560283879944,
+                36.156951243951745
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79319148199941,
+                36.153737173551754
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79645915279606,
+                36.152138888130295
               ]
             }
           }
@@ -576,8 +714,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +734,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"746.6,1717.4 6600.0,1461.2 6600.0,3934.2 5669.3,7047.4 3027.6,8040.0 -0.0,8040.0 -0.0,6758.1 746.6,1717.4\" /></svg>"
+          "value": "<svg><polygon points=\"744.3,1714.0 6600.0,1455.8 6600.0,7056.3 5679.2,7049.1 3032.5,8040.0 -0.0,8040.0 -0.0,6761.2 744.3,1714.0\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +763,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7967747574887,
-                36.15638962744471
+                -86.79677133508835,
+                36.15638823785561
               ]
             }
           },
@@ -646,8 +784,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79336594032476,
-                36.15787784467495
+                -86.79336623382522,
+                36.157873651257404
               ]
             }
           },
@@ -667,8 +805,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79113634738854,
-                36.154501329678254
+                -86.79114084148283,
+                36.15450081694941
               ]
             }
           },
@@ -688,8 +826,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79454516455249,
-                36.153013112448015
+                -86.79454594274596,
+                36.15301540354761
               ]
             }
           }
@@ -714,8 +852,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +872,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4175.4,6977.3 4215.1,8040.0 4005.6,8040.0 3985.1,6977.0 -0.0,6969.4 -0.0,3868.0 920.8,3818.1 905.3,1319.5 5603.3,1027.2 5894.2,3232.2 5935.5,6980.7 4175.4,6977.3\" /></svg>"
+          "value": "<svg><polygon points=\"930.1,6970.7 904.7,1313.6 5613.0,1027.2 5901.1,3234.9 5937.3,6987.2 930.1,6970.7\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +901,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79378298733198,
-                36.15761477250052
+                -86.79378341575598,
+                36.157609938956305
               ]
             }
           },
@@ -784,8 +922,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79039794567578,
-                36.159070626406894
+                -86.79040425542217,
+                36.15906811316232
               ]
             }
           },
@@ -805,8 +943,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78821680377243,
-                36.155717714688855
+                -86.78821963728316,
+                36.155721026930564
               ]
             }
           },
@@ -826,8 +964,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79160184542863,
-                36.15426186078248
+                -86.79159879761697,
+                36.15426285272455
               ]
             }
           }
@@ -852,8 +990,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +1010,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6164.4,6994.0 483.0,6992.6 441.2,3257.1 150.9,1059.7 6155.2,724.6 6164.4,6994.0\" /></svg>"
+          "value": "<svg><polygon points=\"6125.9,6993.8 484.9,6995.7 440.8,3255.9 148.8,1056.2 6148.1,717.4 6125.9,6993.8\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +1039,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7909965864534,
-                36.15883250541531
+                -86.79099382210956,
+                36.15883119039219
               ]
             }
           },
@@ -922,8 +1060,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78759945653866,
-                36.160292936831624
+                -86.78759952284861,
+                36.16028827697793
               ]
             }
           },
@@ -943,8 +1081,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78541142358792,
-                36.156928102465905
+                -86.78541650076905,
+                36.15692624695244
               ]
             }
           },
@@ -964,8 +1102,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78880855350265,
-                36.15546767104959
+                -86.78881080002999,
+                36.1554691603667
               ]
             }
           }
@@ -990,8 +1128,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1010,7 +1148,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6963.5 -0.0,647.2 6163.7,463.4 6179.5,6989.7 -0.0,6963.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6987.7 -0.0,685.6 6136.0,431.8 6188.1,6943.1 -0.0,6987.7\" /></svg>"
         }
       },
       "body": {
@@ -1039,8 +1177,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7878065095758,
-                36.160159940593914
+                -86.78782129192534,
+                36.1601745882727
               ]
             }
           },
@@ -1060,8 +1198,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78443709120982,
-                36.161613552422054
+                -86.78441048900565,
+                36.16160587294424
               ]
             }
           },
@@ -1081,8 +1219,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78225923833924,
-                36.158276223004464
+                -86.78225093070526,
+                36.15825126369762
               ]
             }
           },
@@ -1102,8 +1240,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7856286567052,
-                36.15682261117633
+                -86.78566173362495,
+                36.15681997902608
               ]
             }
           }
@@ -1128,8 +1266,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1148,7 +1286,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6049.9,7528.3 1005.0,7481.4 993.2,5733.0 -0.0,5730.1 -0.0,5127.7 989.1,5127.6 944.5,0.0 3945.0,0.0 3933.1,263.5 4691.9,307.5 6049.9,7528.3\" /></svg>"
+          "value": "<svg><polygon points=\"4682.2,299.6 6047.7,7525.4 998.4,7482.9 957.5,369.2 929.7,67.4 4682.2,299.6\" /></svg>"
         }
       },
       "body": {
@@ -1177,8 +1315,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79866091985627,
-                36.15861120330428
+                -86.79865274151352,
+                36.158613003699294
               ]
             }
           },
@@ -1198,8 +1336,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79538411403031,
-                36.160224432954685
+                -86.79537700842693,
+                36.16022250525293
               ]
             }
           },
@@ -1219,8 +1357,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7929671425427,
-                36.156978798523774
+                -86.79296563935287,
+                36.15697791060677
               ]
             }
           },
@@ -1240,8 +1378,454 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79624394836866,
-                36.15536556887337
+                -86.79624137243947,
+                36.15536840905313
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p1 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3372.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8040.0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"516.1,7024.0 510.9,2798.9 516.1,932.0 2643.1,1022.3 2702.6,6484.3 516.1,7024.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78484356715886,
+                36.161487228078315
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3372.8,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78381330012002,
+                36.161930072805184
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3372.8,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78250541436822,
+                36.15994686400677
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78353568140706,
+                36.1595040192799
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p1 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3370.4"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3229.6"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8040.0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6600.0,142.8 6212.3,7378.0 3370.4,7197.3 3742.1,668.0 6600.0,142.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3370.4,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78371488810757,
+                36.1599003329181
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78300550491282,
+                36.160251644243544
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78192300792803,
+                36.15882696943703
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3370.4,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78263239112277,
+                36.158475658111584
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p2",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5560.4,894.1 5652.0,7116.0 1056.5,7407.0 841.4,1024.1 5560.4,894.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78422872502138,
+                36.1617102879854
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78248354751113,
+                36.162419718528916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78141310843871,
+                36.16070334517544
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78315828594896,
+                36.159993914631926
               ]
             }
           }
@@ -1266,8 +1850,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1286,7 +1870,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1824.2,7562.1 457.5,398.8 5449.6,626.9 5173.3,1846.6 5120.1,2988.4 5457.1,7556.8 1824.2,7562.1\" /></svg>"
+          "value": "<svg><polygon points=\"1820.9,7564.8 454.4,394.4 5451.2,623.8 5174.4,1844.5 5120.9,2987.5 5457.1,7560.2 1820.9,7564.8\" /></svg>"
         }
       },
       "body": {
@@ -1315,8 +1899,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79658845766942,
-                36.159684202559895
+                -86.79658527913959,
+                36.15968304360139
               ]
             }
           },
@@ -1336,8 +1920,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79328173933052,
-                36.16130243565301
+                -86.79328211036834,
+                36.161300343306806
               ]
             }
           },
@@ -1357,8 +1941,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79085725631593,
-                36.15802719389222
+                -86.79085902593498,
+                36.15802861711862
               ]
             }
           },
@@ -1378,8 +1962,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79416397465482,
-                36.1564089607991
+                -86.79416219470623,
+                36.1564113174132
               ]
             }
           }
@@ -1404,8 +1988,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1424,7 +2008,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1780.1,7237.9 1354.1,2627.0 1386.5,1471.9 1720.5,0.0 6600.0,0.0 6600.0,354.3 5357.5,342.0 5918.5,7132.6 1780.1,7237.9\" /></svg>"
+          "value": "<svg><polygon points=\"1776.8,7248.7 1347.6,2629.7 1379.4,1472.5 1712.4,0.0 6600.0,0.0 6600.0,350.1 5356.9,338.4 5922.6,7141.0 1776.8,7248.7\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +2037,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79455995086403,
-                36.16047414847945
+                -86.79455435685784,
+                36.16047606423014
               ]
             }
           },
@@ -1474,8 +2058,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7912528879879,
-                36.16202549669573
+                -86.7912522375159,
+                36.16202315130982
               ]
             }
           },
@@ -1495,8 +2079,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78892859281184,
-                36.15874994326269
+                -86.78893432543177,
+                36.1587524958929
               ]
             }
           },
@@ -1516,8 +2100,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79223565568797,
-                36.15719859504641
+                -86.7922364447737,
+                36.15720540881322
               ]
             }
           }
@@ -1542,8 +2126,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1562,7 +2146,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"538.9,343.2 1773.1,387.4 1782.2,35.4 4954.9,0.0 4921.4,523.5 6600.0,583.3 6600.0,7196.6 918.7,7070.9 538.9,343.2\" /></svg>"
+          "value": "<svg><polygon points=\"539.7,340.2 1773.8,385.0 1783.2,37.4 4980.9,0.0 4946.8,523.5 6600.0,582.5 6600.0,7205.4 917.2,7077.4 539.7,340.2\" /></svg>"
         }
       },
       "body": {
@@ -1591,8 +2175,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79214844791103,
-                36.16159946673085
+                -86.7921474233164,
+                36.16159795466688
               ]
             }
           },
@@ -1612,8 +2196,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78887174412733,
-                36.16323007955037
+                -86.7888760515001,
+                36.16322746310488
               ]
             }
           },
@@ -1633,8 +2217,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78642865018968,
-                36.159984650678965
+                -86.78643461204565,
+                36.15998731554222
               ]
             }
           },
@@ -1654,8 +2238,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78970535397337,
-                36.158354037859446
+                -86.78970598386195,
+                36.15835780710422
               ]
             }
           }
@@ -1680,8 +2264,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1700,7 +2284,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 6600.0,0.0 6600.0,6759.7 5421.5,6804.8 5422.6,6878.3 342.1,6648.2 399.6,8040.0 -0.0,8040.0 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8040.0 -0.0,0.0 5383.5,0.0 5420.8,6883.9 349.1,6654.4 403.6,8040.0 -0.0,8040.0\" /></svg>"
         }
       },
       "body": {
@@ -1729,8 +2313,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.80277607856988,
-                36.16038209829813
+                -86.80277543340637,
+                36.160383280433436
               ]
             }
           },
@@ -1750,8 +2334,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79948543361367,
-                36.161865497629286
+                -86.79948646129304,
+                36.16186676489726
               ]
             }
           },
@@ -1771,8 +2355,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79726294431528,
-                36.15860620275627
+                -86.79726384444547,
+                36.15860912692982
               ]
             }
           },
@@ -1792,8 +2376,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.80055358927147,
-                36.15712280342511
+                -86.80055281655879,
+                36.15712564246599
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0024/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p24",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0024/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0024/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5057.5,7123.8 1252.5,7050.2 1182.8,787.4 4992.5,819.7 5057.5,7123.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0024/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.80074081764963,
+                36.161412373993095
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79742463646217,
+                36.162889292719306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79521181772769,
+                36.15960476270347
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79852799891516,
+                36.158127843977255
               ]
             }
           }
@@ -1818,8 +2540,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,7 +2560,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 6600.0,0.0 6600.0,6818.4 6059.4,6831.4 5985.3,7074.2 -0.0,7048.9 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"703.1,622.1 -0.0,609.3 -0.0,0.0 6600.0,0.0 6600.0,6821.1 6061.6,6833.7 5988.1,7074.4 780.7,7057.7 703.1,622.1\" /></svg>"
         }
       },
       "body": {
@@ -1867,8 +2589,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79852498560653,
-                36.162293859425475
+                -86.79852026710795,
+                36.162290266925524
               ]
             }
           },
@@ -1888,8 +2610,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79526862061299,
-                36.16373723522376
+                -86.79526879361627,
+                36.16373233386599
               ]
             }
           },
@@ -1909,8 +2631,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79310604207859,
-                36.16051197444814
+                -86.79310817697218,
+                36.16051191659192
               ]
             }
           },
@@ -1930,8 +2652,1664 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79636240707212,
-                36.15906859864985
+                -86.79635965046386,
+                36.15906984965146
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p29",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5895.8,664.0 5896.0,7276.0 818.7,7349.2 1009.8,590.7 5895.8,664.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78222451983052,
+                36.16587701578822
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78061786554262,
+                36.166567026630155
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77957668554262,
+                36.16498695505121
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78118333983052,
+                36.164296944209276
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p3",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5576.8,684.8 5796.0,6924.0 1087.4,7287.7 797.0,916.0 5576.8,684.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78295971422949,
+                36.162232316333075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78123155363427,
+                36.16288174041212
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78025166410112,
+                36.16118209004201
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78197982469634,
+                36.16053266596297
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p30",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"629.7,7175.3 849.2,641.1 6048.4,814.5 5696.0,7264.0 629.7,7175.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78099773443098,
+                36.16639255777341
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77940285141707,
+                36.167134070788954
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77828395651565,
+                36.16556557794116
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77987883952956,
+                36.16482406492562
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p31",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"804.4,1699.5 -0.0,1684.0 -0.0,643.0 845.8,706.7 852.8,234.7 6600.0,415.8 6600.0,8040.0 412.0,7704.0 804.4,1699.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77988874483297,
+                36.16716808599212
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77818736145827,
+                36.1679787559673
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77696410294212,
+                36.16630553903228
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77866548631683,
+                36.1654948690571
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p32",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5648.7,7118.5 914.8,7172.2 729.5,6009.9 1008.6,766.9 5667.2,691.2 5648.7,7118.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78509180300544,
+                36.16299502557941
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78336600339196,
+                36.163725104177956
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78226440264102,
+                36.16202779879624
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7839902022545,
+                36.161297720197695
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p33",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5782.3,7334.5 1064.0,7284.0 1160.5,807.1 -0.0,815.6 0.0,0.0 5106.5,0.0 5102.4,781.4 5868.0,784.0 5782.3,7334.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7839266050007,
+                36.16351369172236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78222511084522,
+                36.16425465635504
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78110707895476,
+                36.162581263248455
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78280857311024,
+                36.16184029861577
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p34",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"852.0,7228.0 852.0,621.4 5614.5,661.1 5684.4,7192.7 852.0,7228.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78260771809433,
+                36.16404590165695
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78090875100729,
+                36.16476273835389
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7798271141805,
+                36.16309184798133
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78152608126754,
+                36.16237501128438
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p35",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1095.3,865.3 5924.0,796.0 5924.0,7332.0 1117.0,7408.9 1095.3,865.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.781471687958,
+                36.164576671236794
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77978237614937,
+                36.16530230839291
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77868745509672,
+                36.163640921612
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78037676690535,
+                36.162915284455885
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p36",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"807.7,7242.6 740.0,732.0 5593.1,603.6 5611.9,7132.4 807.7,7242.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78013628976666,
+                36.16513610517782
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77843116043263,
+                36.16585024940206
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77735357418224,
+                36.164173317453
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77905870351627,
+                36.16345917322876
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0037/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p37",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0037/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0037/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6580.1,6925.9 456.0,7022.0 456.0,724.0 6600.0,956.0 6580.1,6925.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0037/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77883349525389,
+                36.16572027458763
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77706850941901,
+                36.16646469410232
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77594523282326,
+                36.16472890686827
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77771021865814,
+                36.16398448735358
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p38",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"788.0,7092.0 788.0,974.0 5549.7,887.6 5611.6,7067.3 788.0,7092.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78175317850726,
+                36.1627578097342
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78001956603534,
+                36.1634700686641
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77894485011511,
+                36.16176508402858
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78067846258703,
+                36.161052825098686
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p39",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5863.7,936.3 5722.8,7152.3 1004.7,6956.0 1192.3,877.8 5863.7,936.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78061464503446,
+                36.16321147339679
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77890321925611,
+                36.16399803146798
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77772471689825,
+                36.162302981005844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7794361426766,
+                36.16151642293465
               ]
             }
           }
@@ -1956,8 +4334,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1976,7 +4354,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2641.1,3081.8 1588.1,3062.4 1477.5,0.0 6600.0,0.0 6600.0,6306.7 4233.7,6307.3 4226.2,6909.1 2644.5,6946.0 2641.1,3081.8\" /></svg>"
+          "value": "<svg><polygon points=\"2652.6,489.8 4208.0,478.2 4207.2,0.0 6595.8,0.0 6600.0,6302.3 4237.6,6274.5 4234.5,6549.8 2649.3,6664.2 2652.6,489.8\" /></svg>"
         }
       },
       "body": {
@@ -2005,8 +4383,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77841521962485,
-                36.16424923967065
+                -86.77841939882472,
+                36.16425300676585
               ]
             }
           },
@@ -2026,8 +4404,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77498950053554,
-                36.16568675545346
+                -86.77499211119844,
+                36.165689865223655
               ]
             }
           },
@@ -2047,8 +4425,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77283563260869,
-                36.162293867431856
+                -86.77283922816845,
+                36.16229542368259
               ]
             }
           },
@@ -2068,2953 +4446,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.776261351698,
-                36.160856351649045
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p5",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1680.3,533.9 -0.0,581.5 0.0,0.0 6600.0,0.0 6600.0,556.8 5674.6,520.6 5655.1,7025.5 2103.1,7139.0 1680.3,533.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78970382340866,
-                36.16284729560297
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78630834555526,
-                36.164303223582365
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78412694802644,
-                36.16094019774449
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78752242587984,
-                36.15948426976509
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p51",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 6600.0,206.6 6600.0,5909.7 6325.7,6471.2 5916.6,6888.7 4849.3,7339.4 3732.4,7340.1 3720.2,8040.0 -0.0,8040.0 -0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.79329514993887,
-                36.15415631991621
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78991178235583,
-                36.155680259013
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78762871362738,
-                36.15232889165094
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.79101208121043,
-                36.15080495255415
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p52",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1083.2,6733.2 1607.2,5524.5 1546.6,271.2 5900.3,243.0 5938.6,6723.5 1083.2,6733.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.79061059659307,
-                36.15541902335416
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78719998488246,
-                36.15686534096029
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78503319228851,
-                36.15348700500208
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78844380399912,
-                36.15204068739595
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p54",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3060.2,4950.1 1816.9,4946.6 1799.5,3947.6 1483.0,3742.8 1398.2,3007.1 1099.2,2723.1 1095.7,800.5 1359.7,191.0 5614.2,186.4 5602.6,7514.4 3049.0,7552.4 3060.2,4950.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78505644879144,
-                36.1577574487835
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78163641629199,
-                36.15919542585028
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77948205563659,
-                36.15580785793981
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78290208813604,
-                36.154369880873034
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p55",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1333.0,292.4 5572.4,330.5 5624.3,7378.4 1423.5,6220.0 1265.4,6793.1 1333.0,292.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78286928932506,
-                36.1587284804336
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77944369636555,
-                36.16019915463316
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7772403212769,
-                36.156806122111355
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78066591423642,
-                36.15533544791179
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p57",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5267.7,7279.4 1377.8,7271.6 1460.9,3846.9 3834.4,3898.2 3849.9,3422.5 5371.0,3449.0 5267.7,7279.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77811304063435,
-                36.16089940692835
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77477237341397,
-                36.162417671822155
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77249763148924,
-                36.15910885396995
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77583829870963,
-                36.15759058907614
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p6",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1113.5,7161.5 1061.3,697.0 1981.3,722.8 1975.2,169.4 -0.0,191.3 0.0,0.0 6600.0,0.0 6600.0,534.8 2573.4,653.8 3013.2,751.7 3090.1,5454.5 2970.6,6577.2 3070.5,7159.7 1113.5,7161.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78738203837773,
-                36.16394575102643
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78394570087522,
-                36.16537987846878
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7817969572896,
-                36.161976398560505
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78523329479209,
-                36.16054227111815
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p62",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 5138.5,0.0 5543.3,620.2 6600.0,0.0 6600.0,383.6 5756.0,950.8 6440.3,2015.1 4210.4,3444.2 5654.6,5605.3 4386.7,6530.8 4017.5,7320.4 3514.4,7561.8 3290.2,8040.0 2499.5,8040.0 2377.2,7121.8 707.2,7437.4 801.0,4774.3 1195.2,4256.3 1376.1,1322.7 0.0,1234.8 -0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78365138932008,
-                36.15344189009675
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78328506944223,
-                36.15650354918475
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77869824018492,
-                36.156140697646116
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77906456006278,
-                36.15307903855812
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p63",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1349.0,3511.1 739.7,2978.7 397.1,2109.7 -0.0,616.1 0.0,0.0 4544.6,0.0 5873.8,4583.4 6600.0,4398.6 6600.0,7573.5 5937.2,7354.0 5567.7,7534.6 3872.7,6223.5 3793.3,5605.1 1567.7,5197.2 1814.6,4436.1 1424.3,4070.9 1349.0,3511.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78042587419301,
-                36.15642073553159
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77677531289046,
-                36.15707429793895
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77579617383074,
-                36.15345831343845
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77944673513329,
-                36.15280475103109
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p65",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"791.9,6895.3 821.2,1211.9 4666.5,1125.7 6149.7,1296.1 6173.5,4277.2 6396.1,4928.8 6077.1,5489.6 6066.8,6501.5 6600.0,6497.4 6600.0,8040.0 -0.0,8040.0 -0.0,6965.8 791.3,6973.4 791.9,6895.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77611579659781,
-                36.15855229315864
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77269214086202,
-                36.160020205617116
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77049290845711,
-                36.156629084161025
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7739165641929,
-                36.15516117170255
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p8",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3165.6,5239.4 -0.0,5285.0 0.0,0.0 5485.4,0.0 5496.3,1990.0 3156.1,2014.7 3165.6,5239.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78404225450225,
-                36.16605453958564
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.780643282496,
-                36.16742534039198
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77858935277384,
-                36.164058980174396
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78198832478009,
-                36.162688179368054
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p14",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1607.9 1677.0,0.0 4900.3,0.0 6600.0,7115.0 6600.0,8040.0 -0.0,8040.0 -0.0,1607.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4888.0,
-                4340.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7951488,
-                36.1548017
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4888.0,
-                6840.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.794399,
-                36.1538023
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p1 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "3372.8"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8040.0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"516.1,7024.0 510.9,2798.9 516.1,932.0 2643.2,1022.4 2702.7,6484.4 516.1,7024.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                516.1,
-                932.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7845343,
-                36.1613251
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                516.1,
-                7024.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7835433,
-                36.1598224
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p1 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "3370.4"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "3229.6"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8040.0"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6600.0,143.0 6212.3,7378.0 3370.4,7197.2 3742.1,668.0 6600.0,143.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3742.1,
-                668.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7835433,
-                36.1598224
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6212.3,
-                7376.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7820973,
-                36.1589021
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p2",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5560.4,894.0 5652.0,7116.0 1056.5,7407.2 841.4,1024.2 5560.4,894.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2816.0,
-                948.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7833579,
-                36.1618106
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5652.0,
-                7116.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7817868,
-                36.1607987
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p29",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5895.8,664.0 5896.0,7276.0 818.7,7349.2 1009.8,590.7 5895.8,664.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5896.0,
-                3476.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7803391,
-                36.1658103
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5896.0,
-                7276.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.779847,
-                36.1650635
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p3",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5576.9,684.9 5796.0,6924.0 1087.3,7287.5 796.9,915.9 5576.9,684.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3184.0,
-                784.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7820307,
-                36.1623803
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5796.0,
-                6924.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7805982,
-                36.1613389
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p30",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"629.7,7175.3 849.2,641.1 6048.4,814.5 5696.0,7264.0 629.7,7175.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                756.0,
-                3420.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7803391,
-                36.1658103
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5696.0,
-                7264.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7786104,
-                36.1656154
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p31",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"412.0,7704.0 804.0,1699.7 -0.0,1684.2 -0.0,643.3 845.3,706.9 852.3,234.9 6600.0,416.1 6600.0,8040.0 1141.8,8040.0 1151.1,7744.1 412.0,7704.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3636.0,
-                7704.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7777793,
-                36.1660114
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                412.0,
-                7704.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7786104,
-                36.1656154
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p32",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"914.8,7172.2 729.5,6009.9 1008.6,766.9 5667.2,691.2 5648.7,7118.5 914.8,7172.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2896.0,
-                7128.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7833579,
-                36.1618106
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2896.0,
-                736.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7842337,
-                36.16316
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p33",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5782.3,7334.5 1064.0,7284.0 1160.5,807.1 5868.0,784.0 5782.3,7334.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5868.0,
-                784.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7823048,
-                36.1640093
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1064.0,
-                7284.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7826394,
-                36.1621171
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p34",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"852.0,7228.0 852.0,621.4 5614.5,661.1 5684.4,7192.7 852.0,7228.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                852.0,
-                620.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7823048,
-                36.1640093
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                852.0,
-                7228.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.781416,
-                36.1626363
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p35",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1095.3,865.3 5924.0,796.0 5924.0,7332.0 1117.0,7408.9 1095.3,865.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5924.0,
-                7332.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7789569,
-                36.1637129
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5924.0,
-                796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.779847,
-                36.1650635
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p36",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"824.8,492.8 6600.0,493.7 6600.0,7172.9 740.0,7188.0 824.8,492.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3172.0,
-                7188.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7783534,
-                36.1639801
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                740.0,
-                7188.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7789569,
-                36.1637129
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p38",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"788.0,974.0 5549.7,887.6 5611.6,7067.3 788.0,7092.0 788.0,974.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                788.0,
-                7092.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7805982,
-                36.1613389
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                788.0,
-                976.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.781416,
-                36.1626363
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p39",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5856.0,940.0 5856.0,7028.0 1251.2,6967.6 1299.7,1013.2 5856.0,940.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5856.0,
-                7028.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7780823,
-                36.1623856
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5856.0,
-                940.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7789569,
-                36.1637129
+                -86.77626651579473,
+                36.160858565224785
               ]
             }
           }
@@ -5032,15 +4465,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5059,34 +4492,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"938.8,7012.0 951.1,782.8 6600.0,705.6 6600.0,5729.0 5622.6,5733.3 5620.0,7012.0 938.8,7012.0\" /></svg>"
+          "value": "<svg><polygon points=\"938.8,7012.0 951.1,782.8 5629.2,733.2 5620.0,7012.0 938.8,7012.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0040/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3224.0,
-                7012.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7774798,
-                36.1626456
+                -86.77931796347887,
+                36.16377130947792
               ]
             }
           },
@@ -5094,20 +4530,216 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5620.0,
-                7012.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7768481,
-                36.1629182
+                -86.77757788835368,
+                36.16452221098043
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7764448547419,
+                36.16281088633465
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7781849298671,
+                36.16205998483214
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p41 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3480.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8040.0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2840.8,849.2 2718.0,8040.0 444.4,8040.0 476.1,892.0 2840.8,849.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77806348431385,
+                36.16443616295302
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3480.8,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77684512931505,
+                36.164960070261166
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3480.8,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77534586980532,
+                36.16268756392136
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77656422480412,
+                36.16216365661321
               ]
             }
           }
@@ -5125,11 +4757,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -5148,8 +4780,8 @@
           "value": "8040.0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5168,34 +4800,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6600.0,0.0 6456.1,6988.0 3713.5,6988.0 3831.5,0.0 6600.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6456.1,6988.0 3713.5,6988.0 3768.5,4089.9 6518.0,4106.1 6456.1,6988.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3713.5,
-                6988.0
+                3469.6,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7759731,
-                36.1615489
+                -86.77713204077529,
+                36.16314512654528
               ]
             }
           },
@@ -5203,20 +4838,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6456.1,
-                6988.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7751818,
-                36.161894
+                -86.77622885141669,
+                36.16353902348405
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77497639549108,
+                36.16166718851396
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3469.6,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77587958484968,
+                36.16127329157519
               ]
             }
           }
@@ -5234,15 +4911,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5261,34 +4938,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5604.0,540.0 5298.9,7230.8 756.0,7200.0 763.3,715.8 5604.0,540.0\" /></svg>"
+          "value": "<svg><polygon points=\"5604.0,540.0 5298.8,7230.7 756.0,7200.0 763.5,715.8 5604.0,540.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0042/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                756.0,
-                7200.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7820973,
-                36.1589021
+                -86.78327738203372,
+                36.16028742909139
               ]
             }
           },
@@ -5296,20 +4976,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5604.0,
-                540.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7817868,
-                36.1607987
+                -86.78160923702337,
+                36.16101933937152
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78050484966417,
+                36.15937877057424
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78217299467451,
+                36.15864686029411
               ]
             }
           }
@@ -5327,15 +5049,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5354,34 +5076,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6600.0,7432.5 992.0,7436.0 1220.1,827.5 6600.0,713.6 6600.0,7432.5\" /></svg>"
+          "value": "<svg><polygon points=\"4158.5,7410.8 992.0,7436.0 1220.2,827.5 4982.7,729.7 4158.5,7410.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0043/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                992.0,
-                7436.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7809449,
-                36.1593996
+                -86.78221379385126,
+                36.16083648940414
               ]
             }
           },
@@ -5389,20 +5114,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5900.0,
-                704.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7805982,
-                36.1613389
+                -86.78051415405179,
+                36.161562710132124
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77941840364493,
+                36.159891087977066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7811180434444,
+                36.15916486724908
               ]
             }
           }
@@ -5420,15 +5187,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5447,34 +5214,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6462.4,6639.7 2384.4,7161.8 1578.7,630.9 5658.1,148.6 6462.4,6639.7\" /></svg>"
+          "value": "<svg><polygon points=\"6462.4,6639.7 -0.0,7531.7 -0.0,817.6 5658.1,148.6 6462.4,6639.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0044/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                892.0,
-                7428.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7798865,
-                36.1598307
+                -86.78091746579145,
+                36.16141586785496
               ]
             }
           },
@@ -5482,20 +5252,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                892.0,
-                684.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7805982,
-                36.1613389
+                -86.77908927544462,
+                36.16197819265652
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7782408074731,
+                36.160180160628066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78006899781992,
+                36.15961783582651
               ]
             }
           }
@@ -5513,15 +5325,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5540,34 +5352,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"672.0,7488.4 679.3,665.7 5636.0,728.0 5636.0,7444.0 672.0,7488.4\" /></svg>"
+          "value": "<svg><polygon points=\"672.1,7488.4 679.3,665.7 5636.0,728.0 5636.0,7444.0 672.1,7488.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0046/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5636.0,
-                728.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7780823,
-                36.1623856
+                -86.77959372878631,
+                36.161926448315214
               ]
             }
           },
@@ -5575,20 +5390,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5636.0,
-                7444.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7771869,
-                36.1610249
+                -86.77793744104949,
+                36.16263686014489
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7768655208589,
+                36.16100791017465
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77852180859573,
+                36.160297498344974
               ]
             }
           }
@@ -5606,15 +5463,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5633,7 +5490,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5884.0,1592.0 5382.0,8040.0 526.9,8040.0 1091.9,1263.2 5884.0,1592.0\" /></svg>"
+          "value": "<svg><polygon points=\"5780.0,1592.0 5278.0,8040.0 425.4,8040.0 990.5,1263.4 5780.0,1592.0\" /></svg>"
         }
       },
       "body": {
@@ -5662,8 +5519,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77889621631175,
-                36.160595746418025
+                -86.7788713158903,
+                36.16060874813287
               ]
             }
           },
@@ -5683,8 +5540,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77725993601794,
-                36.16143470573729
+                -86.7772341770016,
+                36.1614481476739
               ]
             }
           },
@@ -5704,8 +5561,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77599460749595,
-                36.15982472925752
+                -86.77596818453186,
+                36.159837326401465
               ]
             }
           },
@@ -5725,50 +5582,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77763088778975,
-                36.158985769938255
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5884.0,
-                1592.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7771869,
-                36.1610249
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5884.0,
-                1592.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7771869,
-                36.1610249
+                -86.77760532342056,
+                36.15899792686044
               ]
             }
           }
@@ -5786,15 +5601,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5813,34 +5628,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5576.0,7448.0 737.8,7416.2 677.5,6907.2 800.0,708.0 5719.0,741.2 5576.0,7448.0\" /></svg>"
+          "value": "<svg><polygon points=\"5576.0,7448.0 737.8,7416.2 677.5,6907.2 800.0,708.0 5719.0,741.1 5576.0,7448.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0048/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                800.0,
-                708.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7780823,
-                36.1623856
+                -86.77837843312452,
+                36.162440786358324
               ]
             }
           },
@@ -5848,20 +5666,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5576.0,
-                7448.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7759731,
-                36.1615489
+                -86.77672851302555,
+                36.16316436518294
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77563672179899,
+                36.161541683296655
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77728664189796,
+                36.160818104472035
               ]
             }
           }
@@ -5879,15 +5739,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5913,27 +5773,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0049/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5828.0,
-                1452.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7759731,
-                36.1615489
+                -86.77767437599235,
+                36.16120277427071
               ]
             }
           },
@@ -5941,20 +5804,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1116.0,
-                1452.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7771869,
-                36.1610249
+                -86.77597423167997,
+                36.1619367301281
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7748668100259,
+                36.160264612047975
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77656695433828,
+                36.15953065619059
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p5",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5652.4,7031.8 2087.1,7148.3 1655.9,529.9 -0.0,578.6 -0.0,0.0 6146.9,0.0 6141.8,525.2 5667.2,513.9 5652.4,7031.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78969298805721,
+                36.162849947350395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78630303217079,
+                36.16430097609019
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78412897465132,
+                36.16094342014807
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78751893053774,
+                36.15949239140828
               ]
             }
           }
@@ -5972,15 +6015,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5999,34 +6042,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"784.0,7144.0 759.5,699.3 6600.0,869.0 6600.0,7166.9 784.0,7144.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,3950.3 -0.0,674.1 6600.0,869.0 6600.0,7181.1 784.0,7144.0 771.9,3967.7 -0.0,3950.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0050/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                784.0,
-                3968.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7751818,
-                36.161894
+                -86.77429868801215,
+                36.16248286223978
               ]
             }
           },
@@ -6034,20 +6080,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                784.0,
-                7144.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7759731,
-                36.1615489
+                -86.77341042640239,
+                36.16115524734535
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77541359138984,
+                36.16028163147633
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7763018529996,
+                36.16160924637076
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p51",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,0.0 6600.0,207.2 6600.0,5911.2 6322.7,6477.8 5912.6,6895.2 4843.6,7344.9 3725.5,7344.1 3712.5,8040.0 -0.0,8040.0 0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7932923955992,
+                36.15415290974635
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78991502596365,
+                36.15567905366403
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78762866818195,
+                36.15233360693388
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79100603781751,
+                36.1508074630162
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p52",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1070.7,6742.9 1594.7,5533.4 1532.9,277.2 5889.0,248.1 5928.8,6732.2 1070.7,6742.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79060472784985,
+                36.15542484266269
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78719562445099,
+                36.15686974395511
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7850309536994,
+                36.15349290203505
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78844005709827,
+                36.152048000742624
               ]
             }
           }
@@ -6065,15 +6429,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6092,34 +6456,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2642.0,7264.2 528.0,7240.0 582.2,222.8 6600.0,252.9 6341.4,846.0 6313.4,2726.4 6600.0,3007.4 6600.0,4903.7 6058.4,4896.2 5891.0,4898.8 3799.7,8040.0 2754.7,8040.0 2642.0,7264.2\" /></svg>"
+          "value": "<svg><polygon points=\"2527.6,7267.4 393.6,7274.1 304.4,219.6 6387.1,161.4 6129.6,761.6 6139.9,2652.2 6600.0,2984.4 6600.0,4836.5 5927.0,4837.0 5758.5,4842.0 4239.2,7203.1 2485.0,5979.7 2527.6,7267.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0053/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                528.0,
-                4872.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7862099,
-                36.1546124
+                -86.78771625424112,
+                36.15663719370089
               ]
             }
           },
@@ -6127,20 +6494,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                528.0,
-                7240.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7855402,
-                36.1536013
+                -86.7842319618042,
+                36.15808931752264
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7820564395361,
+                36.154638047480745
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78554073197303,
+                36.153185923658995
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p54",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3049.1,4951.4 1803.1,4946.2 1787.0,3943.5 1550.4,3789.7 1554.0,3057.8 1086.8,2717.0 1085.8,790.2 1351.1,179.8 5614.8,180.7 5593.8,7524.5 3034.5,7559.3 3049.1,4951.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78504705163382,
+                36.157754272692834
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78163665633677,
+                36.15919273827942
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7794815639018,
+                36.15581471590989
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78289195919885,
+                36.1543762503233
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p55",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1340.1,286.8 5580.3,331.2 5621.8,7374.7 1405.4,6227.0 1263.3,6749.2 1340.1,286.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78287098417012,
+                36.15872363572096
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.779448774041,
+                36.16019815212618
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77723964253109,
+                36.15680847028079
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7806618526602,
+                36.15533395387557
               ]
             }
           }
@@ -6158,15 +6843,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6185,34 +6870,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5959.9,8040.0 3553.3,8040.0 3576.6,4923.8 768.0,4908.0 760.9,157.1 3606.7,119.9 3575.2,3528.9 6002.0,3348.4 5959.9,8040.0\" /></svg>"
+          "value": "<svg><polygon points=\"6002.0,3350.1 5959.9,8040.0 3553.3,8040.0 3576.6,4923.8 768.0,4908.0 760.9,157.1 3606.7,119.9 3575.2,3530.6 6002.0,3350.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0056/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                768.0,
-                4908.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.778569,
-                36.1578508
+                -86.78032298930961,
+                36.15972631938944
               ]
             }
           },
@@ -6220,20 +6908,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5988.0,
-                4908.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7758725,
-                36.1590163
+                -86.77691362149352,
+                36.1611999400791
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77469023243535,
+                36.15784667157416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77809960025144,
+                36.156373050884504
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p57",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5270.1,7281.5 1372.1,7270.2 1458.3,3838.5 3836.8,3892.0 3852.7,3415.3 5377.0,3443.1 5270.1,7281.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7781068623442,
+                36.16089261559406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77477484706722,
+                36.162410077046594
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77250130798353,
+                36.15910982998076
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77583332326051,
+                36.15759236852822
               ]
             }
           }
@@ -6251,15 +7119,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6278,34 +7146,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"975.3,7174.7 974.2,3408.4 -0.0,3423.7 -0.0,3423.7 2490.6,3384.6 2538.8,0.0 6600.0,0.0 6600.0,8040.0 2452.6,8040.0 2444.2,7331.4 975.3,7174.7\" /></svg>"
+          "value": "<svg><polygon points=\"1037.2,7194.3 989.5,3448.6 2497.4,3406.1 2503.2,0.0 6600.0,0.0 6600.0,8040.0 2517.2,8040.0 2500.0,7332.0 1037.2,7194.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0058/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                968.0,
-                5344.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7738921,
-                36.1598917
+                -86.77587177419178,
+                36.16198371289243
               ]
             }
           },
@@ -6313,20 +7184,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                968.0,
-                632.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7751818,
-                36.161894
+                -86.77235706217027,
+                36.163414906548375
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77019766217026,
+                36.15995806654837
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77371237419177,
+                36.15852687289242
               ]
             }
           }
@@ -6344,11 +7257,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -6367,8 +7280,8 @@
           "value": "8040.0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6387,34 +7300,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"754.2,8040.0 -0.0,5540.7 -0.0,1077.6 -0.0,624.1 5017.1,263.2 6446.9,1314.0 6600.0,8040.0 754.2,8040.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5540.7 -0.0,624.1 5017.1,263.2 6446.9,1314.0 6496.2,2648.6 6600.0,2503.9 6600.0,8040.0 754.2,8040.0 -0.0,5540.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0059__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3144.0,
-                628.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7848859,
-                36.1526002
+                -86.78541160025635,
+                36.15403080790853
               ]
             }
           },
@@ -6422,20 +7338,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                712.0,
-                628.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7855402,
-                36.1536013
+                -86.7836359505853,
+                36.15131400692171
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78773474614259,
+                36.14956744864493
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78951039581364,
+                36.152284249631755
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p6",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,0.0 6600.0,0.0 6600.0,3464.1 3075.1,7161.0 1117.6,7168.1 -0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78737609470986,
+                36.1639523221765
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78393596114154,
+                36.16537860277871
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78179897733007,
+                36.16197135846866
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78523911089839,
+                36.16054507786645
               ]
             }
           }
@@ -6453,15 +7549,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6480,34 +7576,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"315.6,2121.9 2124.1,944.4 3546.6,946.9 4773.8,1807.4 4837.0,791.5 6600.0,901.2 6600.0,4751.0 6106.9,7315.7 6600.0,7357.2 6600.0,8040.0 -0.0,8040.0 315.6,2121.9\" /></svg>"
+          "value": "<svg><polygon points=\"165.4,2289.1 1142.9,0.0 3296.3,0.0 6600.0,3089.2 6600.0,3827.3 6600.0,4664.1 6136.0,7240.0 2915.7,8040.0 -0.0,8040.0 -0.0,7217.7 165.4,2289.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0060/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4968.0,
-                5692.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7830242,
-                36.1517009
+                -86.78545348163235,
+                36.154690961508116
               ]
             }
           },
@@ -6515,20 +7614,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                316.0,
-                2120.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7855402,
-                36.1536013
+                -86.7816006866687,
+                36.15426429808937
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78224438658148,
+                36.150474622078626
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78609718154513,
+                36.15090128549737
               ]
             }
           }
@@ -6546,15 +7687,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6573,34 +7714,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"138.6,1679.8 2717.3,1511.3 2740.5,2014.3 6600.0,1774.3 6600.0,2880.9 6243.2,3412.2 6312.5,6023.0 21.2,7311.9 241.2,8040.0 0.0,8040.0 0.0,2184.7 127.8,2176.7 138.6,1679.8\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,8040.0 0.0,1172.5 138.7,1679.8 2717.3,1511.3 2743.9,2086.5 4303.5,2050.1 4492.4,1759.8 4480.0,1508.4 4114.8,1161.1 4067.3,0.0 6600.0,0.0 6600.0,2880.9 6243.2,3412.2 6312.5,6023.0 94.1,7296.8 241.2,8040.0 0.0,8040.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0061/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1740.0,
-                1568.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7823657,
-                36.1516366
+                -86.78343409750248,
+                36.150943159188934
               ]
             }
           },
@@ -6608,20 +7752,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                900.0,
-                7132.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.779233,
-                36.1508275
+                -86.78282043868766,
+                36.15402053817019
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77817764736201,
+                36.15341693290114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77879130617683,
+                36.150339553919885
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p62",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,1243.6 -0.0,0.0 5134.2,0.0 5611.3,730.7 6600.0,94.4 6600.0,381.5 5753.8,951.6 6440.6,2017.2 4208.2,3451.5 5657.6,5615.0 4388.4,6543.7 4019.5,7335.3 3515.6,7577.7 3299.5,8040.0 2497.0,8040.0 2375.8,7138.2 703.0,7456.3 793.9,4788.1 1188.3,4268.6 1366.0,1329.3 0.0,1243.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78365385688555,
+                36.1534487016818
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78328386428092,
+                36.15650425760871
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77870617848377,
+                36.1561377681169
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7790761710884,
+                36.15308221218999
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p63",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3781.2,5609.8 1538.7,5187.6 1793.5,4417.7 1418.6,4063.5 1346.0,3503.2 739.0,2967.7 -0.0,561.0 0.0,0.0 4529.4,0.0 5779.1,4619.8 6600.0,4414.9 6600.0,7600.0 5917.6,7369.6 5547.0,7548.5 3857.7,6228.8 3781.2,5609.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78043127572451,
+                36.15641230573474
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77678607289944,
+                36.15707984176343
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77578599916187,
+                36.15346916498685
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77943120198694,
+                36.152801628958166
               ]
             }
           }
@@ -6639,15 +8101,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6666,34 +8128,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3481.0,423.0 3498.2,3528.8 5896.6,3497.6 5884.0,8040.0 1359.5,8040.0 1526.7,7419.7 803.8,7412.7 681.8,443.6 3481.0,423.0\" /></svg>"
+          "value": "<svg><polygon points=\"1531.9,7419.8 803.8,7412.7 716.0,7412.0 681.8,443.6 3481.0,423.0 3498.2,3528.8 5896.6,3497.6 5884.0,8040.0 1367.9,8040.0 1531.9,7419.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0064/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                716.0,
-                7412.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7766648,
-                36.1549221
+                -86.77904490600527,
+                36.15788867479065
               ]
             }
           },
@@ -6701,20 +8166,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5884.0,
-                376.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7758725,
-                36.1590163
+                -86.77560063310435,
+                36.15933122345322
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7734241767046,
+                36.1559435442184
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77686844960552,
+                36.15450099555583
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p65",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"832.6,1199.4 4675.0,1093.0 6157.0,1256.3 6163.1,1974.9 6600.0,1981.9 6600.0,8040.0 -0.0,8040.0 -0.0,6976.1 799.0,6979.7 832.6,1199.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77611911772807,
+                36.15854437623073
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77268356500711,
+                36.159999054181654
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77048878188351,
+                36.156619992745696
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77392433460447,
+                36.15516531479477
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p66",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"952.5,1896.8 4690.3,1947.4 4716.6,0.0 6600.0,0.0 6600.0,8040.0 966.8,8007.5 952.5,1896.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77314576662933,
+                36.15975018269521
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7697356212559,
+                36.1611859189374
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7675694030347,
+                36.15783186858268
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77097954840812,
+                36.1563961323405
               ]
             }
           }
@@ -6732,15 +8515,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6759,34 +8542,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"290.0,8040.0 249.6,205.7 157.4,0.0 3263.1,0.0 3446.9,580.4 5293.8,1542.1 5615.1,1303.4 6286.1,1397.5 6032.4,0.0 6600.0,0.0 6600.0,8040.0 290.0,8040.0\" /></svg>"
+          "value": "<svg><polygon points=\"290.0,8040.0 249.6,205.7 157.4,0.0 3263.1,0.0 3446.9,580.4 5293.8,1542.1 5615.1,1303.4 6307.0,1401.2 6045.7,0.0 6600.0,0.0 6600.0,8040.0 290.0,8040.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0067/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6368.0,
-                5272.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7757245,
-                36.151844
+                -86.77954826236011,
+                36.15422059234281
               ]
             }
           },
@@ -6794,20 +8580,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6368.0,
-                7224.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7756839,
-                36.1509257
+                -86.77569899997968,
+                36.154331548587805
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77553160305666,
+                36.150545327049365
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77938086543709,
+                36.15043437080437
               ]
             }
           }
@@ -6815,25 +8643,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0007/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p7",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p8",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T13:59:07Z",
-      "modified": "2026-08-07T13:59:07Z",
+      "created": "2026-08-15T01:17:56Z",
+      "modified": "2026-08-15T01:17:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6842,44 +8670,47 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0007/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0007/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/info.json",
           "type": "ImageService2",
           "height": 8040,
           "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 6404.2,-0.0 6348.7,7292.6 212.7,7205.7 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5866.4,717.7 5676.9,7299.1 -0.0,7221.5 0.0,0.0 3946.9,0.0 3934.8,736.1 5866.4,717.7\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0007/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6384.0,
-                2804.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7835152,
-                36.163476
+                -86.78346379321721,
+                36.16538086211904
               ]
             }
           },
@@ -6887,20 +8718,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6384.0,
-                532.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7829065,
-                36.1637488
+                -86.7818144038186,
+                36.16609012282924
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7807441857335,
+                36.164468010063274
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7823935751321,
+                36.16375874935307
               ]
             }
           }

--- a/gallery/new_orleans_la_1896_vol_2.iiif.json
+++ b/gallery/new_orleans_la_1896_vol_2.iiif.json
@@ -7,25 +7,41 @@
   "label": "Mosaic of main content, New Orleans, La. | 1896 | Vol. 2",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0125/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0101__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p125",
+      "label": "New Orleans, La. | 1896 | Vol. 2 p101 [1]",
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
           "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6387.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -34,21 +50,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0125/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0101__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0125/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0101/info.json",
           "type": "ImageService2",
-          "height": 7796,
-          "width": 6245
+          "height": 7795,
+          "width": 6387
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3072.2 -0.0,392.5 2223.5,407.4 2226.4,0.0 4480.7,0.0 4480.8,422.2 6245.0,433.7 6245.0,7006.6 4455.3,5842.4 4348.8,4882.9 2881.4,4897.4 -0.0,3072.2\" /></svg>"
+          "value": "<svg><polygon points=\"442.0,4479.8 644.3,2123.0 1067.1,2312.4 878.8,1649.4 672.5,1563.9 924.8,0.0 6387.0,0.0 6387.0,6902.9 5921.2,7049.7 6051.2,7324.2 3256.3,7491.3 442.2,7487.3 442.0,4479.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0125/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0101__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -73,8 +89,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0696479,
-                29.9308242
+                -90.0662016646514,
+                29.952065365569883
               ]
             }
           },
@@ -82,7 +98,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6245.0,
+                6387.0,
                 0.0
               ],
               "creator": {
@@ -94,8 +110,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0664683,
-                29.9301363
+                -90.06293249945787,
+                29.951313302169773
               ]
             }
           },
@@ -103,8 +119,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6245.0,
-                7796.0
+                6387.0,
+                7795.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -115,8 +131,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0674593,
-                29.9266958
+                -90.06399178077304,
+                29.947856346149727
               ]
             }
           },
@@ -125,7 +141,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7796.0
+                7795.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -136,8 +152,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0706389,
-                29.9273837
+                -90.06726094596657,
+                29.948608409549838
               ]
             }
           }
@@ -145,25 +161,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0102/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p164",
+      "label": "New Orleans, La. | 1896 | Vol. 2 p102",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -172,21 +188,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0102/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0102/info.json",
           "type": "ImageService2",
           "height": 7795,
-          "width": 6432
+          "width": 6428
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"334.6,1532.4 4363.2,1382.5 6432.0,4683.3 6432.0,7385.1 6090.4,7739.0 5026.4,7795.0 2058.4,6631.5 1671.5,6626.3 1593.0,5955.9 361.1,3346.3 334.6,1532.4\" /></svg>"
+          "value": "<svg><polygon points=\"833.3,7434.2 858.2,1901.6 1134.9,0.0 6084.1,0.0 5821.7,1515.9 6027.4,1603.6 6209.1,2269.2 5787.7,2075.2 5560.9,4432.3 5530.0,7442.9 833.3,7434.2\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0102/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -211,8 +227,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0810593,
-                29.9459841
+                -90.0688564404382,
+                29.952623983133442
               ]
             }
           },
@@ -220,7 +236,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6432.0,
+                6428.0,
                 0.0
               ],
               "creator": {
@@ -232,8 +248,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0791741,
-                29.9483512
+                -90.06556144845206,
+                29.951897436401424
               ]
             }
           },
@@ -241,7 +257,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6432.0,
+                6428.0,
                 7795.0
               ],
               "creator": {
@@ -253,8 +269,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0758629,
-                29.9463712
+                -90.06657843034235,
+                29.948434881870906
               ]
             }
           },
@@ -274,146 +290,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0777481,
-                29.9440041
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p181",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6537
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"921.2,818.0 4443.6,951.4 4416.3,800.5 5832.0,784.1 5850.2,7157.5 3325.9,7200.0 1344.5,7795.0 778.6,7795.0 705.4,6622.7 -0.0,6602.7 -0.0,864.9 921.2,818.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0905859,
-                29.9565429
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6537.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0884648,
-                29.9588658
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6537.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0852668,
-                29.9566738
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0873879,
-                29.9543509
+                -90.06987342232848,
+                29.949161428602924
               ]
             }
           }
@@ -438,8 +316,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -458,7 +336,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6428.0,1852.2 6428.0,7795.0 3789.4,7795.0 1880.1,7492.2 1820.6,178.7 3724.7,238.2 6428.0,1852.2\" /></svg>"
+          "value": "<svg><polygon points=\"6428.0,1849.2 6428.0,7795.0 3792.4,7795.0 3663.7,7729.3 1882.6,7492.6 1818.8,178.1 3722.9,236.4 6428.0,1849.2\" /></svg>"
         }
       },
       "body": {
@@ -487,8 +365,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07271827498059,
-                29.951744317216036
+                -90.07271819897642,
+                29.951745472972704
               ]
             }
           },
@@ -508,8 +386,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07184005650736,
-                29.954586308978612
+                -90.0718380652087,
+                29.954586561169027
               ]
             }
           },
@@ -529,8 +407,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06788978128891,
-                29.953656936187972
+                -90.06788904591768,
+                29.953655161522153
               ]
             }
           },
@@ -550,8 +428,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06876799976214,
-                29.950814944425396
+                -90.0687691796854,
+                29.95081407332583
               ]
             }
           }
@@ -576,8 +454,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +474,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"811.8,206.7 6428.0,224.6 6428.0,7573.9 811.9,7526.8 811.8,206.7\" /></svg>"
+          "value": "<svg><polygon points=\"811.7,208.6 6428.0,224.2 6428.0,7573.0 814.8,7528.4 811.7,208.6\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +503,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0733174835073,
-                29.949711256417043
+                -90.07331861287568,
+                29.94971155155381
               ]
             }
           },
@@ -646,8 +524,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07249280251972,
-                29.952553115422944
+                -90.07249257136287,
+                29.9525532440052
               ]
             }
           },
@@ -667,8 +545,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06854278920314,
-                29.951680381465014
+                -90.06854278954707,
+                29.9516790702462
               ]
             }
           },
@@ -688,8 +566,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06936747019071,
-                29.948838522459113
+                -90.06936883105988,
+                29.948837377794813
               ]
             }
           }
@@ -714,8 +592,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +612,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5437.3,182.4 5515.6,0.0 6098.2,198.7 6101.5,0.0 6428.0,0.0 6428.0,7795.0 5320.3,7781.1 2186.7,7335.8 1655.3,3851.8 1733.5,2822.9 1566.1,1863.9 1325.5,1852.8 1031.4,152.5 5437.3,182.4\" /></svg>"
+          "value": "<svg><polygon points=\"5438.6,181.3 5517.7,0.0 6100.5,197.6 6103.8,0.0 6428.0,0.0 6428.0,7795.0 5321.3,7781.4 2187.1,7335.9 1655.8,3851.2 1734.0,2822.1 1566.6,1862.9 1325.9,1851.8 1031.8,151.2 5438.6,181.3\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +641,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07588279985967,
-                29.954502248298276
+                -90.0758822927702,
+                29.954501756694018
               ]
             }
           },
@@ -784,8 +662,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07386180073465,
-                29.956838197457273
+                -90.0738618031632,
+                29.956837328889883
               ]
             }
           },
@@ -805,8 +683,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0706148461831,
-                29.95469952032018
+                -90.070615372588,
+                29.954699190938847
               ]
             }
           },
@@ -826,8 +704,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07263584530813,
-                29.952363571161182
+                -90.072635862195,
+                29.952363618742982
               ]
             }
           }
@@ -852,8 +730,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +750,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1118.0,695.4 6462.6,1583.3 6337.5,3313.1 5871.7,4230.5 5027.3,7642.0 0.0,7628.2 569.2,4081.3 569.9,3919.4 583.6,3919.4 904.3,1993.3 526.4,1495.9 1024.3,1431.3 1118.0,695.4\" /></svg>"
+          "value": "<svg><polygon points=\"1115.4,702.0 6459.7,1592.8 6338.0,3312.2 5872.5,4230.1 5029.4,7642.6 0.0,7630.9 903.2,1994.6 525.0,1497.2 1023.0,1432.4 1115.4,702.0\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +779,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07666994255133,
-                29.951934052171673
+                -90.07667028656776,
+                29.951935141905302
               ]
             }
           },
@@ -922,8 +800,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07582008115281,
-                29.954806031111126
+                -90.07581918213944,
+                29.9548062371731
               ]
             }
           },
@@ -943,8 +821,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07186990239491,
-                29.953916083926142
+                -90.07187021880166,
+                29.95391498832778
               ]
             }
           },
@@ -964,8 +842,698 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07271976379344,
-                29.95104410498669
+                -90.07272132322998,
+                29.951043893059985
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0107/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p107",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0107/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0107/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6428
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1815.3,7795.0 1553.9,7656.5 -0.0,7649.0 -0.0,6071.4 333.7,6069.2 295.3,0.0 3969.6,553.2 3990.3,2849.4 6423.8,2834.2 6428.0,7654.3 1815.3,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0107/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07475982933839,
+                29.951773052706688
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6428.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07148059990733,
+                29.951021771415654
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6428.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07253218689665,
+                29.947575725200686
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07581141632771,
+                29.94832700649172
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0108/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p108",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0108/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0108/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6361
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"949.8,7549.8 908.0,259.3 5727.0,217.2 5836.7,7491.2 949.8,7549.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0108/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07275961606885,
+                29.947265247638718
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6361.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07188911431193,
+                29.950075121312164
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6361.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06791404067033,
+                29.94915054939492
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06878454242725,
+                29.946340675721473
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0109/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p109",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0109/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0109/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6350
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"847.7,7279.1 847.6,6978.1 275.6,6791.1 847.4,6591.7 846.2,3776.7 836.1,1705.0 622.3,1700.0 248.5,627.8 830.7,613.0 830.3,529.7 5735.9,562.3 5733.3,7279.3 847.7,7279.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0109/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07410425785493,
+                29.948254665717812
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6350.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07086770073545,
+                29.947528240185903
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6350.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07189662987673,
+                29.94408623444299
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07513318699621,
+                29.9448126599749
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0110/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p110",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0110/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0110/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6488
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5615.2,7271.7 704.0,7255.1 704.0,503.9 5589.6,513.4 5615.2,7271.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0110/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07154547575048,
+                29.947651800724667
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6488.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06825668541255,
+                29.946912432452343
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6488.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06928198873005,
+                29.943488173388364
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07257077906799,
+                29.944227541660688
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0111/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p111",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0111/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0111/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6350
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5409.2,3175.1 6350.0,6579.0 6350.0,7251.9 373.9,7214.2 348.6,623.1 5466.1,670.1 5409.2,3175.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0111/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06823666101239,
+                29.94926775368156
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6350.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06501809124512,
+                29.94855462996621
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6350.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06602820367448,
+                29.945131835872576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06924677344175,
+                29.945844959587927
               ]
             }
           }
@@ -990,8 +1558,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1010,7 +1578,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2924.3,125.5 2902.2,0.0 6340.0,0.0 6340.0,7795.0 3556.0,7795.0 3345.0,7007.7 -0.0,7004.0 -0.0,478.6 2788.5,414.9 2661.5,142.0 2924.3,125.5\" /></svg>"
+          "value": "<svg><polygon points=\"2663.2,142.8 2926.0,126.3 2903.7,0.0 6340.0,0.0 6340.0,7795.0 3557.3,7795.0 3346.6,7008.6 2185.1,7012.0 869.1,7007.7 869.3,6370.4 -0.0,3219.1 -0.0,479.4 2790.2,415.7 2663.2,142.8\" /></svg>"
         }
       },
       "body": {
@@ -1039,8 +1607,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06547762246562,
-                29.94861224241752
+                -90.0654783587575,
+                29.948612763753648
               ]
             }
           },
@@ -1060,8 +1628,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06222012223584,
-                29.947881234828202
+                -90.06222091838424,
+                29.94788182509929
               ]
             }
           },
@@ -1081,8 +1649,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06325023863144,
-                29.944385928957608
+                -90.06325093763853,
+                29.94438658345488
               ]
             }
           },
@@ -1102,8 +1670,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06650773886122,
-                29.945116936546924
+                -90.06650837801179,
+                29.945117522109236
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0113/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p113",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0113/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0113/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6356
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"580.1,7795.0 590.7,232.8 5711.8,227.7 5706.0,7557.8 4850.7,7795.0 4073.7,7795.0 4076.8,6972.1 3646.0,6971.2 580.1,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0113/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06985110330027,
+                29.94358575195436
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6356.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06901188016556,
+                29.946365801348772
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6356.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06507663739522,
+                29.94547386407392
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06591586052993,
+                29.942693814679508
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0114/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p114",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0114/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0114/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6305
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,3474.9 808.8,3241.6 797.4,819.9 3824.3,0.0 4251.6,0.0 4249.9,1030.1 5868.9,577.6 5877.6,1749.3 5080.1,1968.1 5092.8,4775.1 6305.0,4765.6 6305.0,7795.0 0.0,7795.0 0.0,3474.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0114/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0663633776534,
+                29.94269748943336
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6305.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06551756360741,
+                29.945476036001324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6305.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06155202300003,
+                29.944569674555897
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06239783704602,
+                29.941791127987933
               ]
             }
           }
@@ -1128,8 +1972,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1148,7 +1992,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"652.5,1464.9 750.3,230.9 6315.3,190.5 6332.0,6782.5 3964.1,7727.5 3329.5,7529.3 0.0,7578.6 0.0,2707.2 330.3,2690.4 652.5,1464.9\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,7553.5 87.5,0.0 418.4,0.0 421.3,237.1 6313.2,187.2 6331.5,6779.0 3963.8,7724.5 3605.4,7522.8 0.0,7553.5\" /></svg>"
         }
       },
       "body": {
@@ -1177,8 +2021,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0718344297266,
-                29.94135147124828
+                -90.07183319319554,
+                29.941352119362907
               ]
             }
           },
@@ -1198,8 +2042,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07098365841244,
-                29.944141799699324
+                -90.0709816690682,
+                29.944142328604162
               ]
             }
           },
@@ -1219,8 +2063,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06705672553396,
-                29.943230031350296
+                -90.06705490395808,
+                29.943229753468128
               ]
             }
           },
@@ -1240,8 +2084,1802 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06790749684811,
-                29.94043970289925
+                -90.06790642808542,
+                29.940439544226873
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0116/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p116",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0116/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0116/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6349
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6349.0,1822.2 6349.0,2169.6 4261.0,7263.3 801.3,6900.0 806.4,300.2 3666.2,1462.0 3921.1,1786.6 6349.0,1822.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0116/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06805696626174,
+                29.94032580770758
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6349.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06850501226286,
+                29.943167212761306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6349.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06447800356918,
+                29.94364402018837
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06402995756805,
+                29.940802615134643
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p119",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6262
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4116.0,0.0 5296.0,0.0 6221.3,358.3 6262.0,7796.0 0.0,7796.0 0.0,2721.0 1227.9,1909.3 1544.6,1077.4 1554.5,1693.4 4116.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06799648917132,
+                29.93704428586004
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6262.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06838056230852,
+                29.939873736319406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6262.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06434538273584,
+                29.940290887352603
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06396130959864,
+                29.937461436893233
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0120/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p120",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0120/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0120/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6509
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4740.3,398.1 6509.0,1092.6 6509.0,7795.0 0.0,7541.6 0.0,1035.0 416.7,0.0 2617.9,0.0 4740.3,398.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0120/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0680661768912,
+                29.9377371448739
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6509.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06852109271766,
+                29.94063888068123
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6509.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06450975879697,
+                29.94111110535083
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0640548429705,
+                29.9382093695435
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0121/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p121",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0121/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0121/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6288
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1070.0,3071.6 1237.6,3138.7 2483.1,0.0 6288.0,0.0 6288.0,7796.0 3148.2,7796.0 3212.0,6198.1 286.3,5043.0 1070.0,3071.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0121/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06803741434018,
+                29.935564109175104
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6288.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06479493007308,
+                29.935931777796608
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6288.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06426890752525,
+                29.932448014184356
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06751139179235,
+                29.932080345562852
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0123/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p123",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0123/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0123/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6321
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3007.1,7795.0 3045.6,5004.6 1890.9,4996.7 1330.3,4993.0 1312.2,543.9 4753.6,550.5 5529.1,2783.8 5517.5,7281.7 5307.2,7280.1 5302.1,7795.0 3007.1,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0123/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06831630543337,
+                29.933748152453266
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6321.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06509399482029,
+                29.93305314340088
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6321.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0660832546891,
+                29.929608399214832
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06930556530219,
+                29.930303408267218
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0124/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p124",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0124/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0124/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"594.1,7276.5 536.1,2799.6 269.5,2068.8 3131.7,894.2 2764.6,0.0 6481.0,0.0 6481.0,6840.6 3221.1,6859.2 3228.5,7255.1 594.1,7276.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0124/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.065745304101,
+                29.933210842114228
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06243937516155,
+                29.9324504256963
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06349503508659,
+                29.929003637371405
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06680096402604,
+                29.929764053789334
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0125/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p125",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0125/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0125/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6245
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6245.0,7796.0 2934.6,7796.0 238.2,6192.8 197.2,2690.3 2015.8,2671.5 1989.0,504.8 4543.2,476.3 4559.2,2645.5 6245.0,2627.9 6245.0,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0125/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07026351139257,
+                29.93313326792419
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6245.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06703858719226,
+                29.9323861987401
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6245.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06810734991393,
+                29.928872076142678
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07133227411424,
+                29.929619145326768
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0126/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p126",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0126/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0126/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"190.8,5990.1 -0.0,5865.2 -0.0,406.2 2866.8,399.2 2861.6,0.0 6447.0,0.0 6447.0,7795.0 168.3,7795.0 190.8,5990.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0126/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06648136845546,
+                29.93012581527216
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06321420691705,
+                29.92939159219522
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06423850876665,
+                29.925968139867113
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06750567030505,
+                29.926702362944052
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0127/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p127",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0127/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0127/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6146
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 188.9,0.0 137.2,798.6 6146.0,1134.6 6146.0,7796.0 -0.0,7796.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0127/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07301906036164,
+                29.92472367344688
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6146.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0707493811995,
+                29.9263966242416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6146.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06830003331171,
+                29.92390065970048
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07056971247385,
+                29.92222770890576
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0128/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p128",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0128/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0128/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6448
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5493.7,729.4 5526.1,1207.9 6320.9,671.5 6270.1,0.0 6448.0,0.0 6448.0,2881.3 4931.8,3846.7 6448.0,6163.7 6448.0,7796.0 -0.0,7796.0 -0.0,1115.0 2960.0,794.9 5493.7,729.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0128/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07069931144967,
+                29.926468986529716
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6448.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06819058455505,
+                29.92844488723861
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6448.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0654340741055,
+                29.92581611800759
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06794280100011,
+                29.923840217298697
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0129/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p129",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0129/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0129/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,374.9 6335.0,296.7 6335.0,7320.7 5828.2,7354.0 5871.4,7796.0 5641.8,7796.0 5613.5,7359.3 -0.0,7408.6 -0.0,374.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0129/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07501694304416,
+                29.927181301577093
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07237630610761,
+                29.92888562777771
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06995662438915,
+                29.926069732530898
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0725972613257,
+                29.92436540633028
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0130/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p130",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0130/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0130/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6444
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3779.0,363.5 4601.0,0.0 5384.3,0.0 5504.6,2740.5 6444.0,4153.4 6444.0,6887.4 5708.0,7395.6 5670.2,6914.3 3120.0,7007.7 648.9,7372.8 1254.6,408.9 3779.0,363.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0130/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0729156490545,
+                29.92853945672111
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6444.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07040127604202,
+                29.930477335476024
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6444.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0676961066431,
+                29.927841037843983
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07021047965557,
+                29.92590315908907
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0131/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p131",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0131/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0131/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6352
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7795.0 55.2,606.3 5819.0,608.9 6032.7,7247.4 168.7,7216.7 162.4,7795.0 -0.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0131/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07725950200516,
+                29.92960359954825
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6352.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07461508973941,
+                29.931349182171772
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6352.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07214300084235,
+                29.928536451357907
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0747874131081,
+                29.926790868734386
               ]
             }
           }
@@ -1266,8 +3904,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1286,7 +3924,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4966.3,382.5 6224.3,2278.2 6444.0,7594.2 6135.8,7796.0 4754.4,7796.0 136.8,7354.8 465.4,682.3 4966.3,382.5\" /></svg>"
+          "value": "<svg><polygon points=\"4367.3,703.7 4964.6,380.2 6051.1,2016.1 6444.0,1757.7 6444.0,5351.9 4700.2,6513.7 4719.2,6993.7 3933.7,6984.3 3420.8,7299.1 135.8,7357.3 461.9,681.8 4367.3,703.7\" /></svg>"
         }
       },
       "body": {
@@ -1315,8 +3953,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07505994123338,
-                29.931070491010384
+                -90.07505824297517,
+                29.93107149590904
               ]
             }
           },
@@ -1336,8 +3974,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07258459150462,
-                29.933026346032666
+                -90.07258303595232,
+                29.933025691437813
               ]
             }
           },
@@ -1357,8 +3995,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06987336437327,
-                29.930412741216024
+                -90.06987410922858,
+                29.9304122372976
               ]
             }
           },
@@ -1378,8 +4016,560 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.072348714102,
-                29.928456886193747
+                -90.07234931625143,
+                29.928458041768828
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0133/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p133",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0133/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0133/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6358
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6015.6,0.0 6016.5,317.2 6358.0,317.0 6358.0,7429.9 6037.8,7437.1 6032.7,4821.0 3799.7,4835.5 3797.7,2972.8 2281.0,2981.6 4264.2,0.0 6015.6,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0133/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07252705826335,
+                29.9305683836118
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6358.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07169989164645,
+                29.933353743105066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6358.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0677601592544,
+                29.93247505052206
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0685873258713,
+                29.929689691028795
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0134/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p134",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0134/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0134/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6444
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5505.4,349.5 5498.0,1440.9 4944.4,1441.2 4948.6,7796.0 3192.5,7796.0 3191.4,7464.1 1254.2,7500.7 1280.0,337.0 5505.4,349.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0134/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07187196913455,
+                29.932798049918272
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6444.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07105133148896,
+                29.935603059526546
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6444.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06713545706215,
+                29.93474268086693
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06795609470774,
+                29.931937671258655
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0135/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p135",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0135/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0135/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6321
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6750.2 -0.0,2887.0 234.5,2962.6 230.2,3320.9 1083.7,797.4 6321.0,816.2 6321.0,7275.2 195.6,7284.4 198.7,6750.7 -0.0,6750.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0135/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07255521231347,
+                29.938899168974693
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6321.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06935565498505,
+                29.938190337768717
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6321.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0703646630248,
+                29.934770168482352
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07356422035323,
+                29.93547899968833
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0136/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p136",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0136/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0136/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6443
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"313.2,830.1 1506.9,832.7 1549.4,0.0 5600.1,0.0 5957.8,857.4 6443.0,671.2 6443.0,7428.8 6264.4,7428.4 6264.2,7796.0 -0.0,7796.0 -0.0,7250.1 296.2,7252.3 313.2,830.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0136/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06951398638296,
+                29.938233765311036
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6443.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06623034154738,
+                29.93751431456916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6443.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06723475237513,
+                29.934071778864457
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0705183972107,
+                29.934791229606333
               ]
             }
           }
@@ -1404,8 +4594,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1424,7 +4614,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2837.9,7216.6 933.1,6608.2 2213.8,2771.7 2880.4,2938.9 2880.9,3749.9 3205.7,2895.3 3162.9,27.2 4403.6,126.5 5635.5,451.2 5705.3,7151.6 6349.0,7147.0 6349.0,7796.0 3004.8,7796.0 2995.8,6371.2 3247.4,6368.7 3245.4,6105.6 2895.1,5991.9 2837.9,7216.6\" /></svg>"
+          "value": "<svg><polygon points=\"2890.1,2943.1 2876.6,3749.2 3213.0,2906.5 3218.4,798.0 5669.8,851.7 5601.0,7197.9 3186.2,7164.7 3194.0,6372.0 2925.2,6369.3 2910.7,7796.0 -0.0,7796.0 -0.0,6240.1 898.6,6558.0 2233.1,2762.8 2890.1,2943.1\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +4643,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07319884534786,
-                29.9420329481592
+                -90.07324984473767,
+                29.94202318887142
               ]
             }
           },
@@ -1474,8 +4664,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07001752394363,
-                29.94129658050002
+                -90.0700199048926,
+                29.94133787994894
               ]
             }
           },
@@ -1495,8 +4685,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07105381780546,
-                29.93788709260611
+                -90.07099115377922,
+                29.93790055879329
               ]
             }
           },
@@ -1516,8 +4706,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07423513920969,
-                29.93862346026529
+                -90.07422109362429,
+                29.938585867715773
               ]
             }
           }
@@ -1542,8 +4732,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1562,7 +4752,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4884.3,995.1 4893.2,3390.5 6133.0,6464.8 4885.4,6466.4 4840.7,7302.8 -0.0,7296.7 23.2,933.1 4884.3,995.1\" /></svg>"
+          "value": "<svg><polygon points=\"35.3,923.9 4900.0,987.8 4909.7,3329.1 6148.3,6460.1 4900.2,6461.5 4855.4,7298.2 -0.0,7291.3 35.3,923.9\" /></svg>"
         }
       },
       "body": {
@@ -1591,8 +4781,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07036375171485,
-                29.941447924565047
+                -90.07037181979334,
+                29.941445882442483
               ]
             }
           },
@@ -1612,8 +4802,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.06711127255748,
-                29.940731372664093
+                -90.067120477244,
+                29.940730037714932
               ]
             }
           },
@@ -1633,8 +4823,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0681034192152,
-                29.937301790243176
+                -90.06811164474064,
+                29.937301653792368
               ]
             }
           },
@@ -1654,8 +4844,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07135589837256,
-                29.93801834214413
+                -90.07136298728997,
+                29.93801749851992
               ]
             }
           }
@@ -1680,8 +4870,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1700,7 +4890,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"163.9,3955.7 1331.2,3966.0 1330.0,3658.0 163.0,3655.1 154.2,895.0 6340.0,888.5 6340.0,7171.6 4477.2,7795.0 3450.5,7795.0 4212.2,7544.0 4163.2,6866.4 164.1,6849.0 163.9,3955.7\" /></svg>"
+          "value": "<svg><polygon points=\"165.8,6849.4 165.9,3956.6 1333.0,3967.0 1331.9,3659.0 165.0,3656.0 156.6,896.3 6340.0,890.5 6340.0,3589.3 5555.1,3582.1 5681.4,3952.1 6340.0,3948.5 6340.0,7172.9 4480.2,7795.0 3453.3,7795.0 4213.1,7544.7 4164.3,6867.2 165.8,6849.4\" /></svg>"
         }
       },
       "body": {
@@ -1729,8 +4919,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07666685689559,
-                29.940681809304238
+                -90.0766682208446,
+                29.94068120964697
               ]
             }
           },
@@ -1750,8 +4940,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07485314201108,
-                29.94311315016355
+                -90.07485454411828,
+                29.943113138544327
               ]
             }
           },
@@ -1771,8 +4961,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07142715532183,
-                29.941166919371014
+                -90.07142772882844,
+                29.941166948697948
               ]
             }
           },
@@ -1792,8 +4982,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07324087020633,
-                29.9387355785117
+                -90.07324140555475,
+                29.938735019800593
               ]
             }
           }
@@ -1818,8 +5008,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,7 +5028,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1619.3,1400.2 4759.2,2377.1 5731.1,0.0 5959.1,0.0 6027.5,7416.8 0.0,7467.9 0.0,6345.0 1619.3,1400.2\" /></svg>"
+          "value": "<svg><polygon points=\"640.2,4329.6 0.0,4118.6 0.0,3720.4 759.1,3983.0 1652.9,1378.5 4793.6,2382.8 5808.1,0.0 6028.4,0.0 6002.5,7422.6 0.0,7420.3 0.0,6195.0 640.2,4329.6\" /></svg>"
         }
       },
       "body": {
@@ -1867,8 +5057,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07537212307565,
-                29.94235196775491
+                -90.07536158759324,
+                29.942328177710145
               ]
             }
           },
@@ -1888,8 +5078,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07452137549134,
-                29.945134489390885
+                -90.07454377210297,
+                29.945106735354
               ]
             }
           },
@@ -1909,8 +5099,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07065171778395,
-                29.944233542232325
+                -90.07065238266686,
+                29.944246727051144
               ]
             }
           },
@@ -1930,8 +5120,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07150246536825,
-                29.94145102059635
+                -90.07147019815713,
+                29.94146816940729
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0141/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p141",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0141/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0141/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6353
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,0.0 310.0,-0.0 302.5,1177.5 2258.1,1185.1 2773.0,2658.0 5528.8,1695.2 5070.4,339.8 5325.7,253.5 5580.7,1006.4 6353.0,748.4 6353.0,3413.5 6242.2,3072.5 5995.7,3075.9 6353.0,4132.3 6353.0,7795.0 6172.4,7795.0 6163.1,6768.9 330.8,6750.3 339.9,7795.0 -0.0,7795.0 -0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0141/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07467866185267,
+                29.94027854487506
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6353.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07189685183172,
+                29.938711827859553
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6353.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07411583589261,
+                29.935753225993807
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07689764591356,
+                29.937319943009314
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0142/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p142",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0142/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0142/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"403.2,2903.6 -0.0,2873.8 -0.0,-0.0 820.7,0.0 819.2,534.6 5570.9,505.2 5579.5,5044.0 5262.2,5045.3 5265.1,7267.8 2421.4,7262.8 2309.3,7194.7 2309.3,7194.7 446.5,6062.4 403.2,2903.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0142/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0737429791332,
+                29.936007835104373
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07048682822638,
+                29.935277813274567
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07150533231527,
+                29.931866110430132
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07476148322209,
+                29.93259613225994
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0143/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p143",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0143/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0143/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6364
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7200.0 -0.0,-0.0 156.9,0.0 145.5,877.8 5507.0,877.5 5793.2,7172.3 -0.0,7200.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0143/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07930038146468,
+                29.931995009955116
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6364.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07665400057677,
+                29.93372296992157
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6364.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0742114137578,
+                29.930913532663215
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0768577946457,
+                29.929185572696763
               ]
             }
           }
@@ -1956,8 +5560,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1976,7 +5580,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3686.0,756.3 5476.9,227.5 6426.0,1780.3 3882.1,3641.0 4050.2,5814.9 4574.5,6679.8 3991.4,7024.3 99.2,7148.4 119.9,860.9 3686.0,756.3\" /></svg>"
+          "value": "<svg><polygon points=\"3685.7,756.2 5476.6,226.5 5720.7,573.4 6426.0,364.4 6426.0,1282.5 6214.2,1433.1 6426.0,1779.6 3883.0,3641.2 4062.2,5946.2 4576.8,6680.2 3993.8,7025.1 101.0,7150.8 119.1,862.2 3685.7,756.2\" /></svg>"
         }
       },
       "body": {
@@ -2005,8 +5609,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07707062973115,
-                29.933438228434078
+                -90.0770705761988,
+                29.93343901611463
               ]
             }
           },
@@ -2026,8 +5630,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07451299869557,
-                29.93531024280496
+                -90.07451246310978,
+                29.935309809434152
               ]
             }
           },
@@ -2047,8 +5651,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07190985223978,
-                29.932601417079194
+                -90.07191101459797,
+                29.93260047315828
               ]
             }
           },
@@ -2068,8 +5672,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07446748327536,
-                29.930729402708312
+                -90.074469127687,
+                29.93072967983876
               ]
             }
           }
@@ -2094,8 +5698,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2114,7 +5718,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6300.9,7795.0 35.1,7795.0 162.7,1235.9 6112.9,674.5 6267.4,2448.0 6300.9,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"36.8,7795.0 3.1,1825.0 152.6,1824.4 164.0,1235.8 6113.7,674.1 6268.2,2447.5 6302.1,7795.0 36.8,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -2143,8 +5747,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07764839276204,
-                29.936125293204732
+                -90.07764877493636,
+                29.93612573719526
               ]
             }
           },
@@ -2164,8 +5768,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07567775599222,
-                29.933796566485263
+                -90.07567813616782,
+                29.93379674315111
               ]
             }
           },
@@ -2185,8 +5789,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07894244111705,
-                29.93169242017725
+                -90.07894319606008,
+                29.93169259470897
               ]
             }
           },
@@ -2206,8 +5810,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08091307788688,
-                29.93402114689672
+                -90.08091383482862,
+                29.93402158875312
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0146/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p146",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0146/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0146/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6432
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5586.1,7405.1 -0.0,5908.1 171.5,4358.4 -0.0,4314.6 -0.0,1659.4 185.5,1658.3 170.5,616.7 5985.2,602.5 6000.2,1625.5 6180.3,1624.5 6171.2,-0.0 6432.0,-0.0 6432.0,3695.0 6032.5,3827.3 6031.6,5688.1 5586.1,7405.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0146/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07635244180365,
+                29.937911320598243
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6432.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0735379026732,
+                29.9363065248896
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6432.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07578249712476,
+                29.933350277669298
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07859703625522,
+                29.934955073377942
               ]
             }
           }
@@ -2232,8 +5974,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2252,7 +5994,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4600.9,1319.2 5841.2,1198.6 5792.8,7082.2 -0.0,6900.6 0.0,-0.0 445.9,0.0 446.4,1013.5 4600.9,1319.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 434.7,0.0 437.4,1025.6 4594.4,1322.7 6396.0,1143.4 6396.0,6938.4 -0.0,6913.0 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -2281,8 +6023,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08299052325044,
-                29.936553580989177
+                -90.08298974110069,
+                29.936561221160716
               ]
             }
           },
@@ -2302,8 +6044,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08033878872601,
-                29.938305588624182
+                -90.08033497754306,
+                29.93830757817046
               ]
             }
           },
@@ -2323,8 +6065,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07789178046265,
-                29.935484885677536
+                -90.07789586148715,
+                29.9354836531272
               ]
             }
           },
@@ -2344,8 +6086,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08054351498708,
-                29.933732878042534
+                -90.08055062504478,
+                29.933737296117457
               ]
             }
           }
@@ -2370,8 +6112,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2390,7 +6132,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1911.5,922.5 3606.6,265.9 5530.7,5352.3 4328.3,5798.9 4388.7,5956.0 2108.3,6777.4 2125.9,6954.4 605.6,7318.9 589.3,7139.3 -0.0,7125.7 -0.0,1239.8 1911.5,922.5\" /></svg>"
+          "value": "<svg><polygon points=\"3606.7,267.1 5619.0,5320.6 2108.6,6778.5 2126.2,6955.5 605.9,7320.0 589.6,7140.4 -0.0,7126.8 -0.0,6977.1 575.6,6975.9 560.9,1181.6 1911.7,923.7 3606.7,267.1\" /></svg>"
         }
       },
       "body": {
@@ -2419,8 +6161,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08057732985148,
-                29.938171125482025
+                -90.08057781617015,
+                29.93817155657853
               ]
             }
           },
@@ -2440,8 +6182,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07788673042118,
-                29.939918540765245
+                -90.0778871001214,
+                29.9399189724123
               ]
             }
           },
@@ -2461,8 +6203,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07546728211591,
-                29.937081381133464
+                -90.07546765105384,
+                29.937081689809727
               ]
             }
           },
@@ -2482,8 +6224,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07815788154622,
-                29.935333965850244
+                -90.07815836710259,
+                29.935334273975958
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0149/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p149",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0149/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0149/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6380
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"931.6,7099.6 901.3,2241.1 -0.0,2240.8 -0.0,1818.5 899.7,1829.2 892.9,-0.0 5776.6,-0.0 5769.4,1966.4 6380.0,1968.3 6380.0,2093.1 5769.7,2090.8 5803.7,7579.6 3029.7,7584.5 931.6,7099.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0149/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07990182565028,
+                29.94264781103926
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6380.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07710630582376,
+                29.941090610366295
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6380.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07930217656582,
+                29.938130535531712
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08209769639234,
+                29.93968773620468
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0150/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p150",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0150/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0150/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6453
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"412.2,6482.2 416.7,2822.7 1026.0,2827.4 1026.5,2702.9 416.9,2698.6 437.5,-0.0 3136.2,-0.0 3132.9,903.9 5912.9,931.0 5842.5,6417.0 412.2,6482.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0150/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07735439270924,
+                29.941623403753294
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6453.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07451505845408,
+                29.940055566709308
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6453.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07670123294122,
+                29.93708261698262
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07954056719637,
+                29.938650454026607
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0151/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p151",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0151/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0151/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6380
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1447.7,5046.9 1396.3,206.2 5267.5,158.8 5272.5,2101.9 4889.0,2106.2 4891.2,2280.3 5273.0,2276.5 5317.1,7710.5 2217.5,7721.1 2178.5,5041.9 1447.7,5046.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0151/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08000429775915,
+                29.941950383883896
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6380.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07816186369716,
+                29.944376958822158
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6380.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07473998699619,
+                29.942426110031988
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07658242105818,
+                29.939999535093726
               ]
             }
           }
@@ -2508,8 +6664,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2528,7 +6684,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"404.4,116.0 1810.9,0.0 6126.0,58.9 6133.5,2318.8 5769.1,2306.5 5696.9,3290.9 6443.0,4275.8 6443.0,4900.5 6171.5,4988.8 6201.8,5082.0 5989.0,5149.3 5783.4,7656.5 364.4,7666.5 384.8,2233.2 -0.0,2230.0 -0.0,2055.9 386.3,2058.6 404.4,116.0\" /></svg>"
+          "value": "<svg><polygon points=\"1805.0,0.0 6115.7,68.7 6121.6,2325.8 5757.7,2313.3 5684.9,3296.4 6443.0,4298.5 6443.0,4900.6 6157.7,4992.5 6181.2,5064.7 5977.1,5131.2 5768.3,7656.7 356.0,7662.9 380.1,2236.3 -0.0,2232.9 -0.0,2059.0 381.7,2062.0 401.1,121.8 1805.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -2557,8 +6713,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07857865275119,
-                29.943786456535904
+                -90.07858037434626,
+                29.943788871627504
               ]
             }
           },
@@ -2578,8 +6734,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07676377551917,
-                29.946274410273805
+                -90.07676523214977,
+                29.946280995958382
               ]
             }
           },
@@ -2599,8 +6755,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07331448543165,
-                29.944358423838526
+                -90.0733101599672,
+                29.944364729797112
               ]
             }
           },
@@ -2620,8 +6776,730 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07512936266369,
-                29.941870470100625
+                -90.0751253021637,
+                29.941872605466234
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p153",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6380
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,365.5 2422.8,333.6 2407.7,961.8 6380.0,905.3 6380.0,7795.0 -0.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07908677087279,
+                29.95025828575818
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6380.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07640978164872,
+                29.949626377586785
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6380.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07730092515921,
+                29.946792016029303
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07997791438328,
+                29.9474239242007
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p154 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6443.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7796.0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6443
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4538.1,606.0 4822.6,920.7 6443.0,1273.9 6443.0,2634.8 4299.9,1830.6 3501.5,4027.6 5923.4,4872.4 4905.4,7796.0 2860.9,7796.0 2049.9,7076.6 2302.2,6764.2 1379.2,6064.1 2063.8,5162.9 2036.7,4586.4 238.0,3113.1 -0.0,3411.5 -0.0,2145.3 778.4,0.0 2935.6,0.0 4538.1,606.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07718900077035,
+                29.948302697845996
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6443.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07411490157907,
+                29.948521928983656
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6443.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07380880775543,
+                29.945299390257265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07688290694671,
+                29.945080159119605
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p154 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "4775.6"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2519.6"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3020.4"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6443
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2111.8,7668.5 0.0,7682.6 0.0,5390.6 2057.6,5339.8 2111.8,7668.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                4775.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07359131779903,
+                29.94732937939593
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2519.6,
+                4775.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07395142138905,
+                29.946215551240613
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2519.6,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07548315434335,
+                29.946592623930375
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0751230507533,
+                29.947706452085693
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0155/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p155",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0155/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0155/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6378
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,32.6 6378.0,1227.6 6189.2,7796.0 -0.0,7796.0 -0.0,32.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0155/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08020554258333,
+                29.95398732004965
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6378.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0770014726148,
+                29.953270190911653
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6378.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07801348037565,
+                29.949875794486733
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08121755034418,
+                29.95059292362473
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0156/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p156",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0156/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0156/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6398
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5811.7,7795.0 271.5,7795.0 487.8,682.4 3297.7,1138.6 3363.5,1645.4 3866.2,1262.1 5814.2,1593.6 5811.7,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0156/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0773174424935,
+                29.953086628723508
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6398.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0741091385908,
+                29.952371637163242
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6398.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07511433036554,
+                29.948985448107443
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07832263426823,
+                29.94970043966771
               ]
             }
           }
@@ -2646,8 +7524,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2666,7 +7544,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"344.7,7795.0 423.2,351.7 6425.0,749.2 6425.0,3920.1 6211.3,6830.9 5915.7,6756.8 5831.1,7795.0 344.7,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"349.8,7795.0 421.1,354.6 6425.0,745.7 6425.0,3842.0 6209.2,6820.4 5913.9,6746.7 5829.5,7795.0 349.8,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -2695,8 +7573,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07992714833584,
-                29.95363187742942
+                -90.0799280411363,
+                29.95363321952978
               ]
             }
           },
@@ -2716,8 +7594,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07858137400102,
-                29.956280382236322
+                -90.07857789918398,
+                29.956283396650182
               ]
             }
           },
@@ -2737,8 +7615,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0748977054541,
-                29.954855348789916
+                -90.074891888331,
+                29.954853744706213
               ]
             }
           },
@@ -2758,8 +7636,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07624347978893,
-                29.95220684398301
+                -90.07624203028331,
+                29.952203567585812
               ]
             }
           }
@@ -2784,8 +7662,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2804,7 +7682,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"237.3,456.2 5718.6,446.5 5727.6,0.0 6373.0,0.0 6373.0,7417.5 5932.5,7373.4 5713.7,7129.5 5707.1,7412.3 1573.6,7456.6 302.1,1521.5 237.3,456.2\" /></svg>"
+          "value": "<svg><polygon points=\"5718.9,447.9 5728.0,0.0 6373.0,0.0 6373.0,7418.3 5931.7,7374.1 5712.9,7130.2 5706.3,7413.0 1573.2,7456.7 310.8,1520.7 238.1,456.7 5718.9,447.9\" /></svg>"
         }
       },
       "body": {
@@ -2833,8 +7711,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07894500422013,
-                29.95645951401314
+                -90.07894551439311,
+                29.956459352145103
               ]
             }
           },
@@ -2854,8 +7732,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07691154019564,
-                29.958729433382818
+                -90.0769122538783,
+                29.95872975939445
               ]
             }
           },
@@ -2875,8 +7753,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07372857578984,
-                29.956558696083246
+                -90.0737286053497,
+                29.956559239342912
               ]
             }
           },
@@ -2896,8 +7774,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07576203981434,
-                29.954288776713568
+                -90.07576186586451,
+                29.954288832093564
               ]
             }
           }
@@ -2922,8 +7800,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2942,7 +7820,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"362.3,6699.1 -0.0,6787.5 -0.0,1368.8 6424.0,0.0 6424.0,7795.0 391.3,7795.0 362.3,6699.1\" /></svg>"
+          "value": "<svg><polygon points=\"361.9,6698.3 -0.0,6786.5 -0.0,1362.8 6424.0,0.0 6424.0,7795.0 390.8,7795.0 361.9,6698.3\" /></svg>"
         }
       },
       "body": {
@@ -2971,8 +7849,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08336373401538,
-                29.95523215616033
+                -90.08336360004365,
+                29.955231891311747
               ]
             }
           },
@@ -2992,8 +7870,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08180772276097,
-                29.9578180405552
+                -90.08180785283156,
+                29.957818074560812
               ]
             }
           },
@@ -3013,8 +7891,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07821108018277,
-                29.956170420179124
+                -90.07821079458445,
+                29.956170733772367
               ]
             }
           },
@@ -3034,8 +7912,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07976709143718,
-                29.953584535784255
+                -90.07976654179654,
+                29.953584550523303
               ]
             }
           }
@@ -3060,8 +7938,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3080,7 +7958,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6423.0,1021.1 6423.0,6796.8 6317.9,6506.7 6311.3,7236.0 937.4,7305.6 -0.0,2767.6 -0.0,968.7 6423.0,1021.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,2767.2 -0.0,966.8 3890.7,1000.2 3884.3,649.2 6240.3,649.8 6230.9,0.0 6423.0,0.0 6423.0,6797.9 6317.8,6509.1 6310.8,7238.7 935.4,7305.9 -0.0,2767.2\" /></svg>"
         }
       },
       "body": {
@@ -3109,8 +7987,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08200726760187,
-                29.958183228536544
+                -90.08200661990593,
+                29.95818230444089
               ]
             }
           },
@@ -3130,8 +8008,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07988729815821,
-                29.96049598851575
+                -90.07988841336858,
+                29.96049517267079
               ]
             }
           },
@@ -3151,8 +8029,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07667045483782,
-                29.958251265019616
+                -90.0766714194811,
+                29.95825231582288
               ]
             }
           },
@@ -3172,8 +8050,836 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07879042428148,
-                29.95593850504041
+                -90.07878962601845,
+                29.95593944759298
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p161",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6414
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6414.0,4525.3 6414.0,7795.0 -0.0,7795.0 -0.0,336.9 3633.8,1183.3 4039.1,-0.0 6403.6,-0.0 6221.4,4636.5 6414.0,4525.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.084591398959,
+                29.95319980656782
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6414.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0830718581751,
+                29.95269367638077
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6414.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08377667064116,
+                29.95108260057762
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08529621142505,
+                29.951588730764673
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0162/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p162",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0162/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0162/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6423
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6423.0,7701.3 1417.8,7795.0 1443.8,5567.5 285.6,5593.8 421.3,3428.7 146.1,682.6 5527.6,1203.6 6423.0,7701.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0162/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08267035977167,
+                29.955252214396477
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07959246715866,
+                29.954156837214292
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08112672654178,
+                29.950920520907044
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08420461915479,
+                29.95201589808923
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p164",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6432
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6432.0,7382.9 6089.0,7738.1 5025.3,7795.0 2047.1,6626.6 1671.0,6618.0 1483.0,1490.1 4362.4,1382.9 5555.2,4775.5 5731.2,4928.9 6432.0,4682.5 6432.0,4941.6 6078.1,5231.4 6432.0,5226.9 6432.0,7382.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0810597,
+                29.9459842
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6432.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.079174,
+                29.9483519
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6432.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0758621,
+                29.946371499999998
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0777478,
+                29.9440038
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0165/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p165",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0165/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0165/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6414
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"468.5,1510.5 6053.5,1427.4 6090.3,6655.1 4385.1,6669.3 4391.5,5774.9 3971.8,5776.8 3975.7,6672.8 487.6,6702.1 493.9,3795.9 -0.0,3858.2 -0.0,3126.9 475.3,1037.8 468.5,1510.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0165/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08420543617324,
+                29.941712618301104
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6414.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0823747206291,
+                29.944155580988504
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6414.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07894907247237,
+                29.942228012144508
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0807797880165,
+                29.939785049457107
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0166/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p166",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0166/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0166/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6431
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5326.5,1115.8 5316.7,1560.3 6431.0,1559.7 6431.0,6537.1 -0.0,6659.7 10.5,1180.1 5326.5,1115.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0166/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0825312470599,
+                29.944037067890303
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6431.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08069183746584,
+                29.946538071580346
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6431.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07719344493573,
+                29.94460621077105
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0790328545298,
+                29.942105207081006
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0167/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p167",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0167/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0167/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6474
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1997.0,7553.9 1303.8,7564.2 1221.0,3435.4 1073.9,3441.8 897.2,2189.5 2642.4,1969.6 3328.7,1714.5 3097.9,1272.8 5473.2,396.0 5498.3,7792.3 1997.8,7795.0 1997.0,7553.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0167/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08282816394438,
+                29.94243399505594
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6474.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0808078985439,
+                29.94007754720674
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6474.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08408360305636,
+                29.937968782212803
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08610386845685,
+                29.940325230062
               ]
             }
           }
@@ -3198,8 +8904,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3218,7 +8924,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,387.9 350.2,257.4 835.5,1508.0 2959.6,1215.5 5543.3,227.0 5993.0,3367.6 5725.8,7513.1 4714.6,7522.8 4717.0,7795.0 -0.0,7795.0 -0.0,387.9\" /></svg>"
+          "value": "<svg><polygon points=\"5547.9,226.2 5997.5,3366.7 5730.1,7512.1 4707.3,7521.8 4709.2,7795.0 -0.0,7795.0 -0.0,388.7 355.0,256.4 840.2,1507.0 2964.2,1214.5 5547.9,226.2\" /></svg>"
         }
       },
       "body": {
@@ -3247,8 +8953,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08112202079631,
-                29.94043872573968
+                -90.08112393921522,
+                29.940440194192867
               ]
             }
           },
@@ -3268,8 +8974,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07911964143574,
-                29.938086440542854
+                -90.0791213990887,
+                29.93808791543213
               ]
             }
           },
@@ -3289,8 +8995,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0823826749656,
-                29.93597106867032
+                -90.08238442369058,
+                29.935972373721786
               ]
             }
           },
@@ -3310,8 +9016,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08438505432618,
-                29.938323353867144
+                -90.0843869638171,
+                29.93832465248252
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0169/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p169",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0169/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0169/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6474
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,0.0 125.3,0.0 125.8,1231.2 4170.0,1215.5 4161.9,782.7 5334.8,353.9 6119.2,6711.1 4862.7,6884.0 4868.7,7031.4 727.7,7100.4 735.7,7795.0 -0.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0169/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08812551789548,
+                29.942288673418354
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6474.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08541956774286,
+                29.944042947293287
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6474.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08298091157003,
+                29.9412185014085
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08568686172265,
+                29.939464227533566
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0170/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p170",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0170/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0170/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,0.0 5285.1,0.0 5350.5,172.3 3773.0,694.2 3774.1,983.5 2020.1,985.5 4048.4,6431.9 4056.4,6866.2 -0.0,6880.3 0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0170/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08983370787998,
+                29.944359918096275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08716460185975,
+                29.94609175394584
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08473305934143,
+                29.94327797913864
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08740216536165,
+                29.941546143289074
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0171/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p171",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0171/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0171/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6474
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"539.2,469.1 5988.2,518.7 5973.7,7795.0 174.6,7795.0 782.6,6156.0 512.0,6056.6 572.8,4401.8 -0.0,4405.6 -0.0,3981.8 570.2,3990.8 539.2,469.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0171/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08655841421648,
+                29.947559196361293
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6474.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08371658870878,
+                29.945974458467763
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6474.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08591962589995,
+                29.943008263692434
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08876145140765,
+                29.944593001585964
               ]
             }
           }
@@ -3336,8 +9456,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3356,7 +9476,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"214.8,-0.0 6146.9,-0.0 6134.9,2177.0 6476.0,2179.8 6476.0,7795.0 134.7,6346.6 214.8,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"135.9,6346.8 216.0,-0.0 6148.0,-0.0 6135.9,2177.3 6476.0,2180.1 6476.0,7795.0 135.9,6346.8\" /></svg>"
         }
       },
       "body": {
@@ -3385,8 +9505,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08408353794118,
-                29.946066239613568
+                -90.08408396395068,
+                29.946066657759896
               ]
             }
           },
@@ -3406,8 +9526,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08124519993359,
-                29.94449886020297
+                -90.08124557460897,
+                29.944499239242827
               ]
             }
           },
@@ -3427,8 +9547,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08340746585976,
-                29.941517193287527
+                -90.08340789448418,
+                29.94151751840104
               ]
             }
           },
@@ -3448,8 +9568,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08624580386737,
-                29.943084572698126
+                -90.08624628382589,
+                29.94308493691811
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0173/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p173",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0173/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0173/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6474
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3068.1 1603.1,3046.5 1641.2,755.4 -0.0,728.1 0.0,0.0 5760.9,29.3 5723.5,7627.3 -0.0,7519.0 -0.0,3068.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0173/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08456185157254,
+                29.95026880784907
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6474.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08168264533715,
+                29.948698039068635
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6474.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08386630635717,
+                29.94569288697392
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08674551259256,
+                29.947263655754355
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0174/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p174",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0174/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0174/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6421
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"174.3,7591.2 -0.0,7588.8 0.0,-0.0 4765.6,-0.0 4945.0,584.7 6421.0,126.8 6421.0,4078.8 5971.4,4068.6 6032.9,7286.7 174.5,7283.4 174.3,7591.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0174/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08200799566903,
+                29.948859736072183
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6421.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07915735497014,
+                29.947287488261686
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6421.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08136074328486,
+                29.944288007762417
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08421138398376,
+                29.945860255572914
               ]
             }
           }
@@ -3474,8 +9870,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3494,7 +9890,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,769.8 1654.8,149.3 1984.5,1056.2 2290.6,940.9 1956.2,-0.0 2230.4,-0.0 2549.4,843.4 2785.5,754.5 2468.2,-0.0 4423.2,-0.0 5391.4,2513.6 4853.0,2710.7 5002.9,3108.5 5367.2,2965.8 5386.7,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,772.6 1650.6,154.0 1980.2,1060.9 2286.3,945.7 1950.3,-0.0 2224.5,-0.0 2545.1,848.3 2781.2,759.4 2462.0,-0.0 4417.1,-0.0 5386.9,2518.9 4848.5,2716.0 4998.3,3113.8 5362.7,2971.1 5381.4,7795.0 -0.0,7795.0 -0.0,772.6\" /></svg>"
         }
       },
       "body": {
@@ -3523,8 +9919,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08804552570057,
-                29.948537204787915
+                -90.08804238166562,
+                29.948536860365262
               ]
             }
           },
@@ -3544,8 +9940,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08605714667792,
-                29.946183980858624
+                -90.0860536284455,
+                29.94618397487431
               ]
             }
           },
@@ -3565,8 +9961,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08930761671884,
-                29.944092663705863
+                -90.08930363100704,
+                29.94409226415193
               ]
             }
           },
@@ -3586,8 +9982,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0912959957415,
-                29.946445887635157
+                -90.09129238422716,
+                29.946445149642884
               ]
             }
           }
@@ -3595,13 +9991,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p179 [1]",
+      "label": "New Orleans, La. | 1896 | Vol. 2 p176",
       "metadata": [
         {
           "label": "streets",
@@ -3612,8 +10008,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3622,21 +10018,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/info.json",
           "type": "ImageService2",
           "height": 7795,
-          "width": 6537
+          "width": 6421
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6537.0,598.3 5943.8,7300.2 6450.3,7349.7 5934.5,7404.8 5900.0,7795.0 1613.1,7795.0 145.8,7326.5 692.3,4667.9 408.3,4619.0 1766.5,0.0 4435.7,0.0 6537.0,598.3\" /></svg>"
+          "value": "<svg><polygon points=\"3346.0,6891.6 3090.3,6795.4 3078.2,7795.0 2753.2,7795.0 2758.0,6833.8 1006.5,6831.2 650.9,7795.0 -0.0,7795.0 0.0,-0.0 6421.0,-0.0 6421.0,2305.2 4809.1,2353.6 4883.5,6830.6 5372.8,6831.1 5389.9,7661.1 3567.4,6975.0 3603.7,7795.0 3353.0,7795.0 3346.0,6891.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -3661,8 +10057,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08740411548146,
-                29.953840025070708
+                -90.0868525868717,
+                29.95116891220895
               ]
             }
           },
@@ -3670,7 +10066,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6537.0,
+                6421.0,
                 0.0
               ],
               "creator": {
@@ -3682,8 +10078,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08614366750648,
-                29.956594024394143
+                -90.08404354768253,
+                29.949579383830567
               ]
             }
           },
@@ -3691,7 +10087,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6537.0,
+                6421.0,
                 7795.0
               ],
               "creator": {
@@ -3703,8 +10099,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08237887747002,
-                29.95528222457263
+                -90.08627121030543,
+                29.946623752437432
               ]
             }
           },
@@ -3724,8 +10120,300 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08363932544502,
-                29.952528225249196
+                -90.0890802494946,
+                29.948213280815814
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0177/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p177",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0177/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0177/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6537
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,0.0 6211.4,0.0 6537.0,3646.4 6537.0,7795.0 -0.0,7795.0 0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0177/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0892918266576,
+                29.953224019933916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6537.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08755337432594,
+                29.955020734989333
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6537.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08507992649987,
+                29.953224104300777
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08681837883154,
+                29.95142738924536
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p179 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6537.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6537
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6537.0,509.2 5987.9,7339.9 6480.5,7376.6 3218.8,7795.0 1018.8,7795.0 36.9,7500.8 400.1,5678.4 -0.0,5693.5 -0.0,4693.5 246.2,4769.0 1562.1,0.0 4574.9,0.0 6537.0,509.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08737036194476,
+                29.953945060461926
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6537.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08607156242957,
+                29.95660640388842
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6537.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08240772679575,
+                29.955264174850644
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08370652631095,
+                29.95260283142415
               ]
             }
           }
@@ -3750,8 +10438,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3770,7 +10458,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"514.6,1175.1 397.4,1799.0 6359.9,2919.1 6323.9,6646.5 259.6,7795.0 198.9,1118.1 514.6,1175.1\" /></svg>"
+          "value": "<svg><polygon points=\"273.3,1130.1 6160.5,2198.4 6137.4,278.7 4509.0,0.0 6387.8,0.0 6323.3,6647.2 266.0,7795.0 273.3,1130.1\" /></svg>"
         }
       },
       "body": {
@@ -3799,8 +10487,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08642175938297,
-                29.956646895056096
+                -90.08642187799514,
+                29.956647260124058
               ]
             }
           },
@@ -3820,8 +10508,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08486737958548,
-                29.95926923191088
+                -90.08486763273066,
+                29.959269524484373
               ]
             }
           },
@@ -3841,8 +10529,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08124030846534,
-                29.957632535329772
+                -90.08124066188087,
+                29.95763296956089
               ]
             }
           },
@@ -3862,8 +10550,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08279468826284,
-                29.955010198474987
+                -90.08279490714534,
+                29.955010705200575
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p181",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6537
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4282.4,815.8 5698.5,826.2 5594.0,7197.6 3345.7,7192.8 989.5,7795.0 515.8,7795.0 462.5,6565.3 -0.0,6543.4 -0.0,796.5 788.2,766.9 4306.9,967.1 4282.4,815.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0905204,
+                29.9565664
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6537.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0884502,
+                29.9589242
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6537.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08520419999999,
+                29.9567847
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0872744,
+                29.9544269
               ]
             }
           }
@@ -3888,8 +10714,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3908,7 +10734,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5973.4,771.1 6011.6,4782.5 5517.9,4849.6 6132.6,7795.0 -0.0,7795.0 -0.0,736.0 5973.4,771.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,737.7 5971.8,771.0 6011.3,4781.6 5518.5,4778.2 5516.9,4906.3 3749.2,5239.1 5418.6,5211.5 5800.5,7114.1 -0.0,7153.7 -0.0,737.7\" /></svg>"
         }
       },
       "body": {
@@ -3937,8 +10763,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08867244784886,
-                29.958599577786405
+                -90.0886729178617,
+                29.958600368047595
               ]
             }
           },
@@ -3958,8 +10784,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0866289536434,
-                29.960882567712396
+                -90.08662825872085,
+                29.960883196620493
               ]
             }
           },
@@ -3979,8 +10805,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08344557596163,
-                29.958713426162994
+                -90.0834451060282,
+                29.95871281850787
               ]
             }
           },
@@ -4000,8 +10826,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0854890701671,
-                29.956430436237003
+                -90.08548976516904,
+                29.95642998993497
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0183/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p183",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0183/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0183/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6504
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6449.5,7795.0 304.6,7795.0 244.0,312.0 660.0,312.7 658.6,-0.0 6469.0,-0.0 6449.5,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0183/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08498380915636,
+                29.96400214621806
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6504.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08228438190808,
+                29.962198638689415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6504.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08477962337965,
+                29.95939540307066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08747905062792,
+                29.961198910599304
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0184/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p184",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0184/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0184/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6483
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6483.0,2521.5 6483.0,6509.0 146.4,7796.0 -0.0,0.0 6483.0,-0.0 6483.0,139.5 5523.4,141.1 5524.9,321.8 6135.1,312.0 6153.0,2467.7 6483.0,2521.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0184/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08226256760142,
+                29.962244774728582
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6483.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07941723121813,
+                29.960254181380726
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6483.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08217976245234,
+                29.957290260426234
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08502509883563,
+                29.95928085377409
               ]
             }
           }
@@ -4026,8 +11128,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4046,7 +11148,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"672.6,7558.6 128.2,7563.7 130.0,7795.0 -0.0,7795.0 -0.0,0.0 6012.6,-0.0 6085.7,7330.1 671.3,7373.6 672.6,7558.6\" /></svg>"
+          "value": "<svg><polygon points=\"666.7,7567.2 120.5,7572.3 122.2,7795.0 -0.0,7795.0 -0.0,0.0 6011.2,-0.0 6085.9,7338.7 665.4,7382.0 666.7,7567.2\" /></svg>"
         }
       },
       "body": {
@@ -4075,8 +11177,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08985556293769,
-                29.967356264908503
+                -90.08985294073597,
+                29.967354495042525
               ]
             }
           },
@@ -4096,8 +11198,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08715820582002,
-                29.965494789738433
+                -90.08715853254071,
+                29.965495209783782
               ]
             }
           },
@@ -4117,8 +11219,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08970004719676,
-                29.96269126539791
+                -90.08969738366874,
+                29.96269475051355
               ]
             }
           },
@@ -4138,8 +11240,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09239740431441,
-                29.96455274056798
+                -90.09239179186399,
+                29.96455403577229
               ]
             }
           }
@@ -4164,8 +11266,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4184,7 +11286,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"458.1,7424.5 338.8,7602.9 -0.0,7601.4 -0.0,0.0 6490.0,-0.0 6490.0,423.3 6069.2,423.8 6069.9,7463.0 458.1,7424.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 6490.0,-0.0 6490.0,422.9 6073.7,423.1 6069.4,7465.7 454.8,7423.2 484.4,7166.4 -0.0,7163.7 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -4213,8 +11315,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08735954322528,
-                29.965664607045778
+                -90.08736199100069,
+                29.96566322488814
               ]
             }
           },
@@ -4234,8 +11336,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08467293114664,
-                29.963858321983306
+                -90.08467521397434,
+                29.963859505782096
               ]
             }
           },
@@ -4255,8 +11357,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08716065758996,
-                29.96104181644642
+                -90.08715940642526,
+                29.96104282732253
               ]
             }
           },
@@ -4276,8 +11378,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08984726966858,
-                29.962848101508893
+                -90.08984618345161,
+                29.962846546428572
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0187/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p187",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0187/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0187/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6529
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"808.3,7663.8 1455.9,7567.5 755.9,403.6 5627.4,214.6 6529.0,4852.4 6529.0,7627.6 4119.2,7652.0 4144.8,7795.0 834.0,7795.0 808.3,7663.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0187/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09355077628265,
+                29.958607397376827
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6529.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09131850668471,
+                29.96105940774485
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6529.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08793857566077,
+                29.958749766754345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09017084525871,
+                29.95629775638632
               ]
             }
           }
@@ -4302,8 +11542,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4322,7 +11562,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"215.9,49.7 6289.2,0.0 6305.4,5617.0 5880.7,5652.7 5908.0,7796.0 1167.2,7774.9 1161.9,4898.1 215.9,49.7\" /></svg>"
+          "value": "<svg><polygon points=\"218.8,52.0 6288.7,0.0 6303.0,5618.3 5878.5,5653.8 5905.1,7796.0 1166.9,7773.2 1162.6,4897.9 218.8,52.0\" /></svg>"
         }
       },
       "body": {
@@ -4351,8 +11591,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09162493462433,
-                29.96059307409981
+                -90.09162686260291,
+                29.96059259627938
               ]
             }
           },
@@ -4372,8 +11612,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08950567319624,
-                29.96294489241024
+                -90.08950734744033,
+                29.962946380666285
               ]
             }
           },
@@ -4393,8 +11633,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08626469315904,
-                29.96072173817544
+                -90.08626365800394,
+                29.960722960258153
               ]
             }
           },
@@ -4414,8 +11654,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08838395458713,
-                29.95836991986501
+                -90.08838317316652,
+                29.958369175871248
               ]
             }
           }
@@ -4440,8 +11680,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4460,7 +11700,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"92.4,7552.2 -0.0,7795.0 -0.0,444.9 547.5,444.0 547.6,258.0 5992.9,256.5 5997.2,435.4 6352.5,435.3 6419.8,6400.7 92.4,7552.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,445.2 548.7,444.3 548.9,258.3 5994.0,257.0 6015.9,-0.0 6500.0,-0.0 6423.5,6493.7 93.5,7552.6 -0.0,7795.0 -0.0,445.2\" /></svg>"
         }
       },
       "body": {
@@ -4489,8 +11729,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09212625106953,
-                29.964759580764348
+                -90.09212665016432,
+                29.96476005907224
               ]
             }
           },
@@ -4510,8 +11750,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08944504666928,
-                29.962938558634328
+                -90.08944532383782,
+                29.962939045047527
               ]
             }
           },
@@ -4531,8 +11771,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09194841674493,
-                29.960132885729074
+                -90.09194868277106,
+                29.960133244555887
               ]
             }
           },
@@ -4552,8 +11792,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09462962114517,
-                29.961953907859094
+                -90.09463000909756,
+                29.9619542585806
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0190/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p190",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0190/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0190/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6484
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1178.5 6308.6,-0.0 6484.0,3226.4 6484.0,7795.0 -0.0,7795.0 -0.0,1178.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0190/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09412395501127,
+                29.962429956338518
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6484.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09149115661779,
+                29.960572846992246
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6484.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09406847445501,
+                29.957830358909597
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09670127284849,
+                29.95968746825587
               ]
             }
           }
@@ -4578,8 +11956,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
+      "created": "2026-08-15T01:27:20Z",
+      "modified": "2026-08-15T01:27:20Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4598,7 +11976,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 0.0,-0.0 6500.0,0.0 6500.0,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 6500.0,0.0 6500.0,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -4627,8 +12005,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09492396753781,
-                29.956334342914428
+                -90.09492379354656,
+                29.956334611115185
               ]
             }
           },
@@ -4648,8 +12026,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09313635208437,
-                29.95878208882904
+                -90.09313646882256,
+                29.958782346752503
               ]
             }
           },
@@ -4669,8 +12047,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08977161797813,
-                29.956911378121763
+                -90.08977174884377,
+                29.956911940288897
               ]
             }
           },
@@ -4690,4783 +12068,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09155923343158,
-                29.95446363220715
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0101__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p101 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6387.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7795.0"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0101__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0101/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6387
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"442.0,4479.8 644.3,2123.0 1067.1,2312.4 878.8,1649.4 672.5,1563.9 918.8,47.0 6387.0,0.0 6387.0,6903.7 5921.2,7049.7 6051.2,7324.2 442.2,7487.3 442.0,4479.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0101__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1763.7,
-                4767.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0659476,
-                29.9497429
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2531.6,
-                7479.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0659214,
-                29.9484512
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0102/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p102",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "22"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0102/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0102/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6428
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"833.3,7434.2 858.2,1901.6 1134.9,0.0 6084.1,0.0 5821.7,1515.9 6027.4,1603.6 6209.1,2269.2 5787.7,2075.2 5560.9,4432.3 5530.0,7442.9 833.3,7434.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0102/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3292.0,
-                3855.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0676722,
-                29.9505385
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3292.0,
-                2463.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0674906,
-                29.9511568
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0107/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p107",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0107/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0107/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6428
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1815.3,7795.0 1553.9,7656.5 -0.0,7649.0 -0.0,6071.4 333.7,6069.2 295.3,0.0 455.9,0.0 3980.0,592.8 3990.3,2849.4 6423.8,2834.2 6428.0,7654.3 1815.3,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0107/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3988.0,
-                5447.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0734605,
-                29.9488979
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                332.0,
-                5447.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0753256,
-                29.9493252
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0108/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p108",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0108/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0108/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6361
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"949.8,7549.8 908.0,259.3 5727.0,217.2 5836.7,7491.2 949.8,7549.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0108/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3320.5,
-                7535.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0684627,
-                29.9478383
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5760.9,
-                2663.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0706129,
-                29.9494941
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0109/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p109",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0109/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0109/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6350
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5733.3,7279.3 847.7,7279.1 847.0,6992.7 254.4,6798.5 846.0,6592.2 830.3,529.7 5735.9,562.3 5733.3,7279.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0109/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                847.7,
-                7279.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.074633,
-                29.9449435
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3291.0,
-                7279.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0733877,
-                29.944664
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0110/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p110",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0110/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0110/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6488
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5615.2,7271.7 704.0,7255.1 704.0,503.9 5589.6,513.4 5615.2,7271.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0110/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                704.0,
-                7255.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0721429,
-                29.9443845
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                704.0,
-                503.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0712549,
-                29.9473502
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0111/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p111",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0111/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0111/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6350
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5467.7,670.1 5469.9,7235.9 373.9,7214.2 348.6,623.1 5467.7,670.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0111/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2731.1,
-                3191.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0672659,
-                29.9475596
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6525.9,
-                7239.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0658675,
-                29.9453563
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0113/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p113",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0113/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0113/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6356
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"590.7,232.8 5711.8,227.7 5706.0,7557.8 4850.7,7795.0 4073.7,7795.0 4076.8,6972.1 3646.0,6971.2 580.1,7795.0 590.7,232.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0113/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4096.0,
-                1963.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0683189,
-                29.9451526
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5704.0,
-                7559.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0652822,
-                29.9452167
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0114/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p114",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0114/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0114/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6305
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"808.8,3241.6 797.4,819.9 3824.3,0.0 4251.6,0.0 4250.3,816.2 5021.0,814.6 5868.9,577.6 5877.6,1749.3 5079.1,1968.4 5091.7,4776.8 6305.0,4767.2 6305.0,7795.0 0.0,7795.0 0.0,3474.9 808.8,3241.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0114/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                788.1,
-                2027.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0652255,
-                29.9428089
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5868.9,
-                575.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0652822,
-                29.9452167
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0116/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p116",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0116/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0116/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6349
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6349.0,1822.2 6349.0,2169.6 4261.0,7263.3 3417.1,7167.8 3156.1,7796.0 0.0,7796.0 0.0,-0.0 3408.2,1358.6 3921.1,1786.6 6349.0,1822.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0116/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4128.7,
-                4916.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0658096,
-                29.9424745
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6489.0,
-                1832.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0675695,
-                29.9433411
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0120/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p120",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0120/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0120/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6509
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,2516.6 0.0,1035.0 416.7,0.0 3759.3,0.0 5756.6,791.9 5704.5,7795.0 0.0,7795.0 8.6,2636.4 156.1,2577.5 0.0,2516.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0120/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4680.7,
-                5331.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0656498,
-                29.9401468
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4680.7,
-                2607.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0670514,
-                29.9399818
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0121/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p121",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0121/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0121/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6288
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2483.1,0.0 6288.0,0.0 6288.0,7796.0 3223.6,7796.0 3212.0,6198.1 -0.0,4930.2 -0.0,2643.8 1237.6,3138.7 2483.1,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0121/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3212.0,
-                6200.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0659629,
-                29.9329822
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                -20.0,
-                4920.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0677164,
-                29.9333635
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0123/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p123",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0123/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0123/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6321
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1315.4,6844.2 1312.2,543.9 4753.6,550.5 5529.1,2783.8 5517.5,7281.7 3567.1,7267.5 3567.3,6845.8 1315.4,6844.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0123/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1312.2,
-                543.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0677164,
-                29.9333635
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1312.2,
-                7251.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0685676,
-                29.9303995
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0124/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p124",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0124/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0124/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6481
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"594.1,7276.5 536.1,2799.6 338.3,2040.6 3131.7,894.2 2764.6,0.0 6481.0,0.0 6481.0,6840.6 3221.1,6859.2 3228.5,7255.1 594.1,7276.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0124/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                536.1,
-                2799.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.065851,
-                29.93191
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3228.5,
-                7255.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.065081,
-                29.929624
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0126/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p126",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0126/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0126/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2866.8,399.2 2861.6,0.0 6447.0,0.0 6447.0,7795.0 804.5,7795.0 -0.0,6944.2 22.3,406.2 2866.8,399.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0126/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2899.6,
-                2667.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0653625,
-                29.928624
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                196.0,
-                2667.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0667326,
-                29.9289319
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0127/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p127",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0127/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0127/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6146
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 188.9,0.0 137.2,798.6 6146.0,1134.6 6146.0,7796.0 -0.0,7796.0 -0.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0127/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                436.1,
-                4748.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.071366,
-                29.923322
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5013.6,
-                1076.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0708295,
-                29.9257439
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0128/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p128",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0128/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0128/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6448
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2960.0,794.9 5493.7,729.4 5554.0,3471.4 5278.7,4376.8 6448.0,6163.7 6448.0,7796.0 -0.0,7796.0 -0.0,1115.0 2960.0,794.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0128/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5552.0,
-                3472.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.067311,
-                29.9270004
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2960.0,
-                796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0692666,
-                29.927108
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0129/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p129",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0129/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0129/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7408.6 -0.0,374.9 5904.5,342.0 6051.1,3488.2 5370.3,3752.2 5457.7,4757.5 5631.1,4756.3 6126.8,4752.6 6239.5,7343.4 5828.2,7354.0 5871.4,7796.0 5641.8,7796.0 5613.5,7359.3 -0.0,7408.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0129/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2915.5,
-                2588.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0729984,
-                29.9270309
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2915.5,
-                4776.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0723193,
-                29.9262406
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0130/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p130",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0130/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0130/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6444
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4755.9 -0.0,3751.7 697.8,3548.6 823.9,416.7 3779.0,363.5 4601.0,0.0 5384.3,0.0 5422.7,799.3 6444.0,786.7 6444.0,1470.5 5481.7,2127.8 5600.2,5553.8 6444.0,6763.3 5708.0,7395.6 5670.2,6914.3 3120.0,7007.7 552.2,7387.1 663.9,4808.7 -0.0,4755.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0130/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3120.0,
-                4804.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0700313,
-                29.9278532
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3120.0,
-                412.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0715553,
-                29.9293384
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0131/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p131",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0131/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0131/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6352
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,605.6 682.4,614.2 839.6,615.3 3127.6,593.6 5819.0,608.9 6032.7,7247.4 168.7,7216.7 162.4,7795.0 -0.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0131/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3092.0,
-                2863.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0750641,
-                29.92942
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                744.0,
-                2863.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0760416,
-                29.9287748
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0133/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p133",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0133/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0133/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6358
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1805.7,318.8 3794.8,310.0 3794.5,0.0 6015.6,0.0 6016.5,317.2 6358.0,317.0 6358.0,5555.8 6032.2,5557.1 6037.8,7437.1 1529.0,7440.4 1527.7,5204.6 0.0,5215.7 380.9,4648.0 677.1,4841.9 1045.2,4842.6 1527.0,4117.6 1526.3,2998.7 188.1,2993.7 1805.7,318.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0133/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1527.5,
-                4843.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0698804,
-                29.9306916
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3794.8,
-                312.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0718767,
-                29.9321959
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0134/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p134",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0134/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0134/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6444
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"936.0,336.0 936.2,16.5 5504.9,0.0 5505.3,349.5 5498.0,1440.9 4944.4,1441.2 4947.9,6788.9 3191.5,7487.2 931.6,7506.8 932.8,5613.4 1261.0,5613.2 1280.0,337.0 936.0,336.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0134/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                936.0,
-                4872.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0693056,
-                29.9326678
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                936.0,
-                336.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.071584,
-                29.9331684
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0135/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p135",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0135/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0135/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6321
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"851.2,1429.2 3314.8,1453.2 3318.9,806.0 6321.0,813.8 6321.0,7263.5 182.8,7278.5 185.3,6745.6 -0.0,6745.3 -0.0,3954.2 851.2,1429.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0135/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4920.8,
-                3027.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0704448,
-                29.9370144
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4920.8,
-                815.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.070157,
-                29.937986
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0136/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p136",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0136/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0136/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6443
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1506.9,832.7 1549.4,0.0 6443.0,0.0 6443.0,7428.8 6264.4,7428.4 6264.2,7796.0 -0.0,7796.0 -0.0,7250.1 317.9,7252.5 341.1,830.2 1506.9,832.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0136/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1599.8,
-                5244.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0693743,
-                29.9357395
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1599.8,
-                776.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0687984,
-                29.9377133
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0141/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p141",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0141/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0141/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6353
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"339.9,7795.0 -0.0,7795.0 -0.0,0.0 310.0,-0.0 302.5,1177.5 5203.2,1179.5 4873.6,-0.0 5239.9,-0.0 5580.7,1006.4 6353.0,748.4 6353.0,7795.0 6172.4,7795.0 6163.1,6768.9 330.8,6750.3 339.9,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0141/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3228.5,
-                4943.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0746722,
-                29.9376061
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                320.1,
-                3047.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0754052,
-                29.9390424
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0142/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p142",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0142/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0142/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,2873.3 -0.0,-0.0 820.7,0.0 819.2,534.6 5223.8,507.3 5265.1,7267.8 2309.3,7194.7 446.5,6062.4 403.2,2902.9 -0.0,2873.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0142/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5575.1,
-                2767.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0712888,
-                29.9341652
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5575.1,
-                7267.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0718767,
-                29.9321959
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0143/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p143",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0143/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0143/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6364
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7200.0 -0.0,-0.0 157.8,0.0 146.4,877.8 5507.0,877.5 5793.2,7172.3 -0.0,7200.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0143/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3088.0,
-                4895.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0764823,
-                29.9310691
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3088.0,
-                7171.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0757692,
-                29.9302489
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0146/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p146",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0146/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0146/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6432
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5586.1,7405.1 -0.0,5908.1 171.5,4358.4 -0.0,4314.6 -0.0,1659.4 185.5,1658.4 170.5,616.7 5985.2,602.5 6000.2,1625.5 6180.3,1624.5 6171.2,-0.0 6432.0,-0.0 6432.0,3695.0 6032.5,3827.3 6031.6,5688.1 5586.1,7405.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0146/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3128.0,
-                5023.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07643,
-                29.935226
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6012.0,
-                2431.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0744219,
-                29.9354891
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0149/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p149",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0149/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0149/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6380
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"931.6,7099.6 901.3,2241.1 -0.0,2240.8 -0.0,1818.5 899.7,1829.2 893.2,149.6 5344.6,155.4 5372.2,7073.6 5800.6,7071.9 5803.7,7579.6 3029.7,7584.5 931.6,7099.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0149/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                908.0,
-                3919.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0806081,
-                29.9409378
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5776.0,
-                156.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0774149,
-                29.9411788
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0150/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p150",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0150/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0150/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6453
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"424.8,6482.2 427.7,7795.0 -0.0,7795.0 -0.0,889.1 430.7,891.4 437.5,-0.0 3136.2,-0.0 3132.9,903.9 5912.9,931.0 5853.4,7554.7 6007.4,7556.1 6004.0,7795.0 5835.9,7795.0 5842.0,6511.2 424.8,6482.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0150/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                408.1,
-                4675.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0784861,
-                29.9397411
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3120.5,
-                6499.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.077805,
-                29.938387
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0151/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p151",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0151/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0151/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6380
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1248.0,208.0 5267.5,158.8 5272.5,2101.9 4884.9,2106.2 4887.0,2280.3 5273.0,2276.5 5317.1,7710.5 2217.5,7721.1 2178.5,5041.9 1293.0,5048.0 1248.0,208.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0151/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5280.0,
-                4991.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0762884,
-                29.9427094
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1248.0,
-                208.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0795526,
-                29.942373
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p153",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6380
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,365.5 2422.8,333.6 2407.7,961.8 6380.0,905.3 6380.0,7795.0 -0.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2528.0,
-                2955.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0783631,
-                29.948933
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2528.0,
-                6191.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.078733,
-                29.9477565
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p154 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6443.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "7796.0"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6443
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"237.4,3114.7 -0.0,2920.2 -0.0,2145.3 778.4,0.0 2853.6,0.0 4538.1,606.0 4822.6,920.7 6443.0,1273.9 6443.0,3359.0 4905.4,7796.0 2860.9,7796.0 2049.9,7076.5 2302.2,6764.2 1378.5,6063.5 2063.8,5162.7 2036.9,4588.5 748.5,3533.3 261.1,5415.6 103.9,4898.3 237.4,3114.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2099.7,
-                3520.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0760493,
-                29.9469191
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3243.5,
-                252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0756308,
-                29.948309
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0155/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p155",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0155/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0155/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6378
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5891.1,1149.1 5894.2,4061.1 6283.9,4149.7 6261.9,4448.6 6378.0,4461.4 6189.2,7796.0 -0.0,7796.0 -0.0,32.6 5891.1,1149.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0155/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3341.0,
-                3500.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0789813,
-                29.9520883
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1900.6,
-                432.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0793069,
-                29.9535853
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0156/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p156",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0156/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0156/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6398
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5814.2,1593.6 5811.7,7795.0 271.5,7795.0 484.4,3924.5 368.0,3911.6 390.5,3611.8 -0.0,3522.7 -0.0,603.2 3297.7,1138.6 3363.5,1645.4 3866.2,1262.1 5814.2,1593.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0156/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5814.2,
-                1591.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0746074,
-                29.9517446
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5814.2,
-                7163.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0753256,
-                29.9493252
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p161",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6414
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4912.2 -0.0,-0.0 6414.0,0.0 6414.0,7795.0 224.5,7795.0 266.8,4916.1 -0.0,4912.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6294.0,
-                3107.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0838375,
-                29.9526685
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2991.1,
-                3107.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0846189,
-                29.9515574
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0162/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p162",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "18"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0162/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0162/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6423
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5527.6,1204.0 6423.0,7795.0 4013.9,7795.0 4184.3,6722.4 1435.4,6285.8 1435.4,6285.8 134.1,6079.1 555.8,4695.8 507.2,717.4 5527.6,1204.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0162/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4139.4,
-                3627.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0814006,
-                29.9530407
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2611.6,
-                575.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0815332,
-                29.9545672
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0165/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p165",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0165/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0165/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6414
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"468.3,1511.6 6053.5,1428.4 6090.3,6654.9 4385.1,6669.3 4391.5,5774.9 3971.8,5776.8 3975.7,6672.8 487.6,6702.1 493.9,3795.9 -0.0,3858.2 -0.0,3126.9 464.7,1084.4 468.3,1511.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0165/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2307.3,
-                6687.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0806081,
-                29.9409378
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6054.1,
-                1015.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.082031,
-                29.9437673
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0166/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p166",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0166/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0166/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6431
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"10.5,1180.1 5326.5,1115.8 5277.8,3319.2 5975.1,3502.3 6213.5,3829.5 6431.0,6544.6 -0.0,6659.7 10.5,1180.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0166/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1767.7,
-                5215.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.079685,
-                29.943432
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3935.4,
-                5215.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.079065,
-                29.944275
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0167/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p167",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0167/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0167/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6474
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5418.3,7795.0 1908.3,7795.0 1910.6,7533.2 1216.4,7535.0 1184.0,3399.7 1036.6,3404.3 875.0,2148.2 2625.2,1949.3 3315.6,1702.3 3089.9,1257.1 5483.9,406.6 5418.3,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0167/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4429.4,
-                767.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0817682,
-                29.9406135
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1216.4,
-                7535.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0856,
-                29.9399131
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0169/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p169",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "22"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0169/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0169/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6474
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 0.0,0.0 125.3,0.0 125.8,1231.2 753.0,1238.9 4170.0,1215.5 4161.9,782.7 5334.8,353.9 6119.2,6711.1 4862.7,6884.0 4868.7,7031.4 727.7,7100.4 735.7,7795.0 -0.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0169/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3024.9,
-                3175.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0858677,
-                29.9419577
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3024.9,
-                7063.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0846515,
-                29.9405491
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0170/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p170",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "25"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0170/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0170/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 5285.0,0.0 5350.5,172.3 3773.0,694.2 3863.2,2627.0 4731.2,2338.7 5225.0,6002.0 4048.4,6431.9 4056.4,6866.2 -0.0,6880.3 0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0170/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2919.5,
-                4772.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0871293,
-                29.943427
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2919.5,
-                996.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0883068,
-                29.9447896
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0171/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p171",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0171/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0171/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6474
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"539.2,469.1 5988.2,518.7 5975.7,6544.7 2381.5,5733.0 2349.0,6643.9 512.0,6056.6 572.8,4401.8 -0.0,4405.6 -0.0,3981.8 570.2,3990.8 539.2,469.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0171/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2368.7,
-                2319.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0861748,
-                29.9460959
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5985.8,
-                6107.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0856569,
-                29.94377
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0173/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p173",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0173/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0173/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6474
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7519.0 0.0,-0.0 6474.0,-0.0 6474.0,7638.0 -0.0,7519.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0173/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4089.3,
-                5407.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.084258,
-                29.947192
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4089.3,
-                7603.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0848731,
-                29.9463455
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0174/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p174",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0174/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0174/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6421
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"712.1,-0.0 4763.5,-0.0 4945.0,584.7 6421.0,126.8 6421.0,4078.8 5971.4,4068.6 6032.9,7287.0 747.9,7284.1 712.1,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0174/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                176.0,
-                5379.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0834504,
-                29.9467467
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5956.9,
-                7635.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0815216,
-                29.9444632
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p176",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6421
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3353.0,7795.0 3346.0,6896.7 3090.3,6800.4 3078.2,7795.0 2753.2,7795.0 2758.0,6833.8 1001.9,6831.2 646.1,7795.0 -0.0,7795.0 -0.0,-0.0 4770.0,-0.0 4883.5,6830.6 5372.8,6831.1 5390.0,7666.6 3567.6,6980.2 3603.7,7795.0 3353.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                932.1,
-                6831.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.088397,
-                29.948348
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5372.8,
-                6831.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0864543,
-                29.9472487
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0177/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p177",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0177/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0177/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6537
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6537.0,7748.9 -0.0,7795.0 0.0,0.0 6211.4,0.0 6345.8,1477.9 6537.0,1472.4 6364.6,1688.3 6537.0,7748.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0177/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3360.5,
-                5011.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0868077,
-                29.9529929
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6281.0,
-                771.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.087376,
-                29.954773
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0183/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p183",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0183/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0183/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6504
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6449.5,7795.0 304.6,7795.0 244.0,312.0 664.7,312.7 663.5,-0.0 6469.0,-0.0 6449.5,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0183/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                244.0,
-                2703.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.085748,
-                29.9629622
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                244.0,
-                312.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0849824,
-                29.9638223
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0184/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p184",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "21"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0184/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0184/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6483
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6483.0,-0.0 6483.0,6509.0 146.4,7796.0 -0.0,0.0 6483.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0184/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                40.0,
-                2644.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0831828,
-                29.9612279
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6135.1,
-                312.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0796805,
-                29.9602424
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0187/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p187",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0187/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0187/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6529
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1455.1,7568.4 755.6,403.7 5539.2,218.1 5587.5,0.0 6529.0,4852.4 6529.0,7627.6 4119.2,7652.0 4144.8,7795.0 834.0,7795.0 808.3,7663.7 1455.1,7568.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0187/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6241.0,
-                3335.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.089972,
-                29.959963
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6673.0,
-                5607.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.088838,
-                29.959452
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0190/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p190",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T15:05:04Z",
-      "modified": "2026-08-07T15:05:04Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0190/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0190/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6484
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1178.3 6308.6,-0.0 6484.0,3226.3 6484.0,7795.0 -0.0,7795.0 -0.0,1178.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0190/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                464.0,
-                1087.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0942946,
-                29.961915
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6132.0,
-                -56.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0916153,
-                29.9606936
+                -90.09155907356777,
+                29.95446420465158
               ]
             }
           }

--- a/gallery/new_orleans_la_1951_vol_5.iiif.json
+++ b/gallery/new_orleans_la_1951_vol_5.iiif.json
@@ -7,6 +7,282 @@
   "label": "Mosaic of main content, New Orleans, La. | 1951 | Vol. 5",
   "items": [
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0425/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p425",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0425/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0425/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5700
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4271.6,388.6 4534.4,242.7 4533.0,2730.0 3670.5,2747.0 3760.2,7565.1 5700.0,7529.0 5700.0,8150.0 -0.0,8150.0 54.1,398.7 4271.6,388.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0425/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.12037840273675,
+                29.91811736934465
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5700.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11741800386983,
+                29.917516751739154
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5700.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1184090678251,
+                29.913847096733612
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.12136946669202,
+                29.914447714339108
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0426/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p426",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0426/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0426/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5637
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"860.9,3337.8 908.5,855.4 4817.9,0.0 4822.2,2406.7 5637.0,2216.8 5637.0,8149.0 -0.0,8149.0 -0.0,3338.7 860.9,3337.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0426/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.118431759509,
+                29.91800604197845
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11548598500093,
+                29.917458281724954
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1163996435781,
+                29.91376709384138
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11934541808617,
+                29.914314854094876
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0427/georef",
       "type": "Annotation",
       "@context": [
@@ -24,8 +300,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +320,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1447.1 5155.7,0.0 5382.2,2456.8 4328.4,2757.0 5681.0,7572.1 5681.0,8150.0 -0.0,8150.0 -0.0,1447.1\" /></svg>"
+          "value": "<svg><polygon points=\"1069.2,3516.8 256.0,3717.1 221.4,1220.5 5092.3,71.8 5238.9,2484.5 5136.1,2509.7 5681.0,5471.8 5681.0,8150.0 1127.3,8150.0 1069.2,3516.8\" /></svg>"
         }
       },
       "body": {
@@ -73,8 +349,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1157872543332,
-                29.918163285617624
+                -90.11587410917768,
+                29.91815158604452
               ]
             }
           },
@@ -94,8 +370,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.11297460973744,
-                29.91752015249703
+                -90.11291652845065,
+                29.91756793518651
               ]
             }
           },
@@ -115,8 +391,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.11403207322888,
-                29.913996589647645
+                -90.1138829869531,
+                29.91388886396481
               ]
             }
           },
@@ -136,8 +412,162 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.11684471782463,
-                29.91463972276824
+                -90.11684056768013,
+                29.91447251482282
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p428 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5637.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5637
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,589.7 4137.7,358.0 4085.4,4154.3 5637.0,3978.1 5637.0,8149.0 -0.0,8149.0 -0.0,589.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11348697756564,
+                29.916714552287743
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11102114977325,
+                29.916624695940694
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11117102937193,
+                29.91353490530524
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11363685716432,
+                29.91362476165229
               ]
             }
           }
@@ -162,8 +592,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -182,7 +612,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"936.2,627.1 3700.4,386.9 4235.0,5538.7 5681.0,5388.7 5681.0,8150.0 1962.7,8150.0 1523.2,2074.4 959.6,2137.2 936.2,627.1\" /></svg>"
+          "value": "<svg><polygon points=\"2828.6,1591.5 3599.2,1577.3 4256.7,6070.6 5681.0,5864.2 5681.0,8150.0 -0.0,8150.0 -0.0,7259.9 1364.9,7240.2 1316.1,3723.1 -0.0,3890.7 -0.0,688.9 2791.3,483.5 2828.6,1591.5\" /></svg>"
         }
       },
       "body": {
@@ -211,8 +641,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.11166195495593,
-                29.916825317345516
+                -90.11166365414697,
+                29.916822346600533
               ]
             }
           },
@@ -232,8 +662,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10873385801618,
-                29.916677494969555
+                -90.10874073597257,
+                29.916678843074273
               ]
             }
           },
@@ -253,8 +683,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10897691038384,
-                29.913009257491847
+                -90.10897668719116,
+                29.913017093189346
               ]
             }
           },
@@ -274,8 +704,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1119050073236,
-                29.91315707986781
+                -90.11189960536555,
+                29.913160596715606
               ]
             }
           }
@@ -300,8 +730,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +750,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5637.0,731.8 5637.0,8149.0 358.6,8149.0 281.8,978.4 5637.0,731.8\" /></svg>"
+          "value": "<svg><polygon points=\"5637.0,8149.0 45.5,8149.0 280.0,-0.0 5637.0,-0.0 5637.0,8149.0\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +779,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10564854167487,
-                29.916877707248627
+                -90.10560229547595,
+                29.91690339997508
               ]
             }
           },
@@ -370,8 +800,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1055183206144,
-                29.914386539195668
+                -90.10533791870289,
+                29.914318615370384
               ]
             }
           },
@@ -391,8 +821,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10964432165657,
-                29.91422220990068
+                -90.10964931743463,
+                29.913987339702828
               ]
             }
           },
@@ -412,4443 +842,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10977454271705,
-                29.916713377953638
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p438",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5655
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8149.0 300.3,6558.9 118.9,1384.1 -0.0,1385.4 -0.0,0.0 5655.0,-0.0 5655.0,8149.0 -0.0,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0865594282041,
-                29.918790700388723
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5655.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08604281887956,
-                29.917619652642408
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5655.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08797556647771,
-                29.916970054251948
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08849217580224,
-                29.918141101998263
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p440",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5655
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1114.0,0.0 5655.0,103.8 5655.0,8149.0 2336.9,8149.0 1568.1,7975.6 1562.0,8149.0 -0.0,8149.0 -0.0,7412.1 499.0,7573.6 1114.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09087553890653,
-                29.921202774149304
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5655.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08816027377885,
-                29.922212113365422
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5655.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08649438926663,
-                29.918797922957793
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08920965439431,
-                29.917788583741675
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p443",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5686
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1355.4,3.0 5119.4,235.6 5019.4,7869.2 603.2,7714.3 1355.4,3.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09622493882532,
-                29.926699310482533
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5686.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09339922112265,
-                29.927548995090913
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5686.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09200465664425,
-                29.92401609960353
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09483037434691,
-                29.92316641499515
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p446",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5643
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"579.8,1886.4 4517.0,1961.6 5262.6,7112.9 3553.1,7286.9 571.1,7253.5 579.8,1886.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09769922471513,
-                29.92645139651953
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5643.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09475963737943,
-                29.926695651116496
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5643.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09435542782326,
-                29.922989894703456
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09729501515896,
-                29.92274564010649
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p454",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5597
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5597.0,218.6 5597.0,8149.3 3008.6,8150.0 3029.7,6009.0 1036.2,5977.6 1105.1,133.7 5597.0,218.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10286580935619,
-                29.91971873622939
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5597.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09996853861777,
-                29.919983729985493
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5597.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09952627539057,
-                29.916299753742226
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10242354612899,
-                29.916034759986125
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p455",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5710
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5235.9,7386.9 -0.0,7318.5 -0.0,611.2 5290.8,663.4 5235.9,7386.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10320420421807,
-                29.922978181068437
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5710.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10024513975398,
-                29.92323367773026
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5710.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09982757897802,
-                29.919549457322315
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10278664344212,
-                29.919293960660493
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p458",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5647
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"815.2,7276.8 767.9,2448.5 333.7,2452.2 321.2,936.5 5057.9,885.2 5116.0,7237.9 815.2,7276.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10229881983297,
-                29.926115718504715
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5647.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09934690917001,
-                29.926321539965322
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5647.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09900671092926,
-                29.922604694826042
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10195862159223,
-                29.922398873365434
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p472",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5673
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5405.0,6853.2 443.7,8064.7 340.1,644.2 4896.6,443.3 5405.0,6853.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11516442942678,
-                29.921189025108873
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5673.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11229163842674,
-                29.920597269985745
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5673.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11326554846119,
-                29.916995161289083
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11613833946122,
-                29.91758691641221
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p478",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5687
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"939.9,7285.9 922.6,2782.2 747.3,2780.6 709.7,992.0 2209.7,978.8 2208.0,0.0 4121.2,0.0 4731.5,7275.9 939.9,7285.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11380961558855,
-                29.927100562214623
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5687.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11090356935385,
-                29.92650500137232
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5687.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11188152379104,
-                29.922869877622308
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11478757002574,
-                29.923465438464614
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p481",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5668
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4543.2,1112.5 4542.2,8149.0 -0.0,8149.0 -0.0,-0.0 748.2,0.0 4543.2,1112.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11710095430881,
-                29.930297019475933
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5668.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11420341133895,
-                29.92970440637415
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5668.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11517951099395,
-                29.92606903040367
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11807705396383,
-                29.926661643505454
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p482",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5687
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"940.8,6466.7 877.6,1457.7 3884.1,1413.0 4893.0,6407.8 940.8,6466.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11520418587777,
-                29.929960098595263
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5687.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11230933123588,
-                29.92933459077866
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5687.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11333649064089,
-                29.92571357162332
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11623134528278,
-                29.926339079439924
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p483",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5705
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6811.4 -0.0,1579.1 998.7,1823.1 1359.8,298.8 5448.5,796.5 5452.0,7424.2 3408.1,7436.2 -0.0,6811.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11336835785565,
-                29.929644718748833
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5705.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11042162741187,
-                29.929533056391033
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5705.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11060438614258,
-                29.925859285423623
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11355111658635,
-                29.925970947781423
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p484",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5693
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4606.8,738.4 4693.9,6204.2 5602.4,6615.3 5606.6,7014.2 4701.6,6628.1 4714.9,8150.0 -0.0,8150.0 -0.0,7438.4 1040.5,7412.8 949.6,805.0 4606.8,738.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11103901315406,
-                29.92956635446732
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5693.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10809795765749,
-                29.92942091594108
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5693.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10833661678464,
-                29.925744681530258
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1112776722812,
-                29.9258901200565
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p488",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5693
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5175.5,933.9 5201.5,7117.5 1298.0,7140.2 1234.6,949.3 5175.5,933.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10263969516531,
-                29.928930126618486
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5693.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09967672279498,
-                29.9291496747071
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5693.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09931645425102,
-                29.925446028642593
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10227942662135,
-                29.925226480553977
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p490",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5693
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"896.7,989.1 3810.2,775.9 4927.2,8150.0 993.1,8150.0 896.7,989.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09814576837414,
-                29.929300897923376
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5693.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09517249232658,
-                29.929498027099473
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5693.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09484901102807,
-                29.92578151526212
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09782228707563,
-                29.925584386086026
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p491",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5707
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1358.7,448.6 3587.1,618.9 4097.9,7613.1 644.4,7402.7 1358.7,448.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09712785500285,
-                29.9300225722927
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5707.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09429511357142,
-                29.930849157829293
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5707.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09294250547917,
-                29.92731827612038
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09577524691059,
-                29.926491690583788
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p492",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5717
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5551.9,0.0 5717.0,0.0 5717.0,7803.5 396.4,7403.6 372.5,7709.6 -0.0,7659.5 -0.0,591.5 5546.7,884.6 5551.9,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09537389802821,
-                29.93054413721939
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5717.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09261586325981,
-                29.931549244550588
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5717.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09097341676294,
-                29.928116315340795
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09373145153134,
-                29.927111208009595
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p493",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5688
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5688.0,132.2 5688.0,7472.5 4559.1,7287.1 4410.9,8150.0 -0.0,8150.0 860.2,3191.4 876.2,47.3 5688.0,-0.0 5688.0,132.2 5688.0,132.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09431921750284,
-                29.935096877876756
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5688.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09318897809922,
-                29.932726176453674
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5688.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09708216422933,
-                29.931312495836295
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09821240363296,
-                29.93368319725938
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p494",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5717
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1523.2,7291.1 1489.3,-0.0 5192.3,-0.0 4981.0,5568.5 4660.4,7791.1 1523.2,7291.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09354663852841,
-                29.933329257416375
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5717.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09241599056257,
-                29.93092615644651
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5717.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09634298127885,
-                29.929518866932586
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0974736292447,
-                29.93192196790245
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p500",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5670
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1292.8,6375.3 1228.6,881.7 3424.6,845.8 4572.4,837.3 4603.3,6347.1 1292.8,6375.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10439772913115,
-                29.934589284496933
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5670.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10142036874036,
-                29.934793741860105
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5670.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1010836612844,
-                29.93105920004781
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10406102167518,
-                29.93085474268464
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p502",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5705
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5354.7,7162.5 509.7,7170.0 499.5,0.0 5346.6,0.0 5354.7,7162.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10412024777521,
-                29.931663970519356
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5705.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10114851194898,
-                29.931890236352217
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5705.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10077817249883,
-                29.928185372883153
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10374990832507,
-                29.92795910705029
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p507",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5642
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4469.1,8080.9 652.1,6909.1 -0.0,6900.7 -0.0,-0.0 1794.6,0.0 4552.2,291.4 4469.1,8080.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11627443981479,
-                29.933345215214803
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5642.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1134094915995,
-                29.93279290254569
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5642.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11432375682328,
-                29.92918068902637
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11718870503857,
-                29.929733001695485
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p508",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5708
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5104.6,94.4 5084.3,8149.0 970.9,8149.0 973.1,99.3 5104.6,94.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11447640314096,
-                29.932913927905965
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5708.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11158788407646,
-                29.932329384874997
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5708.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11254396964009,
-                29.92873082215446
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11543248870458,
-                29.929315365185428
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p515",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5642
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"726.2,1769.1 5067.1,1856.4 5047.4,7244.2 -0.0,7220.7 -0.0,840.7 731.9,850.7 726.2,1769.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10345551223227,
-                29.93755229136845
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5642.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10052954397808,
-                29.937787265371774
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5642.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10014056445434,
-                29.934098283522058
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10306653270852,
-                29.933863309518735
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p518",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5719
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5146.2,3115.3 4307.2,7930.4 115.1,7171.8 940.5,2891.0 958.7,37.8 5173.7,-0.0 5146.2,3115.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09521468232933,
-                29.936896655767256
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5719.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09405734105555,
-                29.934494437153358
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5719.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09798028473479,
-                29.933054981861655
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09913762600857,
-                29.935457200475557
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p520",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5719
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"7.3,6785.3 1163.8,0.0 5719.0,0.0 5719.0,379.9 5719.0,611.3 5719.0,611.3 5719.0,3156.8 5719.0,7226.8 3463.8,7335.1 7.3,6785.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10048179444196,
-                29.940340548511244
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5719.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09771508303801,
-                29.94132848287271
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5719.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09610166933764,
-                29.937887500125694
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09886838074159,
-                29.93689956576423
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p522",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5719
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5332.9,35.3 5364.5,8150.0 3145.5,8150.0 3144.3,7230.3 811.0,7233.9 696.3,93.4 5332.9,35.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10498140429868,
-                29.940348267107176
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5719.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10201714353178,
-                29.94056659804193
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5719.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10166058502337,
-                29.93687990346377
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10462484579027,
-                29.936661572529015
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p524",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5750
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,754.0 5750.0,1965.1 5730.2,8149.0 3547.9,8149.0 3673.2,7158.6 539.5,7063.6 626.7,3224.6 251.1,2199.2 369.0,1040.6 0.0,960.6 0.0,754.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11075583272188,
-                29.93858232226066
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5750.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11069893898,
-                29.9411853769808
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5750.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10647353473735,
-                29.941115046462546
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10653042847922,
-                29.938511991742402
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p525",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5634
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"654.3,0.0 3850.0,0.0 3798.2,3322.4 4532.7,3309.7 4519.6,7185.2 5634.0,7178.7 5634.0,7382.7 688.1,7408.0 676.8,3334.5 437.5,3332.9 654.3,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11476671219476,
-                29.936602699858714
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5634.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11408663096624,
-                29.939111164481155
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5634.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10992811370812,
-                29.938252532603016
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11060819493666,
-                29.93574406798058
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p531",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6087.1 486.1,4512.6 -0.0,4364.0 -0.0,0.0 5660.0,0.0 5660.0,7858.4 2709.5,7855.2 2817.7,6853.8 106.0,6550.9 -0.0,6463.9 -0.0,6087.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11003407476443,
-                29.94709375968909
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1041522160102,
-                29.947549397391608
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5660.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10340055254838,
-                29.940160494089383
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1092824113026,
-                29.939704856386864
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0425/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p425",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0425/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0425/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5700
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4271.6,388.6 4534.4,242.7 4533.0,2730.0 3670.5,2747.0 3727.0,5782.4 5700.0,5398.0 5700.0,8150.0 -0.0,8150.0 54.1,398.7 4271.6,388.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0425/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                976.0,
-                2771.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1202085,
-                29.9167667
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2812.0,
-                419.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.118969,
-                29.917632
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0426/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p426",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0426/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0426/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5637
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3338.7 860.9,3337.8 908.5,855.4 4706.4,24.4 4427.6,6481.9 5637.0,6538.3 5637.0,8149.0 1936.3,8149.0 1975.9,6022.2 -0.0,6369.2 -0.0,3338.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0426/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2776.5,
-                2884.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1173043,
-                29.9164294
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4816.9,
-                -88.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1159036,
-                29.9175779
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p428 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5637.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8149.0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5637
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5637.0,1728.9 5637.0,8149.0 -0.0,8149.0 -0.0,303.4 5177.3,298.1 5095.4,1750.2 5637.0,1728.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3128.6,
-                296.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1123056,
-                29.9165059
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1024.2,
-                296.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1134413,
-                29.9164918
+                -90.10991369420769,
+                29.916572124307525
               ]
             }
           }
@@ -4866,15 +861,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4893,7 +888,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,348.3 5681.0,322.0 5681.0,8150.0 -0.0,8150.0 -0.0,348.3\" /></svg>"
+          "value": "<svg><polygon points=\"4718.3,330.4 4697.8,8147.1 -0.0,8150.0 -0.0,5714.8 1034.8,5718.9 1055.8,344.4 4718.3,330.4\" /></svg>"
         }
       },
       "body": {
@@ -4922,8 +917,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10615293198569,
-                29.916880652663885
+                -90.10615891962927,
+                29.916877229733693
               ]
             }
           },
@@ -4943,8 +938,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10317808509282,
-                29.91711560918433
+                -90.10317771440536,
+                29.917116457345635
               ]
             }
           },
@@ -4964,8 +959,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10278878608935,
-                29.913417323135423
+                -90.10278157511915,
+                29.913408054254194
               ]
             }
           },
@@ -4985,29 +980,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10576363298222,
-                29.913182366614976
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5100.9,
-                331.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.103466,
-                29.916941
+                -90.10576278034306,
+                29.913168826642252
               ]
             }
           }
@@ -5025,15 +999,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5052,7 +1026,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4367.5,2859.2 4192.5,8149.0 973.6,8127.8 963.6,296.9 5148.9,284.0 5154.2,2681.2 4367.5,2859.2\" /></svg>"
+          "value": "<svg><polygon points=\"5157.8,2421.0 5637.0,2414.0 5637.0,8149.0 -0.0,8149.0 -0.0,302.7 5148.9,284.0 5157.8,2421.0\" /></svg>"
         }
       },
       "body": {
@@ -5081,8 +1055,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10368130161875,
-                29.91706490203301
+                -90.10368131053814,
+                29.91706490176609
               ]
             }
           },
@@ -5102,8 +1076,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10072915650292,
-                29.917294758544706
+                -90.1007291557056,
+                29.917294759034334
               ]
             }
           },
@@ -5123,8 +1097,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10034552275718,
-                29.913597857865486
+                -90.10034552069715,
+                29.91359784618711
               ]
             }
           },
@@ -5144,50 +1118,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.103297667873,
-                29.913368001353795
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5148.9,
-                284.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.101228,
-                29.917131
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5148.9,
-                284.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1009714,
-                29.917146
+                -90.10329767552969,
+                29.913367988918864
               ]
             }
           }
@@ -5195,25 +1127,41 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0433/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p433",
+      "label": "New Orleans, La. | 1951 | Vol. 5 p435",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5693.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5222,21 +1170,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0433/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0433/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435/info.json",
           "type": "ImageService2",
-          "height": 8150,
-          "width": 5681
+          "height": 8149,
+          "width": 5693
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"775.4,1047.3 5681.0,773.0 5681.0,8150.0 -0.0,8150.0 -0.0,1511.9 780.4,1308.1 775.4,1047.3\" /></svg>"
+          "value": "<svg><polygon points=\"3524.5,401.1 4591.9,8149.0 -0.0,8149.0 -0.0,2489.7 3063.3,2494.8 3066.7,406.5 3524.5,401.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0433/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -5261,8 +1209,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10130438292997,
-                29.916633694638026
+                -90.09666664817108,
+                29.91769174194716
               ]
             }
           },
@@ -5270,7 +1218,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5681.0,
+                5693.0,
                 0.0
               ],
               "creator": {
@@ -5282,8 +1230,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09832197427549,
-                29.916779999601353
+                -90.09369409995347,
+                29.91792027628109
               ]
             }
           },
@@ -5291,8 +1239,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5681.0,
-                8150.0
+                5693.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5303,8 +1251,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09807956186525,
-                29.913072312881273
+                -90.09331664724918,
+                29.914232283347058
               ]
             }
           },
@@ -5313,7 +1261,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8150.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5324,231 +1272,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10106197051972,
-                29.91292600791795
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5024.9,
-                375.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0986553,
-                29.916593
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p434",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5637
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5637,0 5637,8149 0,8149\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2800.5,
-                412.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09753,
-                29.9167022
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                632.1,
-                412.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0986553,
-                29.916593
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p435",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5693.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8149.0"
-        }
-      ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5693
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2337.0,1858.6 2432.4,414.1 3570.0,483.9 3919.5,2288.4 5693.0,2191.2 5693.0,8149.0 -0.0,8149.0 -0.0,2003.3 2337.0,1858.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2432.4,
-                416.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0953774,
-                29.917602
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                300.1,
-                416.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0964908,
-                29.9175164
+                -90.0962891954668,
+                29.914003749013126
               ]
             }
           }
@@ -5566,15 +1291,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5593,34 +1318,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3959.2,736.1 4434.4,8149.0 665.1,8149.0 1825.7,2158.0 -0.0,1907.1 -0.0,-0.0 3959.2,736.1\" /></svg>"
+          "value": "<svg><polygon points=\"3984.4,719.1 4874.0,8149.0 -0.0,8149.0 -0.0,106.2 4302.3,682.5 3984.4,719.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0436/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3232.6,
-                524.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0931377,
-                29.9177871
+                -90.09481997559158,
+                29.917697821715024
               ]
             }
           },
@@ -5628,20 +1356,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5016.9,
-                856.1
+                5637.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0922248,
-                29.9178626
+                -90.09201547640663,
+                29.918263049876074
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09107930896756,
+                29.91472400842436
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09388380815251,
+                29.91415878026331
               ]
             }
           }
@@ -5659,15 +1429,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5686,34 +1456,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5693.0,1369.2 5693.0,8149.0 -0.0,8149.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5693.0,2838.5 3986.1,2498.1 4339.7,7126.8 5693.0,7023.4 5693.0,8149.0 -0.0,8149.0 -0.0,-0.0 5693.0,1369.2 5693.0,2838.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0437/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3176.6,
-                716.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0910923,
-                29.9179614
+                -90.09275504741147,
+                29.917785055857788
               ]
             }
           },
@@ -5721,20 +1494,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5064.9,
-                1208.1
+                5693.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0900927,
-                29.9180392
+                -90.08999797034964,
+                29.918640640735422
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08858488180763,
+                29.91521994152187
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09134195886946,
+                29.914364356644235
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p438",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5655
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"86.9,6382.5 1854.6,822.7 404.6,759.1 420.8,-0.0 5655.0,-0.0 5655.0,8149.0 1069.4,8149.0 1533.2,6493.0 86.9,6382.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08674490802309,
+                29.919275848870566
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5655.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08554386417904,
+                29.91694528257355
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5655.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08941752357566,
+                29.91544565944119
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09061856741971,
+                29.917776225738205
               ]
             }
           }
@@ -5752,15 +1705,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5779,34 +1732,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4103.3,7830.9 4128.2,8149.0 3373.3,8149.0 3362.6,7656.0 897.9,7074.2 864.1,380.6 4627.2,373.0 4607.8,7950.0 4103.3,7830.9\" /></svg>"
+          "value": "<svg><polygon points=\"900.2,7091.7 824.0,392.6 4630.4,388.8 4636.7,7971.1 900.2,7091.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0439/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2763.5,
-                4688.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0905564,
-                29.919267
+                -90.09271217545098,
+                29.920910614189378
               ]
             }
           },
@@ -5814,20 +1770,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2763.5,
-                2600.3
+                5659.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0909053,
-                29.9201733
+                -90.08989634014083,
+                29.92172714213175
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5659.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08854964357022,
+                29.918188980032586
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09136547888038,
+                29.917372452090213
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p440",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5655
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1114.1,0.0 5655.0,103.7 5632.9,7412.7 4876.4,7407.9 4858.6,8149.0 2337.3,8149.0 499.1,7573.5 1114.1,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09087559862282,
+                29.921202748501937
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5655.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08816030024285,
+                29.92221208891432
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5655.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0864944137562,
+                29.918797856695114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08920971213617,
+                29.91778851628273
               ]
             }
           }
@@ -5845,15 +1981,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5872,34 +2008,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1318.3,565.8 5671.0,513.1 5671.0,7243.9 650.5,7290.3 1318.3,565.8\" /></svg>"
+          "value": "<svg><polygon points=\"5671.0,7243.9 152.1,7293.8 714.2,571.5 5671.0,458.9 5671.0,7243.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0441/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3603.4,
-                2824.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0919936,
-                29.9230615
+                -90.09425302234409,
+                29.923769488352626
               ]
             }
           },
@@ -5907,20 +2046,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5455.0,
-                7256.9
+                5671.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0903439,
-                29.9214099
+                -90.09142569858462,
+                29.924575347966428
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5671.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09009000581834,
+                29.92105522401279
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09291732957782,
+                29.920249364398988
               ]
             }
           }
@@ -5938,15 +2119,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5965,34 +2146,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4939.5,0.0 5655.0,0.0 5655.0,8149.0 5416.2,8149.0 5415.2,7513.8 855.4,7439.7 856.8,7420.4 1075.0,7424.8 1622.4,657.8 4938.6,723.5 4939.5,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5655.0,0.0 5655.0,8149.0 5416.1,8149.0 5415.1,7513.8 855.4,7439.8 856.8,7420.4 1075.0,7424.8 1626.8,603.2 4938.6,723.5 4939.5,0.0 5655.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0442/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4811.1,
-                2960.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0893477,
-                29.9239549
+                -90.09225234327374,
+                29.92434312408746
               ]
             }
           },
@@ -6000,20 +2184,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4811.1,
-                7512.9
+                5655.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0884285,
-                29.9220625
+                -90.08954049172772,
+                29.925332564837262
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5655.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08789586247867,
+                29.92194668973845
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0906077140247,
+                29.92095724898865
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p443",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5686
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1306.5,0.0 5121.9,237.5 5023.4,7877.8 603.2,7723.7 1306.5,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09622440064163,
+                29.92670078082605
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5686.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09340098271565,
+                29.927549234059743
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5686.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09200843917934,
+                29.924019214105154
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09483185710532,
+                29.92317076087146
               ]
             }
           }
@@ -6031,15 +2395,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6065,27 +2429,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0444/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2123.6,
-                6102.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.091751,
-                29.9250945
+                -90.09384889105159,
+                29.92744945274051
               ]
             }
           },
@@ -6093,20 +2460,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                311.9,
-                303.9
+                5643.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0936405,
-                29.9273622
+                -90.09100567170333,
+                29.92827316422265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5643.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0896328855891,
+                29.924714090861556
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09247610493736,
+                29.92389037937942
               ]
             }
           }
@@ -6124,15 +2533,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6151,34 +2560,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"696.5,1872.6 5026.0,1893.0 5047.5,7253.1 694.6,7256.5 696.5,1872.6\" /></svg>"
+          "value": "<svg><polygon points=\"5021.9,865.6 5047.5,7253.1 1225.5,7256.0 1283.9,875.2 5021.9,865.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0445/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                695.8,
-                3948.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0994756,
-                29.9245022
+                -90.10002378526023,
+                29.926266075527774
               ]
             }
           },
@@ -6186,20 +2598,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5034.2,
-                3948.5
+                5686.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0972027,
-                29.9246772
+                -90.09704492461505,
+                29.92649543036648
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5686.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09666583349804,
+                29.922797171126938
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09964469414322,
+                29.922567816288232
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p446",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5643
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"571.8,7253.8 582.2,881.8 2735.7,913.9 4337.4,716.7 5263.3,7113.2 3553.9,7287.1 571.8,7253.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09769964670193,
+                29.926451546475608
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5643.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09476000853572,
+                29.92669580340598
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5643.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09435579511806,
+                29.92298998291407
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09729543328427,
+                29.9227457259837
               ]
             }
           }
@@ -6217,15 +2809,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6251,27 +2843,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0447/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2796.5,
-                7330.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.096755,
-                29.9201345
+                -90.09854843917728,
+                29.92338652502712
               ]
             }
           },
@@ -6279,20 +2874,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2796.5,
-                683.8
+                5681.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.097042,
-                29.923178
+                -90.0955481349986,
+                29.923599047355733
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5681.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09519620599738,
+                29.919867005839485
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09819651017607,
+                29.91965448351087
               ]
             }
           }
@@ -6310,15 +2947,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6337,34 +2974,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"870.5,626.5 5643.0,673.7 5643.0,7409.4 1764.8,7508.5 28.9,7272.5 870.5,626.5\" /></svg>"
+          "value": "<svg><polygon points=\"28.9,7272.5 870.5,626.5 5044.1,739.0 5148.8,7461.9 1764.8,7508.5 28.9,7272.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0448/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3447.4,
-                5238.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0941098,
-                29.9214621
+                -90.09647942231919,
+                29.923453931088442
               ]
             }
           },
@@ -6372,20 +3012,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1763.7,
-                755.8
+                5643.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0954869,
-                29.9232919
+                -90.0935799940044,
+                29.92401247522296
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5643.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09264917210574,
+                29.920382884877494
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09554860042053,
+                29.919824340742977
               ]
             }
           }
@@ -6403,15 +3085,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6430,34 +3112,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2288.6,1162.7 3971.0,930.7 4812.1,6843.4 555.9,6895.8 544.0,1164.1 2288.6,1162.7\" /></svg>"
+          "value": "<svg><polygon points=\"544.0,1164.1 2288.6,1162.7 3971.0,930.7 4812.1,6843.3 555.9,6895.8 544.0,1164.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0449/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                544.0,
-                5168.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0954591,
-                29.91839
+                -90.09597140005148,
+                29.92072882130453
               ]
             }
           },
@@ -6465,20 +3150,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                544.0,
-                1164.1
+                5692.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.095634,
-                29.920218
+                -90.09297310769813,
+                29.920944314553463
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5692.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0926171923135,
+                29.917224398469546
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09561548466685,
+                29.917008905220612
               ]
             }
           }
@@ -6496,15 +3223,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6523,34 +3250,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"966.2,1038.0 4208.7,882.3 4753.5,7548.8 896.7,7014.6 966.2,1038.0\" /></svg>"
+          "value": "<svg><polygon points=\"896.7,7014.6 966.2,1038.0 4208.7,882.3 4753.5,7548.8 896.7,7014.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0450/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2640.5,
-                5078.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0924814,
-                29.9188349
+                -90.09446292797017,
+                29.92081301438828
               ]
             }
           },
@@ -6558,20 +3288,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2640.5,
-                1023.7
+                5597.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0929817,
-                29.9206404
+                -90.09159025461726,
+                29.921410975686392
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5597.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09058521627324,
+                29.917783958436512
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09345788962615,
+                29.9171859971384
               ]
             }
           }
@@ -6589,15 +3361,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6616,34 +3388,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4364.0,239.6 4303.3,8104.9 1093.1,8136.3 1020.9,223.2 4364.0,239.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,215.5 4364.0,239.6 4303.3,8098.9 -0.0,8149.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0451/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2848.0,
-                2460.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0988941,
-                29.918953
+                -90.10049966890479,
+                29.919941995581997
               ]
             }
           },
@@ -6651,20 +3426,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2848.0,
-                232.0
+                5692.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0990042,
-                29.9199592
+                -90.09753374463479,
+                29.9201857828295
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5692.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09713109885381,
+                29.916506017299863
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10009702312381,
+                29.91626223005236
               ]
             }
           }
@@ -6682,15 +3499,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6709,34 +3526,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2514.4,7660.8 2515.2,8150.0 -0.0,8150.0 -0.0,253.0 4970.6,247.2 4865.3,7511.5 2514.4,7660.8\" /></svg>"
+          "value": "<svg><polygon points=\"4958.9,6058.5 5597.0,6049.9 5597.0,8150.0 -0.0,8150.0 -0.0,253.0 4970.6,247.2 4958.9,6058.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0452/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2820.5,
-                4314.9
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0965662,
-                29.918303
+                -90.09822530960484,
+                29.92013460331926
               ]
             }
           },
@@ -6744,20 +3564,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4960.9,
-                6058.5
+                5597.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0953774,
-                29.917602
+                -90.09532003948237,
+                29.920353793415355
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5597.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09495162645602,
+                29.91668565768149
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09785689657849,
+                29.916466467585394
               ]
             }
           }
@@ -6775,15 +3637,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6802,34 +3664,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"783.1,1131.8 5710.0,1144.2 5710.0,6962.0 780.0,6980.2 783.1,1131.8\" /></svg>"
+          "value": "<svg><polygon points=\"5710.0,1144.2 5710.0,6962.0 780.0,6980.2 783.1,1131.8 5710.0,1144.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0453/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5038.2,
-                3368.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1025314,
-                29.9186713
+                -90.10533829330612,
+                29.919991268528314
               ]
             }
           },
@@ -6837,20 +3702,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5038.2,
-                1140.1
+                5710.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1026392,
-                29.9196843
+                -90.10234183328029,
+                29.920230801742605
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10194759880996,
+                29.916526167990355
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10494405883578,
+                29.916286634776064
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p454",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5597
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4493.8,8115.7 3002.4,8150.0 3021.5,6005.2 1025.1,5975.8 1088.4,123.4 4558.9,186.4 4493.8,8115.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1028557760438,
+                29.919715323844372
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5597.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0999623924253,
+                29.919977485327372
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5597.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0995248574407,
+                29.916298440754336
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1024182410592,
+                29.916036279271335
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p455",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5710
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5235.6,7388.1 365.9,7323.1 445.3,616.8 5290.4,664.6 5235.6,7388.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10320408924036,
+                29.922978722101824
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1002450306196,
+                29.923234238294114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0998274379248,
+                29.919550025161488
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10278649654556,
+                29.919294508969198
               ]
             }
           }
@@ -6868,15 +4051,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6902,27 +4085,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0456/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2803.5,
-                5112.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0991164,
-                29.9209845
+                -90.10081729477723,
+                29.92318553833142
               ]
             }
           },
@@ -6930,20 +4116,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2803.5,
-                656.1
+                5647.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0993223,
-                29.9230009
+                -90.09786706250628,
+                29.923411828547366
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5647.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09749039586954,
+                29.919723093208333
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10044062814049,
+                29.919496802992388
               ]
             }
           }
@@ -6961,15 +4189,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6995,27 +4223,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0457/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                607.8,
-                3956.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1042006,
-                29.9241385
+                -90.10471255540885,
+                29.925906989031343
               ]
             }
           },
@@ -7023,20 +4254,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2723.0,
-                904.1
+                5710.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1032427,
-                29.9256126
+                -90.1017232387153,
+                29.926149460997152
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10132414976505,
+                29.9224538231971
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1043134664586,
+                29.92221135123129
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p458",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5647
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"769.4,2446.8 335.3,2450.4 323.3,935.1 5647.0,879.0 5647.0,7231.3 815.3,7273.6 769.4,2446.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.102300046919,
+                29.926115083299415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5647.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09934729018339,
+                29.926321718388976
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5647.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09900574711136,
+                29.922603807932575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10195850384697,
+                29.922397172843013
               ]
             }
           }
@@ -7054,15 +4465,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7081,34 +4492,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1044.9,546.0 3166.1,851.9 5332.2,820.0 5338.5,7166.5 2339.6,7124.2 233.5,6867.1 1044.9,546.0\" /></svg>"
+          "value": "<svg><polygon points=\"1020.8,532.4 3156.1,833.5 5335.5,794.6 5362.0,7180.3 2344.5,7147.2 224.5,6895.2 1020.8,532.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0459/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3233.1,
-                3859.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1075723,
-                29.9238789
+                -90.10943269822748,
+                29.92550045212954
               ]
             }
           },
@@ -7116,20 +4530,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5337.9,
-                3859.1
+                5698.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1064661,
-                29.9239641
+                -90.10645835940153,
+                29.925721334210852
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5698.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10609360684093,
+                29.922032059817337
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10906794566688,
+                29.921811177736025
               ]
             }
           }
@@ -7147,15 +4603,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7181,27 +4637,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0460/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                627.9,
-                3904.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1064661,
-                29.9239641
+                -90.10698044612374,
+                29.925698615234307
               ]
             }
           },
@@ -7209,20 +4668,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2807.5,
-                840.1
+                5647.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1054789,
-                29.9254367
+                -90.10404141251185,
+                29.925933779544092
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5647.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10364996714898,
+                29.922259116890885
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10658900076088,
+                29.9220239525811
               ]
             }
           }
@@ -7240,15 +4741,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7274,27 +4775,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0461/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2817.0,
-                5126.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1061099,
-                29.9204444
+                -90.10782277870277,
+                29.922653030645748
               ]
             }
           },
@@ -7302,20 +4806,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                696.2,
-                5126.7
+                5698.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1072181,
-                29.9203581
+                -90.10484527530657,
+                29.92288490083443
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5698.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1044623879613,
+                29.91919160115042
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1074398913575,
+                29.91895973096174
               ]
             }
           }
@@ -7333,15 +4879,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7360,34 +4906,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"611.9,695.9 4439.5,694.0 4499.9,7370.2 604.7,7374.7 611.9,695.9\" /></svg>"
+          "value": "<svg><polygon points=\"604.7,7374.7 611.9,695.9 4880.2,693.8 4862.1,7369.8 604.7,7374.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0462/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2775.5,
-                5140.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1038381,
-                29.9206131
+                -90.10553453290096,
+                29.922837452087833
               ]
             }
           },
@@ -7395,20 +4944,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2775.5,
-                2960.4
+                5647.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10394,
-                29.9216042
+                -90.10257182878807,
+                29.92306626459962
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5647.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10219096585233,
+                29.919361914691358
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10515366996522,
+                29.919133102179572
               ]
             }
           }
@@ -7426,15 +5017,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7460,27 +5051,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0463/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3024.5,
-                3360.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1080868,
-                29.918237
+                -90.10982531718145,
+                29.919657705863575
               ]
             }
           },
@@ -7488,20 +5082,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2784.5,
-                5172.6
+                5645.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1081334,
-                29.9174021
+                -90.10685237097042,
+                29.91987025007721
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5645.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1064983461384,
+                29.916150355407236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10947129234943,
+                29.9159378111936
               ]
             }
           }
@@ -7519,15 +5155,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7546,34 +5182,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4991.2,1135.3 4987.9,6994.9 -0.0,6971.3 -0.0,1128.4 4991.2,1135.3\" /></svg>"
+          "value": "<svg><polygon points=\"4987.9,6994.9 3082.8,7008.0 -0.0,6971.3 -0.0,1128.4 4991.2,1135.3 4987.9,6994.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0464/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2812.0,
-                5180.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1058182,
-                29.9175828
+                -90.1075407861247,
+                29.919815738636867
               ]
             }
           },
@@ -7581,20 +5220,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4976.0,
-                3368.4
+                5664.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1047727,
-                29.9184957
+                -90.10457518892913,
+                29.92005290856629
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5664.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10418153786367,
+                29.916355342804636
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10714713505924,
+                29.916118172875212
               ]
             }
           }
@@ -7612,15 +5293,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7646,27 +5327,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0465/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2872.5,
-                4908.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1122491,
-                29.9175564
+                -90.1136398477628,
+                29.919862438620058
               ]
             }
           },
@@ -7674,20 +5358,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4952.9,
-                3072.4
+                5645.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1111069,
-                29.9183497
+                -90.11066409273009,
+                29.919738303527314
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5645.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1108708579394,
+                29.916014881060566
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11384661297211,
+                29.91613901615331
               ]
             }
           }
@@ -7705,15 +5431,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7732,34 +5458,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"960.0,868.1 5664.0,863.8 5664.0,6833.7 928.6,7152.0 960.0,868.1\" /></svg>"
+          "value": "<svg><polygon points=\"5664.0,6833.7 3386.1,6986.8 3533.7,8149.0 2773.7,8149.0 2756.6,7047.5 928.6,7152.0 960.0,868.1 5664.0,863.8 5664.0,6833.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0466/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2772.0,
-                4960.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1101921,
-                29.9174787
+                -90.1115412905715,
+                29.919771131922833
               ]
             }
           },
@@ -7767,20 +5496,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                960.0,
-                868.1
+                5664.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1110572,
-                29.9193618
+                -90.10858367570005,
+                29.919673853571595
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5664.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10874513455954,
+                29.91598618830042
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11170274943099,
+                29.916083466651656
               ]
             }
           }
@@ -7798,15 +5569,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7832,27 +5603,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0467/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2860.5,
-                5168.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1100463,
-                29.9203618
+                -90.1114412883634,
+                29.922772547103868
               ]
             }
           },
@@ -7860,20 +5634,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2860.5,
-                668.1
+                5645.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1099501,
-                29.9224148
+                -90.10847035638794,
+                29.922667973928398
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5645.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10864454252128,
+                29.918950675261748
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11161547449673,
+                29.919055248437218
               ]
             }
           }
@@ -7891,15 +5707,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7925,27 +5741,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0468/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2912.0,
-                648.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.107889,
-                29.922356
+                -90.10941239513195,
+                29.922708318575353
               ]
             }
           },
@@ -7953,20 +5772,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2912.0,
-                7416.9
+                5664.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1080385,
-                29.9192585
+                -90.10642146671185,
+                29.922599882877805
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5664.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10660144986788,
+                29.918870800431005
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10959237828799,
+                29.918979236128553
               ]
             }
           }
@@ -7984,15 +5845,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8018,27 +5879,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0469/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5032.9,
-                4872.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1125881,
-                29.9214831
+                -90.11457791363851,
+                29.924157570609538
               ]
             }
           },
@@ -8046,20 +5910,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4696.8,
-                712.1
+                5645.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1122649,
-                29.9233598
+                -90.11169562331023,
+                29.923576253086505
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5645.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11266392366014,
+                29.91996989306072
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11554621398842,
+                29.920551210583753
               ]
             }
           }
@@ -8077,15 +5983,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8111,27 +6017,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0470/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4536.8,
-                5108.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1110066,
-                29.9203953
+                -90.11326617017791,
+                29.922800598964294
               ]
             }
           },
@@ -8139,20 +6048,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2436.4,
-                7372.9
+                5673.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1121565,
-                29.9194091
+                -90.11029747493986,
+                29.922690357137387
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5673.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11048019652108,
+                29.91899418857401
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11344889175913,
+                29.919104430400917
               ]
             }
           }
@@ -8170,15 +6121,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8204,27 +6155,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0471/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2772.5,
-                6588.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1170136,
-                29.917551
+                -90.11764360417934,
+                29.920761615618737
               ]
             }
           },
@@ -8232,20 +6186,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2772.5,
-                924.1
+                5645.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1163355,
-                29.9200642
+                -90.11475503890372,
+                29.920176147625998
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5645.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11573023068769,
+                29.916561854761447
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1186187959633,
+                29.917147322754186
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p472",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5673
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5433.6,6844.2 445.7,8068.6 333.2,648.0 4889.5,441.6 5433.6,6844.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11516002324717,
+                29.921190061134144
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5673.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11228814191308,
+                29.920595290296415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5673.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11326701520782,
+                29.916994322203298
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11613889654191,
+                29.917589093041027
               ]
             }
           }
@@ -8263,15 +6397,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8290,34 +6424,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 499.7,0.0 495.7,956.1 4545.3,960.1 4541.1,7107.7 4274.3,7254.6 -0.0,7247.9 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,953.2 4545.3,960.1 4541.1,7107.7 4274.3,7254.6 -0.0,7247.9 -0.0,953.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0473/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2783.0,
-                5048.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.118712,
-                29.918625
+                -90.11954443491547,
+                29.92115292517662
               ]
             }
           },
@@ -8325,20 +6462,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2783.0,
-                940.1
+                5670.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1182277,
-                29.9204507
+                -90.11663600013709,
+                29.920573368211024
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11759658348664,
+                29.916952189145775
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.12050501826502,
+                29.917531746111372
               ]
             }
           }
@@ -8356,15 +6535,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8383,34 +6562,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"550.2,8149.0 -0.0,8149.0 18.1,1989.7 4572.6,1983.7 4604.4,7130.1 542.9,7150.9 550.2,8149.0\" /></svg>"
+          "value": "<svg><polygon points=\"39.8,1994.0 990.3,1994.4 988.1,994.2 4555.7,935.4 4584.8,7100.9 554.7,7113.8 560.7,8149.0 -0.0,8149.0 39.8,1994.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0474/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2840.5,
-                3008.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1167618,
-                29.9259157
+                -90.11785670697816,
+                29.927553725597296
               ]
             }
           },
@@ -8418,20 +6600,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4584.8,
-                5056.6
+                5673.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1161206,
-                29.924828
+                -90.11494188762354,
+                29.926957946999316
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5673.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1159293945711,
+                29.92332895526311
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11884421392571,
+                29.92392473386109
               ]
             }
           }
@@ -8449,15 +6673,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8476,34 +6700,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"704.9,7985.5 642.6,0.0 4771.3,0.0 4776.6,4042.6 5292.5,4044.1 5354.5,8121.2 704.9,7985.5\" /></svg>"
+          "value": "<svg><polygon points=\"5354.5,8121.2 704.9,7985.5 642.6,0.0 4771.3,0.0 4776.6,4042.6 5292.5,4044.1 5354.5,8121.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0475/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                655.8,
-                4068.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1173261,
-                29.9202617
+                -90.11947973459948,
+                29.920393170074934
               ]
             }
           },
@@ -8511,20 +6738,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4774.3,
-                440.1
+                5670.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1186843,
-                29.9224592
+                -90.11880163916882,
+                29.922900940851306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11464509982105,
+                29.922056680575597
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1153231952517,
+                29.919548909799225
               ]
             }
           }
@@ -8542,15 +6811,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "30"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8569,34 +6838,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4470.3,3099.4 4480.9,8137.0 1258.9,8125.9 1214.9,4055.1 699.5,4051.2 711.9,15.1 4824.0,0.0 4816.0,3098.7 4470.3,3099.4\" /></svg>"
+          "value": "<svg><polygon points=\"699.5,4051.2 713.0,454.5 711.8,0.0 4824.0,0.0 4813.6,4054.5 5395.2,4053.3 5396.6,8140.1 1258.9,8125.9 1214.9,4055.1 699.5,4051.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0476/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2743.5,
-                4059.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1166024,
-                29.9229921
+                -90.11900049864548,
+                29.92218947827652
               ]
             }
           },
@@ -8604,20 +6876,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5395.1,
-                5982.5
+                5687.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1153072,
-                29.9239714
+                -90.11833239736731,
+                29.924709965703848
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5687.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11416444881199,
+                29.923880088844413
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11483255009016,
+                29.921359601417084
               ]
             }
           }
@@ -8635,15 +6949,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "26"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8662,34 +6976,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"966.0,988.6 4765.3,1010.4 4792.8,2782.8 4965.3,2785.9 4953.6,8149.0 -0.0,8149.0 -0.0,7808.9 939.9,7813.3 966.0,988.6\" /></svg>"
+          "value": "<svg><polygon points=\"4958.5,7248.1 939.9,7241.2 966.0,988.6 4765.3,1010.4 4792.8,2782.8 4965.3,2785.9 4958.5,7248.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0477/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                939.7,
-                3760.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.115882,
-                29.9257368
+                -90.1159259273573,
+                29.927528202993425
               ]
             }
           },
@@ -8697,20 +7014,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                939.7,
-                5776.7
+                5670.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1161206,
-                29.924828
+                -90.11297567098858,
+                29.92694640745033
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11394001265526,
+                29.92327334078368
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11689026902398,
+                29.923855136326775
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p478",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5687
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"936.2,7287.2 919.9,2781.1 744.5,2779.4 707.3,989.9 2208.1,977.1 2206.6,0.0 4121.0,0.0 4729.7,7278.0 936.2,7287.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11380866054758,
+                29.92709909568021
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5687.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11090392624122,
+                29.926504436258448
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5687.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11188040047999,
+                29.922870953577263
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11478513478635,
+                29.923465612999024
               ]
             }
           }
@@ -8728,15 +7225,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8762,27 +7259,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0479/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3784.0,
-                3560.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1108325,
-                29.923964
+                -90.11277621725078,
+                29.92231136840115
               ]
             }
           },
@@ -8790,20 +7290,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2284.0,
-                5380.7
+                5668.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1099109,
-                29.9232501
+                -90.11265723332855,
+                29.924883838422456
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10839033016681,
+                29.924735597477618
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10850931408905,
+                29.92216312745631
               ]
             }
           }
@@ -8821,15 +7363,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8848,34 +7390,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"387.2,7243.0 422.8,1180.2 3759.9,1545.5 3773.4,2545.8 3057.3,2538.3 3004.6,7247.5 387.2,7243.0\" /></svg>"
+          "value": "<svg><polygon points=\"387.2,7243.0 422.8,1180.2 3759.9,1545.5 3773.4,2545.3 3058.5,2537.9 3005.6,7247.5 387.2,7243.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0480/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1939.7,
-                5406.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1098198,
-                29.9253299
+                -90.11266377144173,
+                29.924571166332594
               ]
             }
           },
@@ -8883,20 +7428,614 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                383.9,
-                5406.7
+                5687.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1098567,
-                29.9246322
+                -90.11252888249571,
+                29.927121627515103
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5687.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1083112399657,
+                29.926954081355394
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10844612891172,
+                29.924403620172885
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p481",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5668
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,-0.0 669.9,0.0 4541.6,1112.3 4540.5,7089.9 955.6,7150.1 955.1,8149.0 -0.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11710035791648,
+                29.93029752261557
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11420234515285,
+                29.929704034201528
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11517988654447,
+                29.92606806880858
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1180778993081,
+                29.926661557222623
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p482",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5687
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2798.3,1433.8 2803.8,1311.0 3894.5,1428.9 4845.0,6443.0 909.7,6447.8 899.1,1186.0 1793.8,1431.4 2798.3,1433.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11523033011619,
+                29.929947268750933
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5687.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11231092368166,
+                29.929353389027177
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5687.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11329303229223,
+                29.92572726456534
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11621243872676,
+                29.926321144289094
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p483",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5705
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1591.1,6095.2 1408.4,7069.9 -0.0,6818.3 -0.0,1585.7 1061.4,1844.7 1356.1,304.2 4063.5,795.5 5445.2,801.4 5449.8,7429.8 3405.6,7442.1 3500.1,6456.1 1591.1,6095.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1133662123641,
+                29.929647171714578
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5705.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11041981807787,
+                29.92953514525151
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5705.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11060317261658,
+                29.92586179085295
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1135495669028,
+                29.925973817316017
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p484",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5693
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4607.0,739.3 4694.4,6205.1 5602.9,6616.1 5607.0,7015.1 4702.1,6629.0 4715.4,8150.0 -0.0,8150.0 -0.0,7439.5 1040.9,7413.9 949.8,806.0 4607.0,739.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11103906774706,
+                29.9295668381004
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10809802892307,
+                29.929421305708406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10833684208038,
+                29.92574509213782
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11127788090437,
+                29.925890624529814
               ]
             }
           }
@@ -8914,15 +8053,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8941,34 +8080,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"300.2,6788.1 686.4,4246.4 1516.8,4766.8 1573.7,4371.1 738.2,3865.2 1207.5,535.4 3340.3,855.8 4688.1,833.5 4642.2,7102.5 2447.0,7116.3 300.2,6788.1\" /></svg>"
+          "value": "<svg><polygon points=\"686.4,4246.4 1516.8,4766.8 1573.7,4371.1 738.2,3865.2 1207.5,535.4 3982.6,845.2 3912.6,7107.1 2447.0,7116.3 300.2,6788.1 686.4,4246.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0485/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                688.1,
-                4244.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1088042,
-                29.9264565
+                -90.10937369753934,
+                29.928332115816865
               ]
             }
           },
@@ -8976,20 +8118,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3340.6,
-                856.1
+                5705.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.107601,
-                29.928094
+                -90.10641977217668,
+                29.928581381234935
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5705.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10600892130284,
+                29.924924420137465
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1089628466655,
+                29.924675154719395
               ]
             }
           }
@@ -9007,15 +8191,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9034,34 +8218,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"723.4,7184.2 699.5,968.7 5047.9,954.6 5066.4,7164.3 723.4,7184.2\" /></svg>"
+          "value": "<svg><polygon points=\"5047.9,954.6 5066.4,7164.3 -0.0,7196.8 -0.0,988.1 5047.9,954.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0486/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                708.1,
-                3099.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1068039,
-                29.9271979
+                -90.1073134877244,
+                29.928574555196327
               ]
             }
           },
@@ -9069,20 +8256,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2892.5,
-                7174.2
+                5693.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1054789,
-                29.9254367
+                -90.10433836109118,
+                29.928796583480047
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10397145194392,
+                29.92510380056661
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10694657857714,
+                29.92488177228289
               ]
             }
           }
@@ -9100,15 +8329,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9134,27 +8363,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0487/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2672.5,
-                3067.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1034305,
-                29.9274573
+                -90.10498640661127,
+                29.928738921763735
               ]
             }
           },
@@ -9162,20 +8394,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                552.1,
-                7110.3
+                5681.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1043433,
-                29.925526
+                -90.1020028824846,
+                29.928983432469938
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5681.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10159796715038,
+                29.925272398918136
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10458149127706,
+                29.925027888211932
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p488",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5693
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5167.0,931.2 5199.3,7112.9 1297.0,7139.6 1227.3,950.6 5167.0,931.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10263574262083,
+                29.928931705597467
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09967163117659,
+                29.929148703528938
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0993155471461,
+                29.925443635519155
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10227965859035,
+                29.925226637587684
               ]
             }
           }
@@ -9193,15 +8605,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9220,34 +8632,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"695.9,921.8 5050.7,898.9 5085.3,8150.0 727.6,8150.0 695.9,921.8\" /></svg>"
+          "value": "<svg><polygon points=\"689.4,926.6 5045.9,892.3 5087.8,7112.4 733.1,7155.5 689.4,926.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0489/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2887.5,
-                3059.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09867,
-                29.9278238
+                -90.10030300431447,
+                29.929098089218588
               ]
             }
           },
@@ -9255,20 +8670,752 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                695.9,
-                919.8
+                5707.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0999048,
-                29.9287053
+                -90.09733187508637,
+                29.929307834735553
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5707.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09698623557703,
+                29.925630346754907
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09995736480514,
+                29.925420601237942
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p490",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5693
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"897.0,989.8 3810.6,776.4 4526.1,5580.3 4530.1,5606.9 4724.3,6910.5 3128.1,7138.1 976.4,7147.3 897.0,989.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09814590443628,
+                29.929301250957423
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09517266506013,
+                29.92949816467124
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09484953732682,
+                29.925781698672118
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09782277670297,
+                29.9255847849583
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p491",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5707
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"644.6,7402.9 1358.9,449.0 3587.1,619.2 3739.0,2699.3 4497.2,2703.3 4472.8,7636.2 644.6,7402.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09712802104984,
+                29.930022684815107
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5707.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09429525766386,
+                29.9308492974959
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5707.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09294260515337,
+                29.927318388421654
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09577536853935,
+                29.92649177574086
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p492",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5717
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,641.7 5546.7,884.3 5551.9,0.0 5717.0,0.0 5717.0,7803.8 384.0,7403.0 756.7,2788.1 -0.0,2728.9 -0.0,641.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09537403881932,
+                29.930544274615972
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5717.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09261599049994,
+                29.931549391044104
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5717.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09097352913777,
+                29.92811644496736
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09373157745715,
+                29.927111328539226
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p493",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5688
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"319.8,6578.5 862.1,3191.2 878.4,47.3 5688.0,-0.0 5688.0,132.5 5157.7,130.0 5112.6,3156.7 4560.5,7287.1 319.8,6578.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09431975814691,
+                29.935097772686245
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5688.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09318922884769,
+                29.932727078152386
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5688.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09708240366426,
+                29.931313034939457
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09821293296348,
+                29.933683729473316
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p494",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5717
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4931.4,5568.8 4660.9,7791.0 401.3,7112.2 930.3,3006.7 960.8,-0.0 5192.7,-0.0 4931.4,5568.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09354673298193,
+                29.933329408425337
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5717.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0924161335473,
+                29.930926300335777
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5717.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09634313589814,
+                29.929519071227446
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09747373533277,
+                29.931922179317006
               ]
             }
           }
@@ -9286,15 +9433,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9320,27 +9467,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0495/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2832.0,
-                5074.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1000027,
-                29.9296644
+                -90.10172077523218,
+                29.931854029009642
               ]
             }
           },
@@ -9348,20 +9498,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2832.0,
-                811.8
+                5688.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1002003,
-                29.9315993
+                -90.09874251681316,
+                29.932082466757635
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5688.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09836474120343,
+                29.928383286457457
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10134299962245,
+                29.928154848709465
               ]
             }
           }
@@ -9379,15 +9571,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9413,27 +9605,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0496/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2812.5,
-                7166.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0976382,
-                29.9288809
+                -90.09941465217781,
+                29.932051232703046
               ]
             }
           },
@@ -9441,20 +9636,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                612.1,
-                2983.3
+                5717.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0989693,
-                29.9307111
+                -90.09640419625774,
+                29.932255472019563
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5717.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09606809277894,
+                29.928534618998377
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09907854869901,
+                29.92833037968186
               ]
             }
           }
@@ -9472,15 +9709,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9499,34 +9736,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4984.0,7168.2 -0.0,7213.8 -0.0,854.7 4961.0,835.2 4984.0,7168.2\" /></svg>"
+          "value": "<svg><polygon points=\"4984.0,7168.2 734.3,7209.4 704.9,848.4 4961.0,835.2 4984.0,7168.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0497/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2804.0,
-                839.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1004921,
-                29.9344831
+                -90.10199969371429,
+                29.934759064264778
               ]
             }
           },
@@ -9534,20 +9774,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4984.0,
-                7166.2
+                5688.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0990708,
-                29.9316899
+                -90.09901651910069,
+                29.93497558825604
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5688.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0986584397713,
+                29.931270363017497
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1016416143849,
+                29.931053839026234
               ]
             }
           }
@@ -9565,15 +9847,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9592,34 +9874,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"704.4,871.2 2546.4,874.3 2809.4,2998.7 2710.0,2997.8 4016.1,7163.3 3539.6,7229.5 699.8,7212.2 704.4,871.2\" /></svg>"
+          "value": "<svg><polygon points=\"4869.7,7044.9 3539.6,7229.5 699.8,7212.2 704.4,871.2 2546.4,874.3 2809.4,2998.6 4278.4,2827.9 4869.7,7044.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0498/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                699.8,
-                3003.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0992651,
-                29.9336003
+                -90.09977027207125,
+                29.934935447866497
               ]
             }
           },
@@ -9627,20 +9912,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                699.8,
-                7214.2
+                5670.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0990708,
-                29.9316899
+                -90.09680032044871,
+                29.935162306853012
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09642408918981,
+                29.931463119014538
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09939404081236,
+                29.931236260028022
               ]
             }
           }
@@ -9658,15 +9985,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9685,34 +10012,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"665.9,819.2 5703.0,827.8 5703.0,7182.8 646.4,7220.9 665.9,819.2\" /></svg>"
+          "value": "<svg><polygon points=\"646.4,7220.9 665.9,819.2 4948.5,830.0 4928.4,7182.7 646.4,7220.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0499/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2819.5,
-                5048.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1050285,
-                29.9321958
+                -90.1067435019444,
+                29.934372745562726
               ]
             }
           },
@@ -9720,20 +10050,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4935.1,
-                5048.6
+                5703.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1039199,
-                29.9322821
+                -90.10375510194437,
+                29.934605380345328
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5703.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10337164369673,
+                29.930905920645976
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10636004369675,
+                29.930673285863374
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p500",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5670
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"528.9,7191.8 475.3,892.0 5276.8,828.2 5341.7,7141.9 528.9,7191.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10439784199765,
+                29.934589422990747
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10142046388685,
+                29.934793884998797
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10108374878153,
+                29.93105932096006
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10406112689233,
+                29.93085485895201
               ]
             }
           }
@@ -9751,15 +10261,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9778,34 +10288,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"649.1,7185.4 644.8,828.4 4950.7,786.9 4945.2,7184.2 649.1,7185.4\" /></svg>"
+          "value": "<svg><polygon points=\"644.8,828.4 5703.0,786.4 5703.0,7184.0 649.1,7185.4 644.8,828.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0501/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2827.5,
-                5060.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1047311,
-                29.929298
+                -90.10643950189197,
+                29.931469088824496
               ]
             }
           },
@@ -9813,20 +10326,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2827.5,
-                2936.4
+                5703.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1048297,
-                29.9302571
+                -90.10346747715943,
+                29.931698565418667
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5703.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1030892319617,
+                29.92801930609664
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10606125669425,
+                29.92778982950247
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p502",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5705
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5354.8,7163.1 1268.2,7169.5 1252.4,815.0 5348.2,807.3 5354.8,7163.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10412042803797,
+                29.93166435377014
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5705.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10114861044158,
+                29.93189060298477
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5705.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10077829819124,
+                29.928185637572827
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10375011578763,
+                29.9279593883582
               ]
             }
           }
@@ -9844,15 +10537,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9871,34 +10564,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3366.6,840.0 5230.0,834.7 5116.3,8149.0 175.7,8149.0 1290.9,538.0 3366.6,840.0\" /></svg>"
+          "value": "<svg><polygon points=\"3366.6,840.0 5230.0,834.7 5116.3,8149.0 174.3,8149.0 1290.9,538.0 3366.6,840.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0503/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                971.8,
-                2636.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1084922,
-                29.9330105
+                -90.10914419393318,
+                29.93416285384449
               ]
             }
           },
@@ -9906,20 +10602,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2467.6,
-                7152.9
+                5703.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.107465,
-                29.931028
+                -90.10615289956063,
+                29.934429399076816
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5703.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10571354586702,
+                29.930726355712853
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10870484023957,
+                29.930459810480528
               ]
             }
           }
@@ -9937,15 +10675,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9964,34 +10702,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5649.1,1870.8 5585.1,7220.8 2109.9,7210.4 18.3,6886.6 735.0,1875.5 5649.1,1870.8\" /></svg>"
+          "value": "<svg><polygon points=\"738.1,1875.5 5649.1,1870.8 5585.1,7220.8 2109.9,7210.4 18.3,6886.6 738.1,1875.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0504/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3464.0,
-                5096.6
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1070003,
-                29.9291221
+                -90.10910100452523,
+                29.931290892471157
               ]
             }
           },
@@ -9999,20 +10740,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                624.0,
-                2704.3
+                5708.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1086262,
-                29.9300834
+                -90.1060906975207,
+                29.93155661650558
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5708.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1056530152251,
+                29.927832555738657
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10866332222963,
+                29.927566831704233
               ]
             }
           }
@@ -10030,15 +10813,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10057,34 +10840,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"709.9,7622.8 714.4,2699.5 1206.4,57.8 5703.0,913.3 5703.0,5857.6 4981.0,5855.3 4966.5,7636.5 709.9,7622.8\" /></svg>"
+          "value": "<svg><polygon points=\"1206.4,57.8 5703.0,913.3 5703.0,7636.4 709.9,7622.9 714.4,2699.5 1206.4,57.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0505/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2823.5,
-                4048.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1105267,
-                29.9301512
+                -90.11272908010233,
+                29.928931117355532
               ]
             }
           },
@@ -10092,20 +10878,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                703.9,
-                4048.5
+                5703.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.110572,
-                29.929179
+                -90.11260719746078,
+                29.931546885657404
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5703.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10829560700725,
+                29.93139600045978
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1084174896488,
+                29.92878023215791
               ]
             }
           }
@@ -10123,15 +10951,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10150,34 +10978,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1469.5,5291.3 1426.2,322.0 5348.7,1012.0 4997.4,3415.1 5002.7,7048.0 744.7,7085.6 743.6,5295.3 1469.5,5291.3\" /></svg>"
+          "value": "<svg><polygon points=\"5345.9,1027.6 5708.0,1092.4 5708.0,7047.6 1485.1,7079.1 1426.2,322.0 5348.7,1012.0 5345.9,1027.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0506/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2872.0,
-                7080.9
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10853,
-                29.932038
+                -90.11233027400125,
+                29.93088674349673
               ]
             }
           },
@@ -10185,20 +11016,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4988.0,
-                3480.4
+                5708.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1103699,
-                29.9330837
+                -90.11218273121926,
+                29.93349002895113
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5708.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.107894630621,
+                29.933307509604134
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10804217340299,
+                29.930704224149732
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p507",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5642
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4548.6,286.2 4469.1,8080.5 571.2,6907.6 -0.0,6900.4 -0.0,0.0 1828.5,0.0 4548.6,286.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11627154443939,
+                29.933343119607557
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11340863740948,
+                29.932789999193684
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11432423973032,
+                29.92918035928205
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11718714676023,
+                29.929733479695923
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p508",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5708
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"973.4,99.6 5104.9,94.6 5084.6,8149.0 2903.9,8028.7 2898.0,8149.0 1878.6,8149.0 971.8,7900.5 973.4,99.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11447652568157,
+                29.93291406402337
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5708.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11158799143962,
+                29.932329509100576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5708.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11254409645366,
+                29.928730927471744
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11543263069561,
+                29.92931548239454
               ]
             }
           }
@@ -10216,15 +11365,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10243,34 +11392,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"898.4,0.0 4101.1,0.0 4065.2,7834.0 2798.6,7988.8 2799.0,7833.3 617.8,7832.2 628.2,3680.5 898.4,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"617.8,7832.2 628.2,3680.5 894.7,0.0 5642.0,0.0 5642.0,3684.3 4971.2,3684.9 4946.3,7834.4 617.8,7832.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0509/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2777.0,
-                3680.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.113747,
-                29.9337087
+                -90.11592325908994,
+                29.932865163147508
               ]
             }
           },
@@ -10278,20 +11430,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                628.2,
-                3680.5
+                5642.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1139956,
-                29.9327704
+                -90.1152705104866,
+                29.935328855884947
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11116334911574,
+                29.93451164421361
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11181609771909,
+                29.93204795147617
               ]
             }
           }
@@ -10309,15 +11503,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10336,34 +11530,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4826.3,3677.3 5063.8,3678.9 5060.4,7696.6 2962.8,7723.1 2964.3,7483.3 857.9,7491.1 856.4,7718.5 0.0,7722.0 0.0,0.0 5724.0,0.0 5724.0,390.5 5054.9,390.2 4826.3,3677.3\" /></svg>"
+          "value": "<svg><polygon points=\"5054.5,347.1 4840.2,3668.8 5079.4,3669.4 5094.3,7716.9 859.3,7758.1 846.5,3693.8 1503.3,3687.1 1470.4,78.7 5724.0,0.0 5724.0,344.0 5054.5,347.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0510/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2960.0,
-                3672.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1132422,
-                29.9356092
+                -90.11549154657573,
+                29.934682872507718
               ]
             }
           },
@@ -10371,20 +11568,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2960.0,
-                5588.7
+                5724.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1122499,
-                29.9354076
+                -90.1147883280303,
+                29.93723017348855
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11060405139068,
+                29.936362706455395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1113072699361,
+                29.93381540547456
               ]
             }
           }
@@ -10402,15 +11641,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10429,34 +11668,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"656.2,2312.3 1025.0,0.0 1878.1,0.0 3136.9,255.3 3183.6,28.9 5285.0,439.5 4953.9,2285.3 4901.2,8085.7 2734.9,8047.4 2752.6,5934.6 615.4,5903.0 656.2,2312.3\" /></svg>"
+          "value": "<svg><polygon points=\"4961.9,2453.1 4942.6,8089.2 2767.9,8060.2 2776.4,5939.2 1343.8,5924.3 1409.8,0.0 5246.2,651.9 4961.9,2453.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0511/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3829.4,
-                5956.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1084076,
-                29.9344664
+                -90.11158773113586,
+                29.932827073571012
               ]
             }
           },
@@ -10464,20 +11706,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                656.2,
-                2312.3
+                5642.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1103699,
-                29.9330837
+                -90.11147616746834,
+                29.93537417842764
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10722999185398,
+                29.935234504454414
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1073415555215,
+                29.932687399597786
               ]
             }
           }
@@ -10495,15 +11779,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10522,34 +11806,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1038.3,175.7 4349.0,790.0 4349.5,7495.0 755.2,7496.1 770.1,1765.3 1038.3,175.7\" /></svg>"
+          "value": "<svg><polygon points=\"755.2,7496.1 770.1,1765.3 1038.3,175.7 5185.6,945.3 4950.2,2205.8 4981.7,7494.8 755.2,7496.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0512/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2864.0,
-                1968.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1101567,
-                29.935989
+                -90.11125934605589,
+                29.934711139335807
               ]
             }
           },
@@ -10557,20 +11844,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2864.0,
-                7504.9
+                5724.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1072256,
-                29.9358872
+                -90.11113788832289,
+                29.937337396084153
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10682394932051,
+                29.937187568718844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10694540705352,
+                29.934561311970498
               ]
             }
           }
@@ -10588,15 +11917,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10622,27 +11951,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0513/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4841.7,
-                2976.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1054175,
-                29.9360267
+                -90.10808905934996,
+                29.937189600251955
               ]
             }
           },
@@ -10650,20 +11982,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1116.4,
-                5092.6
+                5642.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.107275,
-                29.9349198
+                -90.10513229933572,
+                29.93740999984877
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10476487841956,
+                29.93370825203086
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1077216384338,
+                29.933487852434045
               ]
             }
           }
@@ -10681,15 +12055,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10708,34 +12082,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4650.2,829.6 4677.2,7218.0 625.2,7230.7 648.5,856.2 4650.2,829.6\" /></svg>"
+          "value": "<svg><polygon points=\"648.5,856.2 5377.9,824.8 5369.4,5107.5 4943.1,5108.2 4950.2,7217.1 625.2,7230.7 648.5,856.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0514/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2752.0,
-                2984.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1043082,
-                29.9361224
+                -90.1058802948353,
+                29.93736368247795
               ]
             }
           },
@@ -10743,20 +12120,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                620.0,
-                5096.6
+                5724.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.105326,
-                29.935083
+                -90.10289265926863,
+                29.937589248425095
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10252214526417,
+                29.93390372377718
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10550978083084,
+                29.933678157830037
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p515",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5642
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"277.3,5116.8 706.1,5118.4 732.1,841.8 2945.0,865.6 2948.7,0.0 5642.0,0.0 5642.0,885.8 5070.3,877.0 5048.1,7244.7 275.9,7222.7 277.3,5116.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10345562960981,
+                29.937553286611934
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1005292870388,
+                29.937787843490423
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10014099802981,
+                29.934098389712144
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10306734060083,
+                29.933863832833655
               ]
             }
           }
@@ -10774,15 +12331,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10808,27 +12365,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0516/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3119.5,
-                5122.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0994568,
-                29.9355255
+                -90.10130151002485,
+                29.93773199132288
               ]
             }
           },
@@ -10836,20 +12396,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                919.8,
-                879.8
+                5719.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.100784,
-                29.937367
+                -90.09831325825711,
+                29.93793974646537
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09797159572632,
+                29.934249053657286
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10095984749407,
+                29.934041298514796
               ]
             }
           }
@@ -10867,15 +12469,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10894,34 +12496,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4284.0,7005.5 3915.0,8149.0 1689.4,8047.4 2096.4,6811.7 -0.0,6451.1 529.6,2532.8 449.7,680.9 -0.0,676.4 -0.0,-0.0 5057.6,-0.0 5052.5,2879.4 4284.0,7005.5\" /></svg>"
+          "value": "<svg><polygon points=\"3915.0,8149.0 1689.4,8047.4 2096.4,6811.7 -0.0,6451.1 529.5,2533.9 448.4,673.7 -0.0,668.9 -0.0,0.0 5057.6,-0.0 5052.5,2879.4 4284.0,7005.5 3915.0,8149.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0517/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2380.8,
-                5380.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0981445,
-                29.9366641
+                -90.09604882939274,
+                29.938581304742026
               ]
             }
           },
@@ -10929,20 +12534,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4989.8,
-                3108.4
+                5650.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0965375,
-                29.9359766
+                -90.09492055706659,
+                29.936242016970922
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09881485862839,
+                29.934831492346476
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09994313095454,
+                29.93717078011758
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p518",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5719
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"115.5,7171.7 940.8,2890.8 959.0,37.7 5174.0,-0.0 5146.5,3115.2 4307.5,7930.3 115.5,7171.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09521479876638,
+                29.936896776765874
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0940574539712,
+                29.934494542947803
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09798042247962,
+                29.933055083276322
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0991377672748,
+                29.935457317094393
               ]
             }
           }
@@ -10960,15 +12745,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10987,34 +12772,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"288.0,8149.0 317.5,0.0 5650.0,0.0 4678.4,367.3 5552.6,7213.9 2400.8,7168.9 2397.2,8149.0 288.0,8149.0\" /></svg>"
+          "value": "<svg><polygon points=\"317.7,0.0 5650.0,0.0 4678.2,365.4 5552.6,7213.9 2968.4,7177.0 2968.5,6291.5 294.7,6294.5 317.7,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0519/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2400.8,
-                2960.4
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.100985,
-                29.939273
+                -90.10238086642958,
+                29.940514381847176
               ]
             }
           },
@@ -11022,20 +12810,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2400.8,
-                7168.9
+                5650.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.100784,
-                29.937367
+                -90.09942866013157,
+                29.94074816336024
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5650.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09903946146237,
+                29.937057553094075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10199166776039,
+                29.93682377158101
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p520",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5719
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"11.6,6774.2 1161.4,0.0 5719.0,0.0 5719.0,7209.6 3461.4,7320.4 11.6,6774.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10048216795859,
+                29.94034175869778
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09770901150351,
+                29.941330071226325
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09609498004777,
+                29.937881073063835
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09886813650284,
+                29.93689276053529
               ]
             }
           }
@@ -11053,15 +13021,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11080,34 +13048,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5664.0,7204.3 6.9,7189.6 1062.3,0.0 2041.5,127.3 2056.6,0.0 5664.0,0.0 5664.0,7204.3\" /></svg>"
+          "value": "<svg><polygon points=\"2239.8,153.1 4970.5,66.9 4860.6,7193.6 6.9,7189.6 1062.3,0.0 2239.8,153.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0521/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1044.0,
-                7200.9
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1066463,
-                29.9369006
+                -90.10756283445083,
+                29.94009683452453
               ]
             }
           },
@@ -11115,20 +13086,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5376.0,
-                2972.4
+                5664.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.104614,
-                29.939
+                -90.10461861027066,
+                29.940351682865806
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5664.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10419553774916,
+                29.936681451699275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10713976192933,
+                29.936426603358
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p522",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5719
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7233.5 -0.0,126.1 5332.9,36.1 5356.5,7228.1 -0.0,7233.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10498115946942,
+                29.94034739346116
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10201718459464,
+                29.940567063669555
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10165843890458,
+                29.936880724659616
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10462241377935,
+                29.93666105445122
               ]
             }
           }
@@ -11146,15 +13297,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11173,34 +13324,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4504.0,1190.8 4411.1,2328.0 4802.8,3324.5 4794.8,7086.3 0.0,7067.3 0.0,357.1 4504.0,1190.8\" /></svg>"
+          "value": "<svg><polygon points=\"4187.2,1138.3 4240.5,7065.4 633.3,7006.9 663.7,1744.4 912.8,493.1 4187.2,1138.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0523/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4792.8,
-                4990.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1081964,
-                29.9388031
+                -90.11092509953556,
+                29.93665859937374
               ]
             }
           },
@@ -11208,20 +13362,338 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4792.8,
-                7086.3
+                5645.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1070879,
-                29.9387656
+                -90.11083998369453,
+                29.939261220904395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5645.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10650199535407,
+                29.939154687117604
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1065871111951,
+                29.936552065586948
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p524",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5750
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5750.0,1967.1 5730.1,8149.0 3548.1,8149.0 3673.3,7160.4 0.0,7051.9 0.0,756.8 397.1,840.4 397.1,840.4 5750.0,1967.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1107572457032,
+                29.93858261482889
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5750.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11069995246955,
+                29.941185846461913
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5750.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10647426105335,
+                29.941115022102636
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.106531554287,
+                29.93851179046961
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p525",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5634
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"656.0,0.0 5634.0,0.0 5634.0,7385.4 684.7,7407.7 675.8,3339.4 436.8,3337.7 656.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11477144089248,
+                29.936602795297144
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5634.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11409219502922,
+                29.939114814252324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5634.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10992778609607,
+                29.93825723691965
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11060703195933,
+                29.93574521796447
               ]
             }
           }
@@ -11239,15 +13711,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11266,34 +13738,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4935.4,7183.7 791.9,7285.4 744.0,3383.2 0.0,3409.9 0.0,-0.0 5736.0,0.0 5736.0,1792.7 4967.9,1823.5 4935.4,7183.7\" /></svg>"
+          "value": "<svg><polygon points=\"2423.7,7245.4 2471.4,7448.6 1934.0,7462.9 1812.7,17.4 5736.0,0.0 5736.0,1792.7 4967.9,1823.5 4935.4,7183.7 2423.7,7245.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0526/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                744.0,
-                3383.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1125306,
-                29.9382721
+                -90.11433420909194,
+                29.93832397358525
               ]
             }
           },
@@ -11301,20 +13776,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4892.0,
-                5246.7
+                5736.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1110562,
-                29.9398784
+                -90.11359626466867,
+                29.94083258011388
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5736.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1094819800166,
+                29.939923772568072
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11021992443986,
+                29.93741516603944
               ]
             }
           }
@@ -11332,15 +13849,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T15:25:30Z",
-      "modified": "2026-08-07T15:25:30Z",
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11359,34 +13876,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7456.9 0.0,0.0 5634.0,0.0 5634.0,4263.0 5430.7,4302.1 5378.0,7694.9 -0.0,7456.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7456.9 -0.0,-0.0 5634.0,0.0 5634.0,4262.3 5430.8,4301.4 5378.0,7694.9 -0.0,7456.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0527/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3465.2,
-                5588.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.110815,
-                29.9407862
+                -90.11197114763537,
+                29.943567851542742
               ]
             }
           },
@@ -11394,20 +13914,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1556.6,
-                7588.9
+                5634.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1120002,
-                29.9400852
+                -90.10911271096552,
+                29.943041246712696
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5634.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10999191399053,
+                29.93945779969631
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11285035066038,
+                29.939984404526356
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p531",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:32:53Z",
+      "modified": "2026-08-15T01:32:53Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6469.6 -0.0,6062.9 481.8,4506.1 -0.0,4357.0 -0.0,2699.9 -0.0,0.0 5660.0,0.0 5660.0,7870.8 2678.3,7941.0 2797.6,6858.5 2332.0,6859.4 2339.8,6797.9 97.0,6550.1 -0.0,6469.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11004254396707,
+                29.94707328595176
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10413970758563,
+                29.94753846536481
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5660.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10336688213108,
+                29.940175224758747
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10926971851252,
+                29.939710045345695
               ]
             }
           }

--- a/gallery/philadelphia_pa_1950_vol_3.iiif.json
+++ b/gallery/philadelphia_pa_1950_vol_3.iiif.json
@@ -7,25 +7,25 @@
   "label": "Mosaic of main content, Philadelphia, Pa. | 1950 | Vol. 3",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0237/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0201/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p237",
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p201",
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -34,21 +34,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0237/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0201/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0237/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0201/info.json",
           "type": "ImageService2",
-          "height": 8150,
-          "width": 5680
+          "height": 8149,
+          "width": 5652
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2953.5,7932.0 2251.1,7551.0 72.0,7620.5 311.5,2889.7 369.7,2624.3 4011.5,1941.9 3822.0,1505.7 311.6,341.5 317.3,0.0 4676.3,0.0 5322.9,2840.1 5581.4,3223.3 5370.2,3588.0 5680.0,3776.9 5680.0,8150.0 2935.4,8150.0 2953.5,7932.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1421.4 1390.0,1418.8 1392.3,810.6 4058.9,809.5 4060.3,488.5 5313.9,1948.8 4051.2,1969.2 4046.4,7222.9 5255.8,7230.5 5254.5,8099.0 -0.0,8149.0 -0.0,1421.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0237/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0201/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -73,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1372039,
-                39.9664331
+                -75.15874056303302,
+                39.96094448533517
               ]
             }
           },
@@ -82,7 +82,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5680.0,
+                5652.0,
                 0.0
               ],
               "creator": {
@@ -94,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1338152,
-                39.9659058
+                -75.15543558106828,
+                39.9605247904294
               ]
             }
           },
@@ -103,8 +103,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5680.0,
-                8150.0
+                5652.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -115,146 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1348027,
-                39.9621782
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1381914,
-                39.9627055
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0238/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p238",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0238/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0238/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5670
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4022.3,8150.0 -0.0,8149.9 0.0,0.1 5670.0,-0.1 5670.0,7912.8 4029.3,7659.9 4022.3,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0238/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1558661,
-                39.9719918
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5670.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1525075,
-                39.9715685
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5670.0,
-                8150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1533014,
-                39.967869
+                -75.15622547257156,
+                39.956871708730034
               ]
             }
           },
@@ -263,7 +125,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8150.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -274,8 +136,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15666,
-                39.9682924
+                -75.15953045453631,
+                39.9572914036358
               ]
             }
           }
@@ -300,8 +162,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -320,7 +182,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1554.6,7322.8 1504.0,2094.1 2768.6,2057.4 2238.3,1464.9 4205.0,1447.2 4264.2,7293.6 1554.6,7322.8\" /></svg>"
+          "value": "<svg><polygon points=\"4266.9,7295.5 1558.2,7327.5 1502.3,2100.7 2766.4,2062.7 1758.5,938.9 4193.1,677.4 4266.9,7295.5\" /></svg>"
         }
       },
       "body": {
@@ -349,8 +211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15722148743528,
-                39.960822619071216
+                -75.15721867911049,
+                39.96082635716799
               ]
             }
           },
@@ -370,8 +232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15390478874973,
-                39.96036732629769
+                -75.15390138531045,
+                39.960368280910906
               ]
             }
           },
@@ -391,8 +253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15474893045003,
-                39.95670320534092
+                -75.154750687686,
+                39.956703502156905
               ]
             }
           },
@@ -412,8 +274,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15806562913558,
-                39.957158498114445
+                -75.15806798148604,
+                39.95716157841399
               ]
             }
           }
@@ -421,7 +283,7 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0203/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0203__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
@@ -436,10 +298,26 @@
         {
           "label": "intersections",
           "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5671.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -448,7 +326,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0203/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0203__1/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0203/info.json",
@@ -458,11 +336,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7323.1 1493.7,7314.6 1481.7,0.0 4151.7,0.0 4152.3,6756.5 3778.7,7069.3 3855.4,7189.5 3450.5,7280.5 3450.7,8149.0 -0.0,8149.0 -0.0,7323.1\" /></svg>"
+          "value": "<svg><polygon points=\"5671.0,8064.6 -0.0,8149.0 -0.0,7288.3 1482.1,7284.3 1475.8,0.0 3442.5,16.5 3622.2,1678.2 4144.5,1628.5 4140.3,6730.9 3766.6,7044.6 5671.0,6440.8 5671.0,8064.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0203/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0203__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -487,8 +365,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15564418306634,
-                39.960645981855976
+                -75.15564905130861,
+                39.96060882581467
               ]
             }
           },
@@ -508,8 +386,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15230185306054,
-                39.960209400264226
+                -75.15230391501525,
+                39.96018002741345
               ]
             }
           },
@@ -529,8 +407,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15311472560914,
-                39.956501328009466
+                -75.15310793086896,
+                39.95649485119391
               ]
             }
           },
@@ -550,8 +428,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15645705561495,
-                39.956937909601216
+                -75.15645306716232,
+                39.956923649595126
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0204/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p204",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0204/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0204/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5681
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8001.2 2209.9,7967.0 2209.0,6359.4 -0.0,7167.9 -0.0,7038.9 597.5,6804.0 694.4,6549.0 695.6,1595.6 178.8,1645.2 -0.0,0.0 695.1,0.0 694.0,1366.0 1528.9,1341.9 1656.7,2326.4 3145.2,2165.2 3004.9,0.0 3844.7,0.0 4053.1,2104.0 5681.0,1944.3 5681.0,4744.9 5209.2,6312.3 5110.7,7365.4 5118.6,7707.4 5681.0,7692.5 5681.0,8150.0 -0.0,8150.0 -0.0,8001.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0204/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15362004224954,
+                39.96034105605763
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5681.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15023420452411,
+                39.95990550785783
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5681.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1510491497741,
+                39.95618335560783
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15443498749953,
+                39.95661890380762
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0205/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p205",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0205/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0205/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5627
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1468.7,5025.5 1547.3,2066.4 5627.0,1775.3 5627.0,2590.8 4675.2,2807.3 4660.9,8150.0 789.9,8150.0 925.0,6676.1 1468.7,5025.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0205/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15113867893311,
+                39.960006877775115
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5627.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14795915126787,
+                39.95966409940779
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5627.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14860689322583,
+                39.956133941365835
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15178642089107,
+                39.95647671973316
               ]
             }
           }
@@ -576,8 +730,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -596,7 +750,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"860.4,8150.0 856.0,2916.5 1818.8,2767.9 1810.8,1882.6 4605.2,1966.3 5681.0,1704.9 5681.0,4164.2 4113.2,4132.7 4092.2,6233.7 4823.3,6246.2 4815.1,7606.4 4078.5,7595.2 4073.0,8150.0 860.4,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"4070.3,8150.0 858.7,8099.2 854.0,2918.5 1782.2,2703.4 1779.3,1912.6 3810.0,1925.5 3807.1,2140.6 4130.9,2071.4 4070.3,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -625,8 +779,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14897021507494,
-                39.959863336203846
+                -75.14896893157663,
+                39.95986452844383
               ]
             }
           },
@@ -646,8 +800,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1456845226234,
-                39.9594949141394
+                -75.14568221527436,
+                39.95949587658694
               ]
             }
           },
@@ -667,8 +821,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14636903333206,
-                39.955857334598576
+                -75.14636715293959,
+                39.955857163613956
               ]
             }
           },
@@ -688,8 +842,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1496547257836,
-                39.95622575666303
+                -75.14965386924186,
+                39.956225815470845
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0207/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p207",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0207/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0207/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1700.9 1528.8,1238.4 4540.5,1173.5 4496.0,8150.0 -0.0,8150.0 -0.0,1700.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0207/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14660743119188,
+                39.95939477187432
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14333413803575,
+                39.959007322678225
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5600.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1440699452981,
+                39.955354842357906
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14734323845423,
+                39.955742291554
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0208/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p208",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0208/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0208/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5680
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,945.4 269.9,937.3 270.8,2448.9 4247.8,2448.7 4197.7,7761.8 5680.0,7775.7 5680.0,8149.0 -0.0,8149.0 -0.0,945.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0208/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14397070763644,
+                39.95897706602367
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5680.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14068476248205,
+                39.958565914422884
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5680.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14144919076395,
+                39.95492544640582
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14473513591834,
+                39.9553365980066
               ]
             }
           }
@@ -714,8 +1144,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,7 +1164,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,2690.0 719.6,2682.4 697.4,0.0 3570.7,0.0 3324.7,3559.7 3871.5,3555.1 3851.0,3908.0 5630.4,3871.5 5685.0,3672.7 5685.0,8150.0 -0.0,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,2688.0 710.5,2681.3 691.1,0.0 3570.1,0.0 3320.0,3563.2 3868.0,3559.2 3846.7,3917.6 5685.0,3924.1 5685.0,8150.0 -0.0,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -763,8 +1193,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14148711282373,
-                39.958745791929026
+                -75.14148348659133,
+                39.95874199233953
               ]
             }
           },
@@ -784,8 +1214,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13828472881912,
-                39.95831840078316
+                -75.13828712443996,
+                39.95831814395727
               ]
             }
           },
@@ -805,8 +1235,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13907823014051,
-                39.95477548816665
+                -75.13907404835756,
+                39.95478189420085
               ]
             }
           },
@@ -826,8 +1256,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14228061414511,
-                39.95520287931252
+                -75.14227041050893,
+                39.95520574258311
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0210/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p210",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0210/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0210/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5726
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4261.6,4435.2 4247.4,7546.0 1583.4,7542.1 1580.0,8150.0 -0.0,8150.0 38.1,1573.6 4272.0,1593.6 4265.7,4208.5 5726.0,4062.9 5726.0,4283.0 4261.6,4435.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0210/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15820887042838,
+                39.96397786130229
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5726.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15485631493358,
+                39.96355703024707
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5726.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15563783596433,
+                39.959900531654924
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15899039145913,
+                39.96032136271015
               ]
             }
           }
@@ -852,8 +1420,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -872,7 +1440,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1486.3,4512.8 -0.0,4672.9 -0.0,4450.9 1489.6,4286.6 1486.9,1693.6 4188.0,1678.1 4189.1,3987.6 5652.0,3814.9 5652.0,4063.6 4185.7,4228.5 4189.7,8149.0 2218.6,8149.0 1483.8,7296.2 1486.3,4512.8\" /></svg>"
+          "value": "<svg><polygon points=\"4176.0,7379.2 1764.6,7609.5 1506.2,7296.2 1509.1,4530.7 2961.0,4374.8 2960.3,4156.7 1512.4,4306.0 1510.1,1729.8 3592.9,1722.8 3599.2,2023.1 4176.0,2007.3 4176.7,4015.5 5652.0,3844.3 5652.0,4090.9 4173.4,4254.8 4176.0,7379.2\" /></svg>"
         }
       },
       "body": {
@@ -901,8 +1469,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15656113043133,
-                39.96381557973919
+                -75.156582096182,
+                39.963838474301355
               ]
             }
           },
@@ -922,8 +1490,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15327139623261,
-                39.96338750021253
+                -75.1532475437869,
+                39.96341098230887
               ]
             }
           },
@@ -943,8 +1511,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15407129579528,
-                39.95972503217184
+                -75.1540519835393,
+                39.95972463676433
               ]
             }
           },
@@ -964,8 +1532,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.157361029994,
-                39.9601531116985
+                -75.1573865359344,
+                39.96015212875681
               ]
             }
           }
@@ -990,8 +1558,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1010,7 +1578,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1691.8,6568.3 1659.4,4188.5 1641.6,2548.2 3052.5,1859.8 4296.8,1730.5 5735.0,3460.9 5735.0,3492.4 5735.0,3679.7 4395.6,5762.6 3647.7,6545.5 1691.8,6568.3\" /></svg>"
+          "value": "<svg><polygon points=\"1704.3,6638.2 1643.7,2513.0 3048.2,1868.1 4287.3,1736.5 5735.0,3455.6 5735.0,3673.6 4380.7,5768.7 4396.9,6592.5 1704.3,6638.2\" /></svg>"
         }
       },
       "body": {
@@ -1039,8 +1607,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15506102911708,
-                39.96360445032861
+                -75.15506075657113,
+                39.96361474376137
               ]
             }
           },
@@ -1060,8 +1628,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15174074840792,
-                39.96313987185723
+                -75.15172871142336,
+                39.96314266717558
               ]
             }
           },
@@ -1081,8 +1649,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15259613375129,
-                39.95949751800467
+                -75.1525979025179,
+                39.9594874084154
               ]
             }
           },
@@ -1102,8 +1670,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15591641446044,
-                39.95996209647605
+                -75.15592994766567,
+                39.959959485001185
               ]
             }
           }
@@ -1128,8 +1696,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1148,7 +1716,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1018.2,4886.9 1199.2,3016.1 2570.7,3016.4 2596.7,2803.2 1878.1,1687.3 4126.8,1791.2 4072.1,6064.7 196.5,5561.0 178.1,4894.6 1018.2,4886.9\" /></svg>"
+          "value": "<svg><polygon points=\"1191.1,3012.2 2575.6,3012.5 2602.1,2799.0 1853.9,1648.0 4121.1,1785.1 4078.4,6066.6 3235.4,5975.9 3166.1,8149.0 1627.5,8149.0 1607.0,7154.0 766.3,7087.9 1191.1,3012.2\" /></svg>"
         }
       },
       "body": {
@@ -1177,8 +1745,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15356048094019,
-                39.9629576581149
+                -75.15355476190962,
+                39.96295343230773
               ]
             }
           },
@@ -1198,8 +1766,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15018901526027,
-                39.962806533570266
+                -75.15018858026137,
+                39.962802459360745
               ]
             }
           },
@@ -1219,8 +1787,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15047220191606,
-                39.95904237997271
+                -75.15047148256717,
+                39.95904420156982
               ]
             }
           },
@@ -1240,8 +1808,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15384366759598,
-                39.959193504517344
+                -75.15383766421542,
+                39.9591951745168
               ]
             }
           }
@@ -1266,8 +1834,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1286,7 +1854,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5150.1,1903.2 4706.8,8149.0 -0.0,8149.0 -0.0,842.3 2469.2,797.2 2376.9,2142.6 3703.9,2239.8 3712.5,1756.9 5150.1,1903.2\" /></svg>"
+          "value": "<svg><polygon points=\"4707.0,8007.5 -0.0,8149.0 -0.0,837.9 2476.3,799.6 2380.7,2139.0 3708.4,2240.2 3718.2,1763.8 5156.8,1914.2 4707.0,8007.5\" /></svg>"
         }
       },
       "body": {
@@ -1315,8 +1883,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1510828863526,
-                39.96278437136827
+                -75.15108722614139,
+                39.96278214263357
               ]
             }
           },
@@ -1336,8 +1904,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14770288462388,
-                39.96259928826929
+                -75.14770988803852,
+                39.962604579073286
               ]
             }
           },
@@ -1357,8 +1925,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14804437214461,
-                39.95888361139642
+                -75.14803750163642,
+                39.95889183035652
               ]
             }
           },
@@ -1378,8 +1946,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15142437387331,
-                39.95906869449541
+                -75.15141483973929,
+                39.959069393916806
               ]
             }
           }
@@ -1404,8 +1972,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1424,7 +1992,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"879.9,2342.5 3557.4,2261.3 3537.9,1570.5 3715.0,2300.6 5651.0,2254.8 5651.0,7956.8 4858.9,8150.0 1067.5,8150.0 879.9,2342.5\" /></svg>"
+          "value": "<svg><polygon points=\"1067.3,8150.0 885.7,2341.8 3558.3,2264.1 3538.6,1533.3 3726.0,2309.5 3973.7,2303.9 4063.4,8150.0 1067.3,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +2021,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14842357398375,
-                39.96264896970274
+                -75.14842742051518,
+                39.962649972363614
               ]
             }
           },
@@ -1474,8 +2042,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14520284827941,
-                39.96221142271266
+                -75.14521168166145,
+                39.96221575464388
               ]
             }
           },
@@ -1495,8 +2063,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14602042514188,
-                39.958625723273606
+                -75.14602303779442,
+                39.958635607902536
               ]
             }
           },
@@ -1516,8 +2084,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14924115084622,
-                39.959063270263684
+                -75.14923877664815,
+                39.95906982562227
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0216/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p216",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0216/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0216/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5682
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5112.8,7615.8 2007.3,7693.7 -0.0,8150.0 -0.0,2199.6 1441.2,2192.2 1414.3,2416.5 2451.8,2395.7 2448.9,2605.6 5157.9,2565.7 5112.8,7615.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0216/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14619196148884,
+                39.96231985045121
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5682.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14286430997879,
+                39.96191673386306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5682.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14361859251011,
+                39.958258641543985
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14694624402016,
+                39.95866175813213
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0217/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p217",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0217/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0217/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5637
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1128.2,8150.0 1143.6,1745.1 5637.0,1643.5 5637.0,8150.0 1128.2,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0217/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14392319499024,
+                39.961689007676625
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14054645761956,
+                39.96126665301547
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14134289725813,
+                39.95752561739708
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1447196346288,
+                39.957947972058236
               ]
             }
           }
@@ -1542,8 +2386,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1562,7 +2406,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5088.4,2522.2 4939.4,4527.3 4841.2,5725.6 2049.8,5691.7 2065.4,1635.0 2316.4,1629.3 2255.1,2236.7 5088.4,2522.2\" /></svg>"
+          "value": "<svg><polygon points=\"2055.1,5690.8 2086.7,1622.1 2391.3,1602.3 2337.2,2146.8 5118.7,2413.2 4850.0,5732.7 2055.1,5690.8\" /></svg>"
         }
       },
       "body": {
@@ -1591,8 +2435,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14175457648096,
-                39.96139434130174
+                -75.14177115336597,
+                39.9613856281623
               ]
             }
           },
@@ -1612,8 +2456,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13844060636876,
-                39.96098399050515
+                -75.13845973959968,
+                39.96098589881765
               ]
             }
           },
@@ -1633,8 +2477,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13920036181177,
-                39.95732804800747
+                -75.13919982965884,
+                39.95733277645802
               ]
             }
           },
@@ -1654,8 +2498,1112 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14251433192398,
-                39.95773839880406
+                -75.14251124342512,
+                39.95773250580267
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0219/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p219",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0219/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0219/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5642
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,-0.0 4949.9,0.0 5606.9,131.9 5576.0,2292.7 5182.8,5283.4 4220.4,8149.0 -0.0,8149.0 0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0219/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15753094680014,
+                39.96693481207813
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15421958154631,
+                39.9665068470584
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15502608758888,
+                39.96284110361464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1583374528427,
+                39.963269068634375
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0220/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p220",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0220/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0220/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5666
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2956.1,8150.0 1423.3,8150.0 92.9,1684.1 111.7,0.0 1452.0,0.0 4136.8,358.1 5666.0,766.7 5666.0,4583.1 5666.0,7069.7 4112.2,8150.0 2956.1,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0220/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15591370127808,
+                39.96670191478764
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5666.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1525975879604,
+                39.96628556881335
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5666.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15337885311192,
+                39.962630008628985
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1566949664296,
+                39.96304635460328
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0221/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p221",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0221/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0221/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5678
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"576.4,7570.7 -0.0,7574.3 -0.0,7274.1 582.4,7284.5 604.8,6228.5 2170.9,6240.9 2167.4,4707.2 639.8,4561.7 734.5,0.0 2676.1,0.0 5060.1,526.1 4981.6,8150.0 3190.8,8150.0 3198.3,7478.6 1971.8,7562.6 1898.9,8150.0 564.1,8150.0 576.4,7570.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0221/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15400484863838,
+                39.96609054326874
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5678.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15064046379572,
+                39.96571502870449
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5678.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15134363165632,
+                39.962014147783066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15470801649897,
+                39.96238966234732
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0222/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p222",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0222/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0222/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5696
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1231.2,2429.6 2899.7,2457.0 2919.3,906.8 5696.0,1501.3 5696.0,3666.2 4601.2,3439.7 4637.6,7067.3 2188.8,7317.0 2261.5,8150.0 1241.2,8150.0 1231.2,2429.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0222/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1517376573427,
+                39.96585278018938
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14838805169605,
+                39.96545287099627
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14913479412515,
+                39.96177858785283
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1524843997718,
+                39.96217849704593
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0223/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p223",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0223/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0223/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5663
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5663.0,8149.0 3086.9,8149.0 3083.6,7716.8 1657.2,7676.4 1684.3,8149.0 370.7,8149.0 359.5,3214.8 1443.8,3449.7 1464.1,1301.3 348.7,1042.2 346.1,0.0 4795.2,0.0 4746.8,982.2 5079.8,1208.1 5026.0,3111.2 5663.0,3208.1 5663.0,4374.7 4989.0,4253.1 5663.0,7335.2 5663.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0223/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14928152629474,
+                39.96546527386103
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5663.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1459211758649,
+                39.96508891017514
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5663.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.146627917383,
+                39.96138198747123
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14998826781284,
+                39.961758351157115
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0224/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p224",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0224/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0224/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5651
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2585.5,8149.0 2040.2,8149.0 1181.6,4216.6 1239.0,1925.5 1294.3,315.6 3151.9,354.1 5462.1,4862.0 5496.6,5475.5 4702.4,8149.0 2585.5,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0224/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14700897349711,
+                39.965200711138515
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5651.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14365325106105,
+                39.96480769707429
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5651.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14439282462476,
+                39.96109801423904
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14774854706081,
+                39.961491028303264
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0225/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p225",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0225/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0225/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5663
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5663.0,7397.0 1034.1,8024.6 1012.3,7819.0 -0.0,7960.8 -0.0,7738.4 991.8,7614.5 671.9,4836.2 1447.5,4868.5 1337.5,4265.1 604.6,4251.8 340.2,1955.7 3905.2,2028.8 4508.9,7332.4 5663.0,7174.9 5663.0,7397.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0225/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14428178838004,
+                39.96466906882203
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5663.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14100232083554,
+                39.96395739873175
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5663.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14233869108516,
+                39.96033966078722
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14561815862966,
+                39.9610513308775
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0226/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p226",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0226/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0226/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5663
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1616.1,7971.5 454.5,8088.5 37.4,2754.5 2447.4,2873.1 2259.3,271.5 4507.6,982.4 4426.6,7891.3 1609.8,8149.0 1616.1,7971.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0226/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14198058489056,
+                39.96451316033224
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5663.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13867810188745,
+                39.96389211016083
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5663.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13984429629774,
+                39.960248950753986
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14314677930085,
+                39.9608700009254
               ]
             }
           }
@@ -1680,8 +3628,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1700,7 +3648,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4112.3,5123.6 2682.1,5083.6 2754.7,8150.0 -0.0,8150.0 -0.0,7559.1 -0.0,7545.0 -0.0,1753.2 2765.5,1669.3 2759.4,1466.2 4771.0,1280.0 5494.4,1615.7 5445.4,3364.2 5661.0,3371.9 5661.0,7032.2 5316.3,7030.8 5320.5,6723.1 4080.6,6851.4 4112.3,5123.6\" /></svg>"
+          "value": "<svg><polygon points=\"4131.9,5183.6 2682.3,5129.8 2736.2,8150.0 -0.0,8150.0 -0.0,7624.4 -0.0,7610.5 -0.0,1703.9 2774.2,1648.6 2769.4,1442.0 4821.1,1269.3 5552.5,1618.4 5493.1,3401.2 5661.0,3408.7 5661.0,7143.9 5341.8,7139.8 5347.7,6825.9 4090.1,6945.5 4131.9,5183.6\" /></svg>"
         }
       },
       "body": {
@@ -1729,8 +3677,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13938099840772,
-                39.963926077294225
+                -75.1393881565715,
+                39.96388971496488
               ]
             }
           },
@@ -1750,8 +3698,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13605280516731,
-                39.963243947076364
+                -75.13609736722125,
+                39.96323941452289
               ]
             }
           },
@@ -1771,8 +3719,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1373247177184,
-                39.95954651314176
+                -75.13731848159914,
+                39.95960913855942
               ]
             }
           },
@@ -1792,8 +3740,560 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14065291095882,
-                39.96022864335962
+                -75.14060927094938,
+                39.96025943900141
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0228/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p228",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0228/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0228/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5696
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"940.4,0.0 939.5,2796.5 4167.6,2797.4 4169.9,5976.0 27.6,5926.4 0.0,-0.0 940.4,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0228/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15695564209533,
+                39.9696484502306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15355642034083,
+                39.96921269887381
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15437015261438,
+                39.96548427667278
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15776937436887,
+                39.96592002802957
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0229/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p229",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0229/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0229/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5640
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2071.5,2297.9 2056.9,1797.5 3693.0,1977.2 3637.8,615.3 3879.7,638.5 4096.0,5800.6 1403.5,5517.2 1271.1,2330.3 2071.5,2297.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0229/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15520349751765,
+                39.96920827647947
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5640.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15192073456693,
+                39.9686812078191
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5640.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15291475838539,
+                39.965044737391636
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15619752133611,
+                39.965571806052004
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0230/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p230",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0230/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0230/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5711
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7635.3 -0.0,5542.6 1266.7,715.7 3874.3,1097.2 3894.4,6282.4 1257.2,7894.1 -0.0,7635.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0230/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1537122579608,
+                39.96898590672848
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5711.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1502863298171,
+                39.96855290722609
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5711.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15109264986889,
+                39.96480567911552
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15451857801258,
+                39.96523867861791
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0231/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p231",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0231/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0231/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5682
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1623.0,8149.0 1635.0,6306.2 0.6,5947.8 4.0,756.3 4788.2,1437.8 5682.0,1583.2 5682.0,7151.8 3270.8,6649.0 3258.4,8149.0 1623.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0231/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15142639998098,
+                39.96853558351225
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5682.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14801926179452,
+                39.96811712878558
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5682.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1488023269936,
+                39.96437205390329
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15220946518006,
+                39.96479050862996
               ]
             }
           }
@@ -1818,8 +4318,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,7 +4338,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"463.6,0.0 5489.9,0.0 5466.2,1640.4 5117.0,1646.8 5463.9,1783.8 5389.0,4240.2 5065.1,4388.4 5016.6,5930.0 5355.1,6148.7 5335.3,8048.7 5718.0,8149.0 1741.0,8149.0 1725.4,6314.5 1407.1,6247.7 1383.8,620.9 474.0,479.7 463.6,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5466.3,1779.7 5392.7,4238.6 5068.5,4387.2 5051.2,4948.3 1402.0,5023.4 1381.3,617.8 470.4,477.0 459.9,0.0 5491.1,0.0 5468.1,1657.9 5466.3,1779.7\" /></svg>"
         }
       },
       "body": {
@@ -1867,8 +4367,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14892571288568,
-                39.96777590506791
+                -75.14892347169494,
+                39.967774239797905
               ]
             }
           },
@@ -1888,8 +4388,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14555860558643,
-                39.967345448261796
+                -75.14556015361185,
+                39.96734278462061
               ]
             }
           },
@@ -1909,8 +4409,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14635343163738,
-                39.96364162097687
+                -75.14635682312634,
+                39.96364312548388
               ]
             }
           },
@@ -1930,8 +4430,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14972053893663,
-                39.96407207778298
+                -75.14972014120943,
+                39.96407458066117
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0233/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p233",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0233/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0233/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5684
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1058.6,7950.7 737.0,5823.0 782.7,4275.1 1176.3,1659.9 3107.1,793.0 3101.9,0.0 4585.7,0.0 4586.5,128.9 5684.0,565.8 5684.0,7422.8 4613.8,8149.0 2609.3,8149.0 1058.6,7950.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0233/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14641353911068,
+                39.96739333936616
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5684.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14305891435266,
+                39.96696600073118
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5684.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14385857773456,
+                39.96327852559644
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14721320249258,
+                39.963705864231414
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0234/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p234",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0234/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0234/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5713
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4253.8,7661.6 3045.3,7499.7 2713.7,7455.2 -0.0,7075.1 -0.0,937.5 660.2,605.9 2850.6,593.7 3081.3,594.0 5713.0,4721.3 5713.0,7847.6 4253.8,7661.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0234/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14464646852943,
+                39.96717455362309
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5713.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14126917023229,
+                39.966756388094915
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5713.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14204728745554,
+                39.96306477206612
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14542458575268,
+                39.96348293759429
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0235/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p235",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0235/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0235/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5697
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1203.2,7396.1 -0.0,7241.3 -0.0,370.7 1166.6,356.9 1164.0,0.0 2716.8,0.0 2719.2,329.3 4469.6,317.9 4469.6,7801.6 2656.2,7573.6 2640.0,4463.3 1185.0,3893.9 1203.2,7396.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0235/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1428449395856,
+                39.96684859266674
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5697.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13946314238399,
+                39.966416007969435
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5697.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14027034351047,
+                39.96270906773624
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14365214071208,
+                39.96314165243355
               ]
             }
           }
@@ -1956,8 +4870,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1976,7 +4890,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5282.0,2013.5 5282.4,1825.2 5506.6,1762.8 5615.5,1490.1 5729.0,3084.1 5562.9,7949.7 5729.0,7939.4 5729.0,8149.0 2874.5,8149.0 2905.6,7122.0 638.8,6384.0 356.7,2016.8 5282.0,2013.5\" /></svg>"
+          "value": "<svg><polygon points=\"5729.0,7939.8 5729.0,8149.0 2903.2,8149.0 2926.8,7129.4 644.8,6390.9 355.5,2021.6 5283.8,2010.2 5283.9,1822.0 5483.3,1821.5 5616.6,1486.1 5680.1,3087.2 5523.7,3547.8 5691.3,3532.5 5574.4,7949.7 5729.0,7939.8\" /></svg>"
         }
       },
       "body": {
@@ -2005,8 +4919,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14021352010664,
-                39.9670388507825
+                -75.14021029024421,
+                39.96704023020051
               ]
             }
           },
@@ -2026,8 +4940,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1369240343141,
-                39.96644643767819
+                -75.13692401234084,
+                39.96644406107601
               ]
             }
           },
@@ -2047,8 +4961,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.138015605764,
-                39.962835529191075
+                -75.13802250457687,
+                39.962836673927804
               ]
             }
           },
@@ -2068,8 +4982,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14130509155652,
-                39.96342794229539
+                -75.14130878248024,
+                39.9634328430523
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0237/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p237",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0237/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0237/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5680
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"64.2,7743.6 157.4,0.0 4634.7,0.0 5680.0,3694.9 5680.0,8150.0 3005.3,8150.0 64.2,7743.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0237/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13710593868007,
+                39.9664196911228
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5680.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13380707142389,
+                39.96584480596282
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5680.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13487603249534,
+                39.962190409018774
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13817489975152,
+                39.96276529417876
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0238/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p238",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0238/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0238/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5670
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4050.7,8150.0 -0.0,8150.0 0.0,0.0 5670.0,0.0 5670.0,7897.3 4056.4,7653.6 4050.7,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0238/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1558664,
+                39.9719913
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1525124,
+                39.9715606
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15332020000001,
+                39.9678664
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1566742,
+                39.9682971
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0239/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p239",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0239/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0239/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5653
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4049.9,6548.1 1183.0,6159.2 1172.5,4746.1 1149.3,1615.5 1137.4,0.0 4038.6,0.0 5653.0,1337.3 5653.0,2612.6 5653.0,6711.7 4049.9,6548.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0239/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15322311101559,
+                39.97149456499431
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5653.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14986121644225,
+                39.97104317868026
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5653.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.15071015231196,
+                39.96732981800624
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1540720468853,
+                39.96778120432029
               ]
             }
           }
@@ -2094,8 +5422,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2114,7 +5442,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"102.1,122.4 0.0,0.0 5699.0,0.0 5699.0,7454.2 47.0,6676.8 102.1,122.4\" /></svg>"
+          "value": "<svg><polygon points=\"97.4,123.6 0.0,-0.0 5699.0,0.0 5699.0,7454.2 47.0,6681.0 97.4,123.6\" /></svg>"
         }
       },
       "body": {
@@ -2143,8 +5471,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.15086966079328,
-                39.971235623721114
+                -75.15086667740295,
+                39.9712357922417
               ]
             }
           },
@@ -2164,8 +5492,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14750303082282,
-                39.97080429324534
+                -75.14750201620804,
+                39.97080278704652
               ]
             }
           },
@@ -2185,8 +5513,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14830230483145,
-                39.96708818402502
+                -75.14830439354414,
+                39.96708885097449
               ]
             }
           },
@@ -2206,8 +5534,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1516689348019,
-                39.96751951450081
+                -75.15166905473905,
+                39.96752185616967
               ]
             }
           }
@@ -2232,8 +5560,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2252,7 +5580,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1093.6,0.0 4020.5,0.0 4020.5,132.1 4680.4,137.0 5452.2,26.7 5240.4,6489.3 973.6,6410.9 1093.6,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1007.3,6397.3 1118.5,0.0 4015.3,0.0 4015.6,133.7 4669.1,138.6 5433.2,28.8 5235.7,6478.3 1007.3,6397.3\" /></svg>"
         }
       },
       "body": {
@@ -2281,8 +5609,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1481940326163,
-                39.97062961586525
+                -75.14821367362114,
+                39.97063257835012
               ]
             }
           },
@@ -2302,8 +5630,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14489665785806,
-                39.9702559548879
+                -75.14488413870714,
+                39.97025552620028
               ]
             }
           },
@@ -2323,8 +5651,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14559444918022,
-                39.96658794894463
+                -75.14559322974925,
+                39.96657768870497
               ]
             }
           },
@@ -2344,8 +5672,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14889182393847,
-                39.96696160992199
+                -75.14892276466325,
+                39.96695474085481
               ]
             }
           }
@@ -2370,8 +5698,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2390,7 +5718,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1137.7,8150.0 1000.3,8150.0 -0.0,168.3 0.0,0.0 3723.2,0.0 4555.2,140.5 5699.0,352.7 5661.3,7187.5 1400.3,8150.0 1137.7,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"1260.3,8150.0 1020.0,8150.0 -0.0,186.3 0.0,0.0 3715.8,0.0 4547.7,144.2 5699.0,355.7 5699.0,355.7 5675.1,7184.1 1437.8,8150.0 1260.3,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -2419,8 +5747,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1457961416249,
-                39.97037602411131
+                -75.14579126704321,
+                39.97038394320634
               ]
             }
           },
@@ -2440,8 +5768,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14239304225148,
-                39.97000737084192
+                -75.14238790387577,
+                39.97000691050263
               ]
             }
           },
@@ -2461,8 +5789,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14307616412984,
-                39.966250959382336
+                -75.14308655301345,
+                39.96625020786174
               ]
             }
           },
@@ -2482,8 +5810,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14647926350325,
-                39.96661961265172
+                -75.14648991618088,
+                39.96662724056545
               ]
             }
           }
@@ -2508,8 +5836,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2528,7 +5856,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,359.1 626.7,365.2 626.5,120.8 -0.0,129.9 0.0,0.0 5477.5,40.5 5671.0,578.6 5671.0,7353.5 4103.8,7374.7 4131.6,2043.8 2845.4,2043.2 2840.4,4766.2 2816.4,4782.9 2789.0,7366.1 2693.8,7365.5 2631.1,448.5 1469.3,371.9 1432.9,6916.0 -0.0,7608.9 -0.0,359.1\" /></svg>"
+          "value": "<svg><polygon points=\"641.0,124.0 -0.0,133.3 -0.0,0.0 5427.4,0.0 5671.0,675.4 5671.0,6991.3 4119.3,6980.0 4119.3,2035.5 2846.6,2038.8 2633.8,453.8 2197.1,379.6 1476.3,378.0 1474.0,6769.2 -0.0,6759.5 -0.0,369.7 642.4,373.9 641.0,124.0\" /></svg>"
         }
       },
       "body": {
@@ -2557,8 +5885,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14393071155729,
-                39.970234275842046
+                -75.1439416970578,
+                39.970241224824875
               ]
             }
           },
@@ -2578,8 +5906,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14059179502955,
-                39.96983418428754
+                -75.14056911928864,
+                39.96982902551557
               ]
             }
           },
@@ -2599,8 +5927,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14133683116854,
-                39.96613041859769
+                -75.14134211672842,
+                39.96611412596739
               ]
             }
           },
@@ -2620,8 +5948,836 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14467574769628,
-                39.96653051015219
+                -75.14471469449758,
+                39.96652632527669
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0244/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p244",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0244/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0244/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5740
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4635.1,7311.4 -0.0,7356.4 18.4,2038.5 2604.0,0.0 4329.0,0.0 4609.3,381.2 5740.0,5122.3 5740.0,5950.8 4635.1,7311.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0244/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14225381705695,
+                39.97003210412016
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5740.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13885389677408,
+                39.969602136801136
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5740.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13965065929429,
+                39.96590147121147
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14305057957716,
+                39.96633143853049
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0245/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p245",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0245/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0245/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5668
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"541.3,3936.5 300.7,666.3 -0.0,314.2 0.0,-0.0 3331.1,0.0 3377.2,687.8 4250.0,693.8 4254.9,0.0 5073.3,0.0 5032.2,4096.3 5257.1,4347.4 5098.6,4489.5 5074.7,6382.5 4736.9,6285.2 3159.0,6749.2 4226.7,7964.0 5668.0,7963.9 5668.0,8150.0 824.9,8150.0 691.7,6151.1 1800.8,6153.7 1745.6,5326.2 541.3,3936.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0245/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13964536126812,
+                39.969843531577126
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13633510717821,
+                39.96924925154962
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13745037212863,
+                39.96560051026475
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.14076062621854,
+                39.966194790292256
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0246/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p246",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0246/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0246/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5719
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"926.8,7957.7 -0.0,6916.4 -0.0,0.0 5584.7,0.0 5370.5,4233.3 2637.7,7888.3 926.8,7957.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0246/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1377032163836,
+                39.96950424378507
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13435517086225,
+                39.96889507113778
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13548797729335,
+                39.9652381775128
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1388360228147,
+                39.96584735016009
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0247/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p247",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0247/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0247/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5668
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7590.7 55.4,3113.5 812.6,0.0 1441.9,0.0 1794.5,0.0 1948.4,0.0 2146.2,0.0 4791.0,50.6 5668.0,6257.4 5640.9,7316.7 4793.0,7743.6 3741.8,8150.0 3273.3,8150.0 15.5,8150.0 -0.0,7590.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0247/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13730667457122,
+                39.96891324338119
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13390770723694,
+                39.96892224528777
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13389081440683,
+                39.96517555549821
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1372897817411,
+                39.96516655359163
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0248/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p248",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0248/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0248/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5697
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1095.9,6240.8 1144.3,107.7 716.4,0.0 1187.7,0.0 1349.3,386.9 2222.7,0.0 3683.3,0.0 4550.5,1969.6 3551.5,2474.7 5159.7,6181.4 4903.5,5936.5 3745.8,6530.6 3483.3,5962.5 1946.5,6898.6 1964.6,6389.7 1745.9,5931.1 1095.9,6240.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0248/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1351166109504,
+                39.96895154492835
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5697.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13172151854117,
+                39.968986470868394
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5697.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13165634477664,
+                39.965265077946434
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13505143718588,
+                39.96523015200639
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0249/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p249",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0249/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0249/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5668
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,847.3 -0.0,0.0 4722.6,0.0 4642.5,7913.1 1284.3,8150.0 1222.0,3609.4 2333.6,3528.8 2292.5,1387.4 951.0,827.2 -0.0,847.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0249/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13451123275755,
+                39.969139883447234
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13139811547234,
+                39.97017433456209
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12945683091552,
+                39.9667428273659
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13256994820073,
+                39.965708376251044
               ]
             }
           }
@@ -2646,8 +6802,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2666,7 +6822,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1481.2,7889.8 1660.7,0.0 5697.0,0.0 5697.0,3263.3 3992.6,3300.8 3905.0,7071.9 1481.2,7889.8\" /></svg>"
+          "value": "<svg><polygon points=\"3876.5,8149.0 -0.0,8149.0 -0.0,8003.0 1480.4,7893.4 1658.2,7.7 5697.0,0.0 5697.0,511.6 4062.7,473.2 4058.1,771.0 5697.0,777.4 5697.0,3263.1 3992.6,3301.0 3876.5,8149.0\" /></svg>"
         }
       },
       "body": {
@@ -2695,8 +6851,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13282405586865,
-                39.969690382139625
+                -75.13282195148432,
+                39.969690475625576
               ]
             }
           },
@@ -2716,8 +6872,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12972101171806,
-                39.97077215086539
+                -75.12972067368248,
+                39.97077107528982
               ]
             }
           },
@@ -2737,8 +6893,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12771646586826,
-                39.967346958140375
+                -75.12771829413515,
+                39.96734783228919
               ]
             }
           },
@@ -2758,8 +6914,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13081951001885,
-                39.96626518941461
+                -75.13081957193698,
+                39.96626723262495
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0251/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p251",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0251/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0251/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5670
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2997.5,8076.8 -0.0,8149.0 -0.0,7776.8 975.1,7753.8 1002.1,2856.5 2714.3,2777.9 2668.3,268.4 1021.1,300.8 1020.3,0.0 4759.8,0.0 4706.7,5214.0 5670.0,4860.4 5670.0,5206.7 2862.8,6263.3 4745.7,6205.9 4805.0,7156.4 3001.9,7440.6 2997.5,8076.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0251/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13105236302552,
+                39.970079815521935
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12794976507142,
+                39.9710938675922
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12604806681757,
+                39.967676434286034
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12915066477167,
+                39.966662382215766
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0252/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p252",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0252/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0252/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5697
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2603.1,5313.6 2600.8,4973.8 1657.8,5327.4 1674.4,209.2 -0.0,220.9 0.0,0.0 3369.9,0.0 3311.3,103.1 4887.8,302.7 4881.7,2609.1 5697.0,2540.8 5697.0,8149.0 -0.0,8149.0 -0.0,7524.5 1767.6,7233.2 1702.8,6300.7 -0.0,6314.2 2603.1,5313.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0252/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12943311778766,
+                39.97072058081636
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5697.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12624727505757,
+                39.97174184826851
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5697.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12434142838255,
+                39.96825000697968
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12752727111264,
+                39.967228739527535
               ]
             }
           }
@@ -2784,8 +7216,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2804,7 +7236,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 5663.0,0.0 5663.0,424.7 4953.0,476.7 4933.8,2542.2 4483.6,2815.7 4472.3,4446.6 5663.0,4343.6 5663.0,4634.7 4920.2,4649.1 4905.2,7078.6 4453.9,7090.7 4446.5,8150.0 -0.0,8150.0 -0.0,7531.7 2346.4,7147.2 2353.8,5299.4 -0.0,5553.1 2.6,5213.1 2355.1,4975.0 2362.7,3065.2 1530.0,3127.0 1545.6,784.2 -0.0,565.0 -0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,-0.0 5663.0,0.0 5663.0,429.1 4955.3,480.7 4935.8,2546.0 4485.7,2819.5 4474.2,4450.1 5663.0,4347.1 5663.0,4638.1 4922.0,4652.7 4906.8,7081.9 2352.0,6240.5 2365.1,3068.6 1532.4,3130.4 1548.3,787.9 -0.0,568.6 0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -2833,8 +7265,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12765459188972,
-                39.971520107197385
+                -75.12765704196282,
+                39.97152108561327
               ]
             }
           },
@@ -2854,8 +7286,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12456479334416,
-                39.97253589171096
+                -75.12456701554281,
+                39.972537255020306
               ]
             }
           },
@@ -2875,8 +7307,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12267050622623,
-                39.96910372955323
+                -75.12267201065585,
+                39.969104839738485
               ]
             }
           },
@@ -2896,8 +7328,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1257603047718,
-                39.968087945039656
+                -75.12576203707586,
+                39.96808867033145
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0254/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p254",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0254/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0254/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5725
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4281.4 -0.0,2654.6 444.8,2376.5 449.6,316.0 1151.5,256.0 1149.7,0.0 5725.0,0.0 5725.0,8149.0 -0.0,8149.0 -0.0,6904.2 183.9,6903.1 -0.0,6759.0 447.8,6901.5 445.9,4478.1 1181.1,4454.7 1179.6,4239.7 -0.0,4281.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0254/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12516227894365,
+                39.97226263928932
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5725.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12199856526932,
+                39.973268399142064
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5725.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12013078709313,
+                39.9698178477974
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12329450076746,
+                39.968812087944656
               ]
             }
           }
@@ -2922,8 +7492,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2942,7 +7512,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,678.4 345.4,698.0 340.1,162.8 5661.4,524.1 5370.2,3466.4 4732.1,3405.2 4244.3,8150.0 0.0,8150.0 0.0,2473.1 232.8,2472.7 38.1,2419.6 0.0,678.4\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,8150.0 0.0,688.3 349.6,707.8 343.8,173.4 5658.0,528.4 5370.3,3467.0 5740.0,3510.2 5740.0,8150.0 0.0,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -2971,8 +7541,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.14008872344122,
-                39.956809950062116
+                -75.14009553929017,
+                39.956809054982614
               ]
             }
           },
@@ -2992,8 +7562,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13951300960959,
-                39.959359292595174
+                -75.13951550728164,
+                39.95936149116427
               ]
             }
           },
@@ -3013,8 +7583,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1348226728938,
-                39.95872813851943
+                -75.13481947880288,
+                39.95872560307868
               ]
             }
           },
@@ -3034,8 +7604,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13539838672544,
-                39.956178795986375
+                -75.13539951081141,
+                39.956173166897024
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0257/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p257",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0257/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0257/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5661
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5029.3,1503.6 3278.3,1511.4 3432.3,2757.8 3120.4,2760.6 3125.3,3078.0 3870.8,3057.0 3762.0,8150.0 0.0,8150.0 0.0,7767.2 1437.6,7611.2 963.7,3140.4 601.0,3137.7 579.7,275.9 5042.2,61.6 5029.3,1503.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0257/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13947634165459,
+                39.95906125483054
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5661.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.1385297765767,
+                39.96157977733503
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5661.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13380066193436,
+                39.96053554214618
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13474722701224,
+                39.95801701964169
               ]
             }
           }
@@ -3060,8 +7768,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3080,7 +7788,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,2709.8 3004.7,2367.7 4578.1,2349.3 4628.2,2700.8 4616.3,2727.4 4861.6,5156.9 5755.0,5069.2 5755.0,8150.0 0.0,8150.0 0.0,7911.9 1955.1,7871.1 1840.0,3189.5 0.0,2709.8\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,2673.1 3002.9,2364.9 4640.8,2344.8 4850.0,5027.9 5755.0,4957.4 5755.0,8150.0 0.0,8150.0 0.0,2673.1\" /></svg>"
         }
       },
       "body": {
@@ -3109,8 +7817,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13856862579061,
-                39.96075129204403
+                -75.13856668046871,
+                39.96075236488689
               ]
             }
           },
@@ -3130,8 +7838,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13756331719517,
-                39.963263566755224
+                -75.13756065774672,
+                39.9632638370045
               ]
             }
           },
@@ -3151,8 +7859,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13295377336892,
-                39.96216457269416
+                -75.13295258652889,
+                39.96216406226626
               ]
             }
           },
@@ -3172,8 +7880,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13395908196436,
-                39.95965229798296
+                -75.13395860925088,
+                39.95965259014866
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0259/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p259",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0259/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0259/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5691
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,-0.0 3427.3,24.1 4200.9,692.6 5384.0,320.2 5691.0,749.6 5691.0,1309.6 1356.1,1300.2 97.1,1623.0 0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0259/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13717825259103,
+                39.96297985213124
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5691.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13496901869429,
+                39.964960990358186
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5691.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13126497709202,
+                39.96253728859184
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.13347421098875,
+                39.960556150364894
               ]
             }
           }
@@ -3198,8 +8044,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3218,7 +8064,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2618.5,359.9 2982.4,0.0 3416.5,0.0 4763.2,471.4 4534.2,1049.3 5755.0,1483.6 5554.4,2315.0 5755.0,2404.6 5755.0,8150.0 -0.0,8150.0 -0.0,1573.1 428.5,1566.3 527.0,1238.7 1726.2,24.8 2618.5,359.9\" /></svg>"
+          "value": "<svg><polygon points=\"2618.7,365.6 2987.3,0.0 3400.7,0.0 4760.7,473.8 4532.9,1051.3 5755.0,1484.0 5553.5,2313.8 5755.0,2386.9 5755.0,8150.0 -0.0,8150.0 -0.0,1838.2 433.3,1573.7 531.3,1246.3 1727.1,32.3 2618.7,365.6\" /></svg>"
         }
       },
       "body": {
@@ -3247,8 +8093,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13512492584304,
-                39.96478425240269
+                -75.13513059745947,
+                39.96478634333794
               ]
             }
           },
@@ -3268,8 +8114,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13279910554803,
-                39.966732891456246
+                -75.13279795241638,
+                39.96673490390038
               ]
             }
           },
@@ -3289,8 +8135,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12922356274525,
-                39.964190441881605
+                -75.12922255363625,
+                39.96418499391373
               ]
             }
           },
@@ -3310,3170 +8156,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.13154938304027,
-                39.962241802828046
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0201/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p201",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0201/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0201/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5652
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5652.0,8149.0 -0.0,8149.0 -0.0,1452.5 1382.9,1447.0 1384.0,843.7 4029.4,837.0 4030.1,518.6 5276.7,1964.4 4024.1,1987.3 4029.9,7198.4 5218.6,7203.4 5218.5,8035.3 5652.0,8036.4 5652.0,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0201/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1384.0,
-                4886.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1584049,
-                39.9586513
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1384.0,
-                843.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.158005,
-                39.9604777
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0204/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p204",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0204/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0204/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5681
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3834.9,0.0 4037.8,2108.1 5681.0,1951.6 5681.0,4745.0 5681.0,4745.0 5681.0,8150.0 -0.0,8150.0 -0.0,7038.9 597.5,6804.0 694.4,6602.3 695.1,0.0 3834.9,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0204/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                695.6,
-                4794.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1536849,
-                39.9580979
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                695.6,
-                1595.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.153365,
-                39.959559
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0205/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p205",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0205/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0205/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5627
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1689.1,2137.2 5627.0,1845.1 5627.0,2719.3 4681.1,2855.7 4639.6,8022.9 5627.0,8033.8 5627.0,8150.0 1496.6,8150.0 1598.5,4968.2 1598.5,4968.2 1689.1,2137.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0205/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4675.2,
-                3951.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.148811,
-                39.9580107
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4675.2,
-                6078.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1489807,
-                39.9570478
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0207/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p207",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0207/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0207/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,7108.9 728.0,7114.3 728.1,6987.7 722.7,5761.5 -0.0,5754.9 -0.0,3665.5 1549.7,3684.5 1525.3,1239.0 4555.3,1173.2 4503.4,8150.0 -0.0,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0207/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                728.0,
-                7114.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1468242,
-                39.9561561
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4808.0,
-                1167.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1439025,
-                39.9585388
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0208/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p208",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0208/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0208/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5680
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,889.3 256.9,881.8 259.4,2415.0 4255.8,2419.4 4205.2,7817.4 5680.0,7834.7 5680.0,8149.0 -0.0,8149.0 -0.0,889.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0208/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3628.0,
-                3334.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1421948,
-                39.9572181
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2128.0,
-                6965.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1433931,
-                39.9557261
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0210/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p210",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0210/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0210/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5726
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2783.0,4365.0 2782.2,4587.5 4261.8,4435.6 4247.4,7546.0 1583.4,7542.1 1579.9,8150.0 -0.0,8150.0 38.4,1574.4 4272.3,1594.4 4265.8,4209.0 2783.0,4365.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0210/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4510.4,
-                7542.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1562922,
-                39.9602627
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1583.4,
-                7542.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.158005,
-                39.9604777
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0216/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p216",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0216/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0216/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5682
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5110.7,7612.4 1558.8,7795.7 1636.2,2630.5 5149.3,2566.3 5110.7,7612.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0216/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4298.5,
-                1115.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.143772,
-                39.961514
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2463.1,
-                7590.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1454519,
-                39.9587383
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0217/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p217",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0217/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0217/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5637
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1143.6,1745.1 5637.0,1643.5 5637.0,8150.0 1128.2,8150.0 1143.6,1745.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0217/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1998.9,
-                1507.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1428731,
-                39.9608472
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4381.7,
-                4390.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1417274,
-                39.9593458
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0219/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p219",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0219/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0219/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5642
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 4949.9,0.0 5606.9,131.9 5576.0,2292.7 5182.8,5283.4 4220.4,8149.0 -0.0,8149.0 -0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0219/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1567.4,
-                6085.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1572133,
-                39.9640783
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1567.4,
-                1483.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1567577,
-                39.9661491
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0220/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p220",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0220/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0220/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5666
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4010.0,8150.0 1423.4,8150.0 92.9,1684.1 111.7,0.0 1451.9,0.0 4130.9,2535.7 5666.0,5521.2 5666.0,6524.1 5666.0,7069.7 4112.3,8150.0 4010.0,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0220/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2411.1,
-                3595.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.154847,
-                39.964913
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4118.5,
-                6234.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1541009,
-                39.9636029
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0221/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p221",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0221/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0221/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5678
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5678.0,8150.0 3164.5,8150.0 3174.8,7449.0 1955.4,7528.0 1877.5,8150.0 552.9,8150.0 601.4,6196.9 2127.6,6214.6 2159.6,4690.3 642.3,4540.2 753.2,0.0 2625.3,0.0 5050.8,544.9 4881.3,7316.2 5655.5,7265.5 5678.0,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0221/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2535.1,
-                2127.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.152687,
-                39.964957
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4998.2,
-                2691.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.151265,
-                39.964539
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0222/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p222",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0222/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0222/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5696
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1251.6,549.9 -0.0,269.7 0.0,0.0 4554.8,0.0 4569.7,1250.9 5696.0,1501.3 5696.0,3666.2 4601.2,3439.7 4637.6,7067.3 2193.4,7316.5 2263.7,8150.0 1987.6,8150.0 1956.0,7340.8 1173.2,7402.8 1251.6,549.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0222/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2892.0,
-                3067.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.150318,
-                39.964267
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1228.0,
-                2723.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.151265,
-                39.964539
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0223/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p223",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0223/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0223/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5663
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5663.0,7377.3 5663.0,8149.0 3095.1,8149.0 3091.9,7713.3 1675.1,7672.9 1702.2,8149.0 397.2,8149.0 386.9,3241.2 1463.8,3474.7 1466.8,3166.5 5663.0,3236.7 5663.0,4395.5 4984.9,4273.3 5663.0,7377.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0223/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1703.7,
-                3526.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1485852,
-                39.9637602
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1703.7,
-                1391.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.148399,
-                39.964738
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0224/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p224",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0224/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0224/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5651
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2040.2,8149.0 1181.6,4216.6 1238.9,1925.5 1294.3,315.7 3151.9,354.1 5462.1,4862.0 5496.6,5475.5 4702.4,8149.0 2040.2,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0224/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3379.4,
-                6641.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.145605,
-                39.961942
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4735.2,
-                4758.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1446289,
-                39.9627055
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0225/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p225",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0225/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0225/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5663
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"224.2,7671.0 1008.7,7578.5 709.8,4815.0 1480.5,4852.4 1375.2,4252.0 647.0,4233.7 399.8,1949.8 5663.0,2082.6 5663.0,7393.0 264.9,8094.2 224.2,7671.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0225/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3311.4,
-                4294.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1430833,
-                39.9623487
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5147.1,
-                6373.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1423477,
-                39.961192
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0226/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p226",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "13"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0226/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0226/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5663
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4376.3,7896.2 1619.7,8149.0 1770.7,2839.8 2447.4,2873.1 2259.3,271.5 4495.3,978.9 4376.3,7896.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0226/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3655.4,
-                3814.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1403948,
-                39.9624069
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4767.2,
-                1055.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1393517,
-                39.9635181
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0228/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p228",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0228/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0228/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5696
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1034.6,0.0 1000.6,2792.2 4206.4,2831.3 4161.3,6015.8 16.6,5904.5 0.0,-0.0 1034.6,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0228/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1536.0,
-                5262.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1565646,
-                39.9671227
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1536.0,
-                7389.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1567577,
-                39.9661491
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0229/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p229",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0229/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0229/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5640
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2071.3,2292.0 2056.9,1797.5 3722.6,1980.5 3663.3,617.7 3879.7,638.5 4096.0,5800.6 1403.5,5517.2 1271.0,2326.8 2071.3,2292.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0229/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4096.0,
-                5802.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1535269,
-                39.9662373
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2096.0,
-                3139.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1543664,
-                39.9676117
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0230/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p230",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0230/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0230/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5711
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7635.3 -0.0,6711.9 -0.0,5542.6 1266.7,715.7 3874.3,1097.2 3894.4,6282.4 1257.2,7894.1 -0.0,7635.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0230/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3387.4,
-                6202.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.152295,
-                39.965877
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4747.2,
-                1171.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1509806,
-                39.9680865
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0231/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p231",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0231/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0231/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5682
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3.9,756.4 4788.2,1437.7 5682.0,1583.2 5682.0,7151.8 4889.7,6979.2 4869.8,5753.0 405.9,5772.5 407.1,6036.9 0.5,5947.8 3.9,756.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0231/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3270.8,
-                6649.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.150104,
-                39.965239
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3270.8,
-                1211.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1495815,
-                39.9677379
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0233/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p233",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "21"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0233/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0233/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5684
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4323.5,8149.0 2609.3,8149.0 1058.6,7950.7 737.0,5823.0 782.7,4275.0 1176.3,1659.9 4586.5,128.9 5684.0,565.8 5684.0,1713.6 5684.0,7422.8 4613.8,8149.0 4323.5,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0233/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3676.0,
-                5198.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1447541,
-                39.9647648
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4588.0,
-                555.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1437603,
-                39.9667969
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0234/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p234",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0234/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0234/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5713
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4253.8,7661.6 3045.3,7499.7 2713.7,7455.2 -0.0,7075.1 -0.0,937.5 660.2,605.9 2850.6,593.7 3081.3,594.0 5713.0,4721.3 5713.0,6290.3 5713.0,7847.6 4253.8,7661.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0234/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4253.8,
-                7662.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1428633,
-                39.9633928
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4253.8,
-                595.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1421887,
-                39.9665933
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0235/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p235",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0235/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0235/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5697
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2656.1,7569.6 2640.0,4463.3 1185.0,3893.9 1203.2,7396.1 -0.0,7241.3 -0.0,370.7 4469.6,317.9 4469.6,7801.6 2656.1,7569.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0235/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4469.6,
-                319.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1402232,
-                39.9663646
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4469.6,
-                7801.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1409645,
-                39.9629603
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0239/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p239",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0239/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0239/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5653
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5653.0,6711.7 1207.9,6162.5 1143.6,0.0 4038.6,0.0 5653.0,1337.3 5653.0,6711.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0239/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4049.9,
-                6546.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1514967,
-                39.9681877
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4049.9,
-                1411.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1509616,
-                39.9705283
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0244/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p244",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0244/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0244/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5740
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1323.9,7354.0 18.7,7356.4 18.4,2038.5 2630.2,0.0 4052.1,0.0 4333.7,0.0 4609.3,381.2 5740.0,5122.3 5740.0,5952.8 4635.1,7311.4 1323.9,7354.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0244/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2156.0,
-                4850.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.141451,
-                39.967668
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2156.0,
-                7325.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.141693,
-                39.966544
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0245/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p245",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0245/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0245/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5668
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"541.3,3936.6 300.7,666.4 -0.0,314.4 0.0,-0.0 3331.0,0.0 3377.2,687.8 4250.0,693.8 4254.9,0.0 5073.3,0.0 5032.2,4096.3 5257.1,4347.4 5098.6,4489.5 5074.8,6382.5 4736.9,6285.2 3159.0,6749.2 4226.7,7963.9 5668.0,7963.8 5668.0,8150.0 824.9,8150.0 691.9,6154.9 1800.9,6155.7 1745.6,5326.2 541.3,3936.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0245/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4248.0,
-                695.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1372582,
-                39.9690873
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                788.0,
-                7586.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1402232,
-                39.9663646
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0246/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p246",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0246/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0246/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5719
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"926.8,7957.7 -0.0,6916.5 -0.0,6707.7 -0.0,0.0 3017.9,0.0 5584.7,0.0 5370.5,4233.3 2637.7,7888.3 926.8,7957.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0246/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2675.5,
-                4282.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1367322,
-                39.9672975
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2675.5,
-                719.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1362367,
-                39.9688972
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0247/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p247",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "18"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0247/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0247/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5668
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7590.7 55.4,3113.5 812.6,0.0 2146.3,0.0 4791.0,50.6 5668.0,6257.4 5640.9,7316.7 4793.0,7743.6 3741.8,8150.0 1515.8,8150.0 15.5,8150.0 -0.0,7590.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0247/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2404.0,
-                3859.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1358578,
-                39.9671433
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4800.0,
-                2859.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1344223,
-                39.9676064
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0248/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p248",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "21"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0248/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0248/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5697
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1095.9,6240.8 1144.3,107.7 716.3,0.0 1187.7,0.0 1350.1,388.8 2222.7,0.0 3683.3,0.0 4550.5,1969.6 3551.5,2474.7 5367.6,6660.6 4901.3,5937.6 3745.8,6530.6 3483.3,5962.5 1946.2,6907.1 1964.6,6389.7 1745.9,5931.1 1095.9,6240.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0248/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1111.4,
-                4222.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1344205,
-                39.9670301
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5013.4,
-                5881.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.132082,
-                39.966297
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0249/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p249",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0249/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0249/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5668
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,849.3 -0.0,-0.0 4722.6,0.0 4642.5,7913.1 3164.8,8150.0 1284.3,8150.0 1222.0,3609.4 2333.6,3528.8 2292.5,1387.4 951.0,827.2 -0.0,849.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0249/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3220.0,
-                3483.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.131913,
-                39.968261
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1184.0,
-                671.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1337009,
-                39.9690731
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0251/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p251",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "25"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0251/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0251/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5670
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1002.1,2856.5 2715.4,2777.8 2663.9,0.0 4759.7,0.0 4706.7,5214.0 5670.0,4860.4 5670.0,5206.7 3010.8,6207.6 4745.7,6205.9 4805.1,7156.4 975.1,7760.0 1002.1,2856.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0251/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4734.3,
-                3882.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1275557,
-                39.9692983
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                999.6,
-                1987.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1300416,
-                39.9694252
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0252/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p252",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0252/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0252/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5697
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6314.2 2603.1,5313.6 2600.8,4973.8 1657.8,5327.4 1674.4,209.2 -0.0,220.9 0.0,0.0 3372.8,0.0 3311.3,103.1 4887.8,302.7 4881.7,2609.1 5697.0,2540.8 5697.0,4421.0 3394.0,4676.3 3366.6,5019.6 5697.0,4740.3 5697.0,6559.5 1806.1,7236.1 1702.8,6300.7 -0.0,6314.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0252/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2878.5,
-                355.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1277402,
-                39.9710841
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1659.1,
-                5502.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1272187,
-                39.9686608
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0254/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p254",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0254/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0254/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5725
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4281.4 -0.0,2654.6 444.8,2376.5 449.6,316.0 1153.8,255.8 1152.0,0.0 5725.0,0.0 5725.0,8149.0 -0.0,8149.0 -0.0,6918.9 447.8,6901.5 445.9,4478.1 1182.8,4454.8 1181.3,4239.6 -0.0,4281.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0254/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                447.8,
-                6901.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.123333,
-                39.969419
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                447.8,
-                431.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1248154,
-                39.9721576
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0257/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p257",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0257/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0257/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5661
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5029.3,1503.6 3288.3,1505.0 3436.9,2744.9 3126.8,2746.6 3131.2,3129.1 3868.6,3077.9 5661.0,3583.1 5661.0,8150.0 0.0,8150.0 0.0,3118.9 620.3,3112.4 609.5,266.9 5047.4,69.9 5029.3,1503.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0257/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3182.3,
-                1503.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1380696,
-                39.9602788
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5029.3,
-                1503.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1377629,
-                39.9611061
+                -75.13155519867934,
+                39.96223643335129
               ]
             }
           }
@@ -6491,15 +8175,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6518,104 +8202,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4160.0,365.4 4095.3,1633.6 3063.2,1738.6 4169.3,8150.0 -0.0,8150.0 -0.0,1345.7 1301.4,1273.6 4160.0,365.4\" /></svg>"
+          "value": "<svg><polygon points=\"247.8,1416.8 3155.3,1438.5 3143.8,1808.8 5755.0,1889.9 5755.0,8150.0 -0.0,8150.0 -0.0,6980.1 759.6,6664.2 -0.0,4801.4 -0.0,1249.6 249.7,1270.1 247.8,1416.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0262/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1303.8,
-                1631.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1299957,
-                39.9665286
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4095.3,
-                1631.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1287079,
-                39.9669999
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0263/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p263",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0263/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0263/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5687
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,374.8 5687.0,706.9 5687.0,8150.0 -0.0,8150.0 -0.0,374.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0263/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -6640,8 +8231,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12929057196557,
-                39.966928615204495
+                -75.1313102,
+                39.9668083
               ]
             }
           },
@@ -6649,7 +8240,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5687.0,
+                5755.0,
                 0.0
               ],
               "creator": {
@@ -6661,8 +8252,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12651435579235,
-                39.96843428726529
+                -75.1281896,
+                39.9679173
               ]
             }
           },
@@ -6670,7 +8261,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5687.0,
+                5755.0,
                 8150.0
               ],
               "creator": {
@@ -6682,8 +8273,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12369729140573,
-                39.9653864198922
+                -75.1261402,
+                39.964530100000005
               ]
             }
           },
@@ -6703,50 +8294,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12647350757895,
-                39.963880747831396
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                883.8,
-                435.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1287079,
-                39.9669999
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                883.8,
-                435.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -75.1287079,
-                39.9669999
+                -75.1292608,
+                39.9634211
               ]
             }
           }
@@ -6764,15 +8313,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         }
       ],
-      "created": "2026-08-07T16:12:47Z",
-      "modified": "2026-08-07T16:12:47Z",
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6791,7 +8340,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5772,0 5772,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"5772.0,6537.2 5643.9,6181.6 3248.0,7041.4 3639.7,8150.0 0.0,8150.0 0.0,709.7 930.4,3318.2 5772.0,1564.5 5772.0,6537.2\" /></svg>"
         }
       },
       "body": {
@@ -6820,8 +8369,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12721400804112,
-                39.967993258916046
+                -75.12529131348624,
+                39.96800344434855
               ]
             }
           },
@@ -6841,8 +8390,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12420805778258,
-                39.96929310820198
+                -75.1253770539093,
+                39.969296984919
               ]
             }
           },
@@ -6862,8 +8411,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.12181147383085,
-                39.96604105351585
+                -75.1230100242634,
+                39.96939044747983
               ]
             }
           },
@@ -6883,8 +8432,83 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.1248174240894,
-                39.96474120422991
+                -75.12292428384035,
+                39.96809690690938
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0265/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Philadelphia, Pa. | 1950 | Vol. 3 p265",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:46:43Z",
+      "modified": "2026-08-15T01:46:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0265/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0265/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5649
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,8150 0,0 5649,0 5649,8150 0,8150\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd382m:g3824m:g3824pm:g3824pm_g07905195003:07905_03_1950-0265/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12499361464475,
+                39.96902853426088
               ]
             }
           },
@@ -6892,20 +8516,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                612.0,
-                483.9
+                5649.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -75.126753,
-                39.967938
+                -75.12223940871688,
+                39.97052607291298
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5649.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.11941971551894,
+                39.96748311021787
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -75.12217392144682,
+                39.96598557156577
               ]
             }
           }

--- a/gallery/richmond_va_1925_vol_3.iiif.json
+++ b/gallery/richmond_va_1925_vol_3.iiif.json
@@ -1,19 +1,19 @@
 {
-  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn01309_018/main-content//generated",
+  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn09064_008/main-content//generated",
   "type": "AnnotationPage",
   "@context": [
     "http://www.w3.org/ns/anno.jsonld"
   ],
-  "label": "Mosaic of main content, Miami, Fla. | 1950 | Vol. 1",
+  "label": "Mosaic of main content, Richmond, Va. | 1925 | Vol. 3",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0001/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0301/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p1",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p301",
       "metadata": [
         {
           "label": "streets",
@@ -24,8 +24,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -34,21 +34,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0001/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0301/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0001/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0301/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6663
+          "height": 8038,
+          "width": 6787
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1792.7,6098.8 1754.4,4425.1 -0.0,4487.9 -0.0,2500.4 165.9,2495.6 154.0,1660.0 5273.4,1451.5 5254.6,644.8 6663.0,852.9 6663.0,6577.6 5448.7,6648.0 5445.8,5995.2 5195.6,6004.7 5195.6,6004.7 1792.7,6098.8\" /></svg>"
+          "value": "<svg><polygon points=\"6787.0,8038.0 -0.0,8038.0 0.0,-0.0 6787.0,-0.0 6787.0,4549.4 5826.7,4547.9 5403.1,4893.1 5315.2,7046.2 6787.0,7056.3 6787.0,8038.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0001/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0301/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -73,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19632403078805,
-                25.773618289198552
+                -77.45168353327948,
+                37.55991899440854
               ]
             }
           },
@@ -82,7 +82,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6663.0,
+                6787.0,
                 0.0
               ],
               "creator": {
@@ -94,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19282099061257,
-                25.773600691528948
+                -77.44857486053402,
+                37.558089703226166
               ]
             }
           },
@@ -103,8 +103,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6663.0,
-                7677.0
+                6787.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -115,8 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19284335349893,
-                25.769939479468317
+                -77.45130799694988,
+                37.55517076456926
               ]
             }
           },
@@ -125,7 +125,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -136,8 +136,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1963463936744,
-                25.76995707713792
+                -77.45441666969533,
+                37.55700005575164
               ]
             }
           }
@@ -145,13 +145,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0010/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0302/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p10",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p302",
       "metadata": [
         {
           "label": "streets",
@@ -162,8 +162,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -172,21 +172,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0010/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0302/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0010/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0302/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6543
+          "height": 8038,
+          "width": 6787
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1629.8,7678.0 1676.5,861.1 4969.6,864.5 4909.5,7678.0 1629.8,7678.0\" /></svg>"
+          "value": "<svg><polygon points=\"6787.0,7045.5 6787.0,8038.0 2217.7,8007.5 2215.0,7009.7 719.2,7003.5 802.8,4814.9 1232.4,4462.8 2208.4,4461.8 2196.7,-0.0 4751.9,-0.0 4683.0,4459.3 5275.2,4458.9 5275.2,7022.3 6787.0,7045.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0010/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0302/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -211,8 +211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19287581583997,
-                25.776495185523395
+                -77.4496170848326,
+                37.558616431812396
               ]
             }
           },
@@ -220,7 +220,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6543.0,
+                6787.0,
                 0.0
               ],
               "creator": {
@@ -232,8 +232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18955153027437,
-                25.776622844982104
+                -77.44656445027499,
+                37.55681022340319
               ]
             }
           },
@@ -241,8 +241,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6543.0,
-                7678.0
+                6787.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -253,8 +253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1893863232117,
-                25.77308483892928
+                -77.4492630555792,
+                37.55394385678854
               ]
             }
           },
@@ -263,7 +263,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -274,8 +274,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1927106087773,
-                25.77295717947057
+                -77.4523156901368,
+                37.55575006519775
               ]
             }
           }
@@ -283,13 +283,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0011/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0303/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p11",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p303",
       "metadata": [
         {
           "label": "streets",
@@ -300,8 +300,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -310,21 +310,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0011/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0303/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0011/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0303/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6480
+          "height": 8038,
+          "width": 6787
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1632.3,770.5 4925.0,803.6 4908.3,5032.9 4043.0,5021.0 4029.1,7678.0 1558.2,7632.2 1632.3,770.5\" /></svg>"
+          "value": "<svg><polygon points=\"6787.0,1644.0 6787.0,8038.0 2162.4,8038.0 2156.0,7622.3 635.3,7622.4 595.5,5044.6 -0.0,5054.2 0.0,0.0 1593.3,-0.0 1584.1,177.6 6787.0,1644.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0011/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0303/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -349,8 +349,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19117281865428,
-                25.776513239433903
+                -77.44728606657131,
+                37.55755111877737
               ]
             }
           },
@@ -358,7 +358,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6480.0,
+                6787.0,
                 0.0
               ],
               "creator": {
@@ -370,8 +370,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1879044949942,
-                25.776644596473478
+                -77.44428634661715,
+                37.55571828093333
               ]
             }
           },
@@ -379,8 +379,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6480.0,
-                7678.0
+                6787.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -391,8 +391,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18773282398618,
-                25.77313179277719
+                -77.44702465276839,
+                37.55290151224929
               ]
             }
           },
@@ -401,7 +401,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -412,8 +412,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19100114764626,
-                25.773000435737615
+                -77.45002437272255,
+                37.554734350093334
               ]
             }
           }
@@ -421,13 +421,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0012/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0304/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p12",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p304",
       "metadata": [
         {
           "label": "streets",
@@ -438,8 +438,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -448,21 +448,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0012/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0304/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0012/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0304/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6560
+          "height": 8038,
+          "width": 6787
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1340.4,4952.2 1352.2,763.3 2716.4,785.3 2500.6,0.0 6560.0,0.0 6560.0,7677.0 -0.0,7677.0 -0.0,7564.8 472.5,7573.0 483.2,4941.4 1340.4,4952.2\" /></svg>"
+          "value": "<svg><polygon points=\"1644.9,5893.0 1769.4,2029.5 4035.4,2775.4 6163.7,-0.0 6470.8,-0.0 6674.1,1878.5 6582.0,8038.0 -0.0,8038.0 1644.9,5893.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0012/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0304/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -487,8 +487,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18937612002219,
-                25.77657103578258
+                -77.44507860394135,
+                37.55626313957734
               ]
             }
           },
@@ -496,7 +496,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6560.0,
+                6787.0,
                 0.0
               ],
               "creator": {
@@ -508,8 +508,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18603581707447,
-                25.776701795006893
+                -77.44193465862662,
+                37.55446703716701
               ]
             }
           },
@@ -517,8 +517,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6560.0,
-                7677.0
+                6787.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -529,8 +529,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18586701118817,
-                25.773155414205462
+                -77.44461803816347,
+                37.55151479209932
               ]
             }
           },
@@ -539,7 +539,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -550,8 +550,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18920731413588,
-                25.77302465498115
+                -77.4477619834782,
+                37.55331089450965
               ]
             }
           }
@@ -559,13 +559,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0014/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0305/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p14",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p305",
       "metadata": [
         {
           "label": "streets",
@@ -576,8 +576,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -586,21 +586,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0014/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0305/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0014/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0305/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6544
+          "height": 8038,
+          "width": 6787
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1107.7,7054.6 -0.0,7062.4 -0.0,739.6 6154.9,632.4 6126.5,7678.0 1110.7,7678.0 1107.7,7054.6\" /></svg>"
+          "value": "<svg><polygon points=\"3705.7,0.0 3672.6,2483.7 5992.5,2460.3 6494.9,4127.1 4591.5,6292.8 3651.7,6311.3 3639.9,7237.3 74.1,7381.0 -0.0,0.0 3705.7,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0014/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0305/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -625,8 +625,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19843994542981,
-                25.779149035833157
+                -77.44474795107067,
+                37.549721740903195
               ]
             }
           },
@@ -634,7 +634,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6544.0,
+                6787.0,
                 0.0
               ],
               "creator": {
@@ -646,8 +646,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19514729282795,
-                25.779223088114673
+                -77.4424472445754,
+                37.552187438401845
               ]
             }
           },
@@ -655,8 +655,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6544.0,
-                7678.0
+                6787.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -667,8 +667,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19505078129139,
-                25.7757433946773
+                -77.4387636568986,
+                37.55002691770023
               ]
             }
           },
@@ -677,7 +677,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -688,8 +688,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19834343389324,
-                25.775669342395783
+                -77.44106436339386,
+                37.54756122020158
               ]
             }
           }
@@ -697,13 +697,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0015/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0306/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p15",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p306",
       "metadata": [
         {
           "label": "streets",
@@ -714,8 +714,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -724,21 +724,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0015/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0306/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0015/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0306/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6456
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4594.2,7678.0 1454.6,7678.0 1568.0,563.9 4614.0,575.5 4594.2,7678.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,3587.3 3532.8,3429.6 3540.5,2511.7 4471.7,2489.3 5609.4,1182.8 5574.9,7482.7 -0.0,7483.6 -0.0,3587.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0015/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0306/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -763,8 +763,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1961441107781,
-                25.779163711019375
+                -77.4429937264217,
+                37.54874335273033
               ]
             }
           },
@@ -772,7 +772,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6456.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -784,8 +784,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19285744333442,
-                25.779274642185186
+                -77.44067382631584,
+                37.55120718892551
               ]
             }
           },
@@ -793,8 +793,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6456.0,
-                7678.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -805,8 +805,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1927108978799,
-                25.775753914912464
+                -77.43696907010889,
+                37.54901439178788
               ]
             }
           },
@@ -815,7 +815,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -826,8 +826,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1959975653236,
-                25.775642983746653
+                -77.43928897021475,
+                37.546550555592695
               ]
             }
           }
@@ -835,13 +835,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0016/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0307/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p16",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p307",
       "metadata": [
         {
           "label": "streets",
@@ -852,8 +852,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -862,21 +862,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0016/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0307/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0016/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0307/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6544
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4961.5,609.0 4918.9,6823.3 1696.0,6810.2 1729.0,586.9 4961.5,609.0\" /></svg>"
+          "value": "<svg><polygon points=\"5769.9,6377.5 5300.0,6549.0 406.5,6483.2 452.0,1751.6 2406.9,1141.8 2401.7,534.0 5339.1,567.8 5892.9,397.4 5770.7,-0.0 6742.0,-0.0 6742.0,5407.2 5769.9,6377.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0016/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0307/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -901,8 +901,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19469105743853,
-                25.77922076810758
+                -77.4347661636341,
+                37.55205814940168
               ]
             }
           },
@@ -910,7 +910,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6544.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -922,8 +922,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19130437796663,
-                25.779341554717856
+                -77.43167451007757,
+                37.5502152065775
               ]
             }
           },
@@ -931,8 +931,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6544.0,
-                7678.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -943,8 +943,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19114694911865,
-                25.775762697021822
+                -77.43444571613723,
+                37.547293000511004
               ]
             }
           },
@@ -953,7 +953,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -964,8 +964,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19453362859055,
-                25.775641910411547
+                -77.43753736969376,
+                37.54913594333519
               ]
             }
           }
@@ -973,13 +973,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0017/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0308/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p17",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p308",
       "metadata": [
         {
           "label": "streets",
@@ -990,8 +990,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1000,21 +1000,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0017/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0308/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0017/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0308/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6505
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1513.3,7039.5 1499.2,761.2 4771.4,754.4 4778.2,7003.3 1513.3,7039.5\" /></svg>"
+          "value": "<svg><polygon points=\"211.5,-0.0 5403.7,-0.0 5391.2,179.3 5629.0,-0.0 6566.9,-0.0 6191.6,1853.3 6188.9,4485.2 6742.0,4372.8 6742.0,8038.0 332.3,8038.0 211.5,-0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0017/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0308/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -1039,8 +1039,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19289139557118,
-                25.77935869033597
+                -77.43691087955783,
+                37.54964890482333
               ]
             }
           },
@@ -1048,7 +1048,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6505.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -1060,8 +1060,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18955654342919,
-                25.779450296211124
+                -77.4338516824381,
+                37.54777369153666
               ]
             }
           },
@@ -1069,8 +1069,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6505.0,
-                7678.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1081,8 +1081,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18943648722771,
-                25.775906712762655
+                -77.43667133017739,
+                37.5448820779778
               ]
             }
           },
@@ -1091,7 +1091,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1102,8 +1102,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1927713393697,
-                25.775815106887503
+                -77.43973052729712,
+                37.54675729126447
               ]
             }
           }
@@ -1111,13 +1111,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0018/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0309/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p18",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p309",
       "metadata": [
         {
           "label": "streets",
@@ -1128,8 +1128,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1138,21 +1138,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0018/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0309/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0018/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0309/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6587
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"787.4,1467.7 6587.0,1790.1 6587.0,4536.0 6587.0,4536.0 6587.0,6133.0 5088.3,6141.4 5304.4,6918.3 753.3,6893.1 787.4,1467.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8038.0 -0.0,1582.4 3510.0,1626.6 3404.2,1070.3 5958.2,1087.7 5976.7,8038.0 -0.0,8038.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0018/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0309/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -1177,8 +1177,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19085752904051,
-                25.779394727783114
+                -77.43733548396257,
+                37.54537337952304
               ]
             }
           },
@@ -1186,7 +1186,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6587.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -1198,8 +1198,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18744739861968,
-                25.77951107200465
+                -77.43501679926123,
+                37.54781424528449
               ]
             }
           },
@@ -1207,8 +1207,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6587.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1219,8 +1219,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18729678114394,
-                25.775931297247368
+                -77.4313467033429,
+                37.54562252487632
               ]
             }
           },
@@ -1229,7 +1229,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1240,8 +1240,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19070691156477,
-                25.775814953025833
+                -77.43366538804423,
+                37.54318165911487
               ]
             }
           }
@@ -1249,13 +1249,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0019/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0310/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p19",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p310",
       "metadata": [
         {
           "label": "streets",
@@ -1266,8 +1266,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1276,21 +1276,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0019/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0310/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0019/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0310/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6505
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1492.5,7678.0 1464.7,693.8 4637.2,695.0 4686.6,7678.0 1492.5,7678.0\" /></svg>"
+          "value": "<svg><polygon points=\"538.0,959.7 2622.1,1232.7 2553.0,238.8 2345.5,0.0 2606.6,0.0 3850.4,1111.9 6742.0,871.5 6742.0,8038.0 1138.3,8038.0 538.0,959.7\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0019/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0310/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -1315,8 +1315,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20209775767563,
-                25.781936290909773
+                -77.43536984721152,
+                37.547335124728406
               ]
             }
           },
@@ -1324,7 +1324,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6505.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -1336,8 +1336,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19873082265865,
-                25.782024588864868
+                -77.43294863000928,
+                37.54949029283732
               ]
             }
           },
@@ -1345,8 +1345,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6505.0,
-                7678.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1357,8 +1357,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19861510172841,
-                25.778446914446267
+                -77.42970750504263,
+                37.54720208167002
               ]
             }
           },
@@ -1367,7 +1367,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1378,8 +1378,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20198203674539,
-                25.77835861649117
+                -77.43212872224487,
+                37.54504691356111
               ]
             }
           }
@@ -1387,13 +1387,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0002/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0312/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p2",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p312",
       "metadata": [
         {
           "label": "streets",
@@ -1404,8 +1404,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1414,21 +1414,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0002/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0312/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0002/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0312/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6515
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4330.5,176.1 6515.0,0.0 6515.0,5808.3 3207.4,6499.5 2239.4,0.0 4295.5,0.0 4330.5,176.1\" /></svg>"
+          "value": "<svg><polygon points=\"6742.0,8038.0 -0.0,8038.0 -0.0,486.1 1567.7,0.0 3036.0,0.0 3324.5,3052.8 4457.1,3090.7 6063.7,6513.3 5953.5,6802.8 5653.8,6970.9 6232.9,6842.0 6742.0,8038.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0002/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0312/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -1453,8 +1453,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19384443063572,
-                25.773335996274387
+                -77.43226943264918,
+                37.55077893483297
               ]
             }
           },
@@ -1462,7 +1462,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6515.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -1474,8 +1474,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19087423168364,
-                25.772922736591468
+                -77.42991564431684,
+                37.55325503469346
               ]
             }
           },
@@ -1483,8 +1483,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6515.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1495,8 +1495,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19141517377668,
-                25.769770505194664
+                -77.426218361343,
+                37.55101461260969
               ]
             }
           },
@@ -1505,7 +1505,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1516,8 +1516,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19438537272876,
-                25.770183764877583
+                -77.42857214967535,
+                37.548538512749204
               ]
             }
           }
@@ -1525,13 +1525,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0020/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0314/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p20",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p314",
       "metadata": [
         {
           "label": "streets",
@@ -1542,8 +1542,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1552,21 +1552,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0020/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0314/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0020/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0314/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6587
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"708.9,620.4 6081.3,689.1 6013.0,6890.4 2875.9,6869.1 2859.7,7677.0 647.9,7610.2 708.9,620.4\" /></svg>"
+          "value": "<svg><polygon points=\"4903.3,3560.5 5297.4,3689.2 4374.2,5293.7 4383.8,5143.4 2815.6,5134.3 2808.6,5693.1 279.0,5717.4 278.1,5557.3 -0.0,5560.8 -0.0,1587.2 4967.9,3350.4 4903.3,3560.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0020/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0314/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -1591,8 +1591,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20006507033946,
-                25.781949124516295
+                -77.44680498667894,
+                37.56016637175269
               ]
             }
           },
@@ -1600,7 +1600,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6587.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -1612,8 +1612,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19668650352754,
-                25.782087629241794
+                -77.44376414178149,
+                37.55833065831532
               ]
             }
           },
@@ -1621,8 +1621,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6587.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1633,8 +1633,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19650844993389,
-                25.77851603907904
+                -77.44650546730318,
+                37.555436545070705
               ]
             }
           },
@@ -1643,7 +1643,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1654,8 +1654,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1998870167458,
-                25.77837753435354
+                -77.44954631220064,
+                37.55727225850808
               ]
             }
           }
@@ -1663,13 +1663,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0021/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0315/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p21",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p315",
       "metadata": [
         {
           "label": "streets",
@@ -1680,8 +1680,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1690,21 +1690,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0021/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0315/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0021/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0315/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6505
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6250.7,6810.7 260.8,6850.0 253.9,571.7 6236.9,548.9 6250.7,6810.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,3497.9 0.0,0.0 234.9,0.0 286.6,1088.5 675.7,1073.6 667.3,753.6 1970.9,696.2 3175.7,687.7 3311.0,1032.7 4065.6,1012.0 6098.1,951.2 6491.1,928.1 6533.5,3102.3 6307.1,4102.2 6548.6,3991.7 6362.0,4441.0 3705.0,7554.3 3141.1,5889.6 809.8,5979.2 755.6,3476.5 -0.0,3497.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0021/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0315/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -1729,8 +1729,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1970682423168,
-                25.782015381826863
+                -77.44529511255129,
+                37.55177161856326
               ]
             }
           },
@@ -1738,7 +1738,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6505.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -1750,8 +1750,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19376943831757,
-                25.782114332114777
+                -77.4429372099328,
+                37.55415480057598
               ]
             }
           },
@@ -1759,8 +1759,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6505.0,
-                7678.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1771,8 +1771,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19364067014651,
-                25.778584188297323
+                -77.43937862595352,
+                37.55191049064025
               ]
             }
           },
@@ -1781,7 +1781,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1792,8 +1792,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19693947414574,
-                25.77848523800941
+                -77.44173652857202,
+                37.54952730862753
               ]
             }
           }
@@ -1801,13 +1801,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0022/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0316/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p22",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p316",
       "metadata": [
         {
           "label": "streets",
@@ -1818,8 +1818,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1828,21 +1828,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0022/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0316/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0022/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0316/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6608
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5050.4,6784.9 1809.5,6770.0 1824.0,579.8 5078.4,598.6 5050.4,6784.9\" /></svg>"
+          "value": "<svg><polygon points=\"1205.2,6569.0 335.5,7846.1 -0.0,7728.9 -0.0,5349.9 247.3,5277.2 196.8,0.0 1784.4,398.8 1996.0,411.2 2005.8,0.0 2223.3,0.0 2206.7,417.1 4346.1,441.3 4286.7,2391.4 5444.2,2422.2 6188.0,3049.5 6742.0,2234.4 6742.0,2975.9 3638.3,6938.2 1984.5,5658.9 1377.2,6715.9 1205.2,6569.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0022/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0316/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -1867,8 +1867,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19484896344852,
-                25.782095808669908
+                -77.44673700238236,
+                37.5570141909725
               ]
             }
           },
@@ -1876,7 +1876,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6608.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -1888,8 +1888,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1914378308828,
-                25.78221062551888
+                -77.44361354571652,
+                37.55881300245319
               ]
             }
           },
@@ -1897,8 +1897,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6608.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1909,8 +1909,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19128963670804,
-                25.778640730373255
+                -77.4409083401336,
+                37.5558611283228
               ]
             }
           },
@@ -1919,7 +1919,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1930,8 +1930,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19470076927375,
-                25.778525913524284
+                -77.44403179679945,
+                37.55406231684211
               ]
             }
           }
@@ -1939,13 +1939,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0023/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0317/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p23",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p317",
       "metadata": [
         {
           "label": "streets",
@@ -1956,8 +1956,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1966,21 +1966,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0023/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0317/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0023/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0317/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6505
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4765.8,591.8 4746.2,6814.6 1491.4,6809.6 1499.3,608.2 4765.8,591.8\" /></svg>"
+          "value": "<svg><polygon points=\"2438.1,8038.0 840.5,3351.3 574.6,2144.8 3174.5,0.0 3266.6,0.0 3452.9,0.0 4209.8,1150.1 6742.0,5775.6 6742.0,5913.4 6742.0,6343.5 2809.0,8038.0 2438.1,8038.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0023/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0317/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -2005,8 +2005,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19299921773734,
-                25.782164118404012
+                -77.44386932426656,
+                37.55645764191718
               ]
             }
           },
@@ -2014,7 +2014,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6505.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -2026,8 +2026,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18964692568075,
-                25.782267117999634
+                -77.44023313221872,
+                37.5555761353619
               ]
             }
           },
@@ -2035,8 +2035,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6505.0,
-                7678.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2047,8 +2047,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.189511937175,
-                25.7787050030571
+                -77.4415587167022,
+                37.55213943300002
               ]
             }
           },
@@ -2057,7 +2057,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2068,8 +2068,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19286422923159,
-                25.77860200346148
+                -77.44519490875004,
+                37.553020939555296
               ]
             }
           }
@@ -2077,13 +2077,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0024/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0318/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p24",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p318",
       "metadata": [
         {
           "label": "streets",
@@ -2094,8 +2094,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2104,21 +2104,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0024/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0318/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0024/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0318/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6615
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2598.9,0.0 6615.0,0.0 6615.0,7677.0 473.8,7677.0 124.4,524.2 2608.8,431.5 2598.9,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"4265.8,7721.3 2929.9,7581.0 -0.0,2821.2 0.0,0.0 6531.4,0.0 6742.0,995.8 5254.2,5965.4 4740.5,6122.4 4265.8,7721.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0024/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0318/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -2143,8 +2143,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19059030100608,
-                25.782203278042342
+                -77.4410057429987,
+                37.55595941466008
               ]
             }
           },
@@ -2152,7 +2152,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6615.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -2164,8 +2164,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1872888819284,
-                25.78215071670612
+                -77.43719743992492,
+                37.554829517261304
               ]
             }
           },
@@ -2173,8 +2173,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6615.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2185,8 +2185,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18735616574018,
-                25.778675451809093
+                -77.43889667566147,
+                37.55123041776135
               ]
             }
           },
@@ -2195,7 +2195,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2206,8 +2206,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19065758481787,
-                25.778728013145315
+                -77.44270497873525,
+                37.55236031516013
               ]
             }
           }
@@ -2215,13 +2215,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0025/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0319/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p25",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p319",
       "metadata": [
         {
           "label": "streets",
@@ -2232,8 +2232,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2242,21 +2242,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0025/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0319/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0025/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0319/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6559
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2248.1,270.9 4735.3,229.9 4735.3,7286.1 2252.1,7289.6 2248.1,270.9\" /></svg>"
+          "value": "<svg><polygon points=\"6064.3,7739.1 368.1,6007.0 344.4,2202.2 159.5,251.8 5367.2,1824.7 5563.6,2041.4 6055.1,3698.0 6064.3,7739.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0025/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0319/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -2281,8 +2281,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20223805792607,
-                25.785007209759872
+                -77.43946207176599,
+                37.55237895793609
               ]
             }
           },
@@ -2290,7 +2290,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6559.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -2302,8 +2302,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1988472346647,
-                25.785090648886392
+                -77.43817719049704,
+                37.55521741804629
               ]
             }
           },
@@ -2311,8 +2311,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6559.0,
-                7678.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2323,8 +2323,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19873874840799,
-                25.78151615186174
+                -77.43393870582406,
+                37.55399445833353
               ]
             }
           },
@@ -2333,7 +2333,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2344,8 +2344,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20212957166936,
-                25.78143271273522
+                -77.435223587093,
+                37.55115599822333
               ]
             }
           }
@@ -2353,13 +2353,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0026/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0320/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p26",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p320",
       "metadata": [
         {
           "label": "streets",
@@ -2370,8 +2370,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2380,21 +2380,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0026/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0320/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0026/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0320/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6599
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4941.9,0.0 5007.2,7209.2 1728.8,7240.4 1684.3,211.2 -0.0,248.8 -0.0,-0.0 4941.9,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,7454.3 902.7,4636.2 315.9,4461.2 346.6,402.9 5984.5,2099.6 6021.9,4067.4 6742.0,4268.1 6742.0,4646.4 6023.6,4491.8 6050.2,6119.3 5490.5,8038.0 0.0,8038.0 0.0,7454.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0026/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0320/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -2419,8 +2419,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20066498357849,
-                25.78504214199593
+                -77.43650723696406,
+                37.55153454707478
               ]
             }
           },
@@ -2428,7 +2428,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6599.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -2440,8 +2440,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19724044314182,
-                25.785108380193808
+                -77.43520391033076,
+                37.554398040963356
               ]
             }
           },
@@ -2449,8 +2449,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6599.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2461,8 +2461,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19715484308354,
-                25.781520224200364
+                -77.43089754485713,
+                37.55316631067737
               ]
             }
           },
@@ -2471,7 +2471,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2482,8 +2482,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.2005793835202,
-                25.781453986002486
+                -77.43220087149044,
+                37.55030281678879
               ]
             }
           }
@@ -2491,13 +2491,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0027/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0321/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p27",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p321",
       "metadata": [
         {
           "label": "streets",
@@ -2508,8 +2508,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2518,21 +2518,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0027/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0321/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0027/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0321/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6511
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"801.6,180.8 3799.0,229.6 3797.0,748.7 5469.9,745.2 5453.8,7186.6 536.9,7200.5 539.4,669.6 801.6,180.8\" /></svg>"
+          "value": "<svg><polygon points=\"6588.8,0.0 6565.3,3549.5 6232.0,3525.0 6254.0,5338.6 2957.5,4215.3 1992.8,7004.2 1622.5,5443.3 1428.8,5441.0 1205.1,4161.0 940.6,4088.5 1174.1,5443.8 -0.0,5440.9 30.2,0.0 6588.8,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0027/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0321/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -2557,8 +2557,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1983931783623,
-                25.78507653319173
+                -77.44263096944586,
+                37.55792098919217
               ]
             }
           },
@@ -2566,7 +2566,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6511.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -2578,8 +2578,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19504098446671,
-                25.785183628558006
+                -77.43877522660804,
+                37.557836521964
               ]
             }
           },
@@ -2587,8 +2587,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6511.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2599,8 +2599,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19490169880018,
-                25.781598646050675
+                -77.43890136093269,
+                37.55416674228509
               ]
             }
           },
@@ -2609,7 +2609,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2620,8 +2620,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19825389269576,
-                25.7814915506844
+                -77.4427571037705,
+                37.55425120951326
               ]
             }
           }
@@ -2629,13 +2629,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0028/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0322/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p28",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p322",
       "metadata": [
         {
           "label": "streets",
@@ -2646,8 +2646,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2656,21 +2656,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0028/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0322/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0028/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0322/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6567
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2967.7,266.9 4443.3,260.3 4442.9,786.3 5463.8,782.6 5456.2,7219.0 -0.0,7220.2 -0.0,834.5 2970.3,791.6 2967.7,266.9\" /></svg>"
+          "value": "<svg><polygon points=\"323.9,3446.3 388.0,0.0 6459.2,0.0 6361.3,1596.7 6742.0,1638.8 6742.0,8035.5 4759.9,7353.0 3003.4,7329.0 3114.5,6307.1 -0.0,5195.0 -0.0,3415.4 323.9,3446.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0028/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0322/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -2695,8 +2695,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19557765467535,
-                25.785211597072056
+                -77.43909173303814,
+                37.55782711168586
               ]
             }
           },
@@ -2704,7 +2704,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6567.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -2716,8 +2716,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19214281321605,
-                25.785312113139167
+                -77.43512688226227,
+                37.557779421847236
               ]
             }
           },
@@ -2725,8 +2725,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6567.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2737,8 +2737,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19201228357181,
-                25.781695607210313
+                -77.43519859965643,
+                37.5540322365234
               ]
             }
           },
@@ -2747,7 +2747,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2758,8 +2758,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19544712503111,
-                25.781595091143203
+                -77.4391634504323,
+                37.55407992636202
               ]
             }
           }
@@ -2767,13 +2767,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0029/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0323/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p29",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p323",
       "metadata": [
         {
           "label": "streets",
@@ -2784,8 +2784,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2794,21 +2794,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0029/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0323/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0029/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0323/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6517
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7319.1 -0.0,856.3 6517.0,916.7 6517.0,6911.6 6360.9,6903.9 6350.0,7320.1 -0.0,7319.1\" /></svg>"
+          "value": "<svg><polygon points=\"3184.9,0.0 6742.0,38.8 6742.0,7099.8 3895.2,6484.7 3184.9,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0029/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0323/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -2833,8 +2833,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1927204800953,
-                25.78532832908226
+                -77.43695128963431,
+                37.55719609157464
               ]
             }
           },
@@ -2842,7 +2842,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6517.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -2854,8 +2854,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18932451977471,
-                25.78542407417311
+                -77.43312017587948,
+                37.55681365236511
               ]
             }
           },
@@ -2863,8 +2863,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6517.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2875,8 +2875,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18919926977475,
-                25.781822199173106
+                -77.43369126346168,
+                37.55316727412119
               ]
             }
           },
@@ -2885,7 +2885,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2896,8 +2896,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19259523009534,
-                25.781726454082257
+                -77.43752237721651,
+                37.553549713330725
               ]
             }
           }
@@ -2905,13 +2905,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0031/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0324/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p31",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p324",
       "metadata": [
         {
           "label": "streets",
@@ -2922,8 +2922,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2932,21 +2932,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0031/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0324/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0031/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0324/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6517
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5120.4,0.0 5115.4,1066.8 6517.0,1067.0 6517.0,7278.4 4903.9,7283.2 4904.3,7677.0 4538.7,7677.0 4541.8,7283.8 593.7,7258.0 -0.0,6694.4 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1256.2,4.0 6027.9,0.0 3274.0,5174.1 3566.8,5171.9 2851.4,6717.4 2479.4,6635.7 2124.2,7296.1 1280.9,7127.5 1256.2,4.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0031/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0324/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -2971,8 +2971,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20714346944607,
-                25.784843472771698
+                -77.43382901609489,
+                37.55685651069984
               ]
             }
           },
@@ -2980,7 +2980,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6517.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -2992,8 +2992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20377857669834,
-                25.784942038655252
+                -77.4300493510794,
+                37.55646855813295
               ]
             }
           },
@@ -3001,8 +3001,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6517.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3013,8 +3013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20364963732979,
-                25.781373096122334
+                -77.43062866763334,
+                37.55287112296266
               ]
             }
           },
@@ -3023,7 +3023,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3034,8 +3034,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20701453007752,
-                25.78127453023878
+                -77.43440833264883,
+                37.553259075529546
               ]
             }
           }
@@ -3043,13 +3043,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0032/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0325/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p32",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p325",
       "metadata": [
         {
           "label": "streets",
@@ -3060,8 +3060,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3070,21 +3070,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0032/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0325/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0032/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0325/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6609
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1425.4,7413.4 1396.7,1225.6 -0.0,1231.8 -0.0,-0.0 6609.0,0.0 6609.0,7380.5 1425.4,7413.4\" /></svg>"
+          "value": "<svg><polygon points=\"6247.7,3587.6 5835.2,5552.5 4364.0,5522.4 1510.7,7348.8 1350.9,8038.0 89.0,8038.0 2863.1,2954.8 2707.2,0.0 4861.4,58.3 6165.3,2775.4 6247.7,3587.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0032/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0325/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -3109,8 +3109,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20450212110235,
-                25.784999616177043
+                -77.4318667421292,
+                37.55798351780832
               ]
             }
           },
@@ -3118,7 +3118,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6609.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -3130,8 +3130,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20107747142147,
-                25.78508563946705
+                -77.42805678170181,
+                37.55761518247109
               ]
             }
           },
@@ -3139,8 +3139,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6609.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3151,146 +3151,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20096650552782,
-                25.78150385510344
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.2043911552087,
-                25.781417831813435
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0033/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p33",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0033/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0033/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6544
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 729.6,631.3 4701.8,678.3 4696.8,1070.9 5064.6,1072.9 5042.4,6866.9 1068.9,6906.3 247.4,7362.8 243.4,7677.0 -0.0,7677.0 -0.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0033/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.2071015143175,
-                25.781759375635154
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6544.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20374402790029,
-                25.78187395955645
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6544.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20359573566067,
-                25.77830077556598
+                -77.4286068126145,
+                37.55398896599461
               ]
             }
           },
@@ -3299,7 +3161,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3310,8 +3172,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20695322207789,
-                25.778186191644686
+                -77.4324167730419,
+                37.55435730133184
               ]
             }
           }
@@ -3319,4291 +3181,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0034/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0326__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p34",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0034/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0034/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6578
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6145.2,6859.5 -0.0,6867.4 -0.0,646.7 6146.3,634.6 6145.2,6859.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0034/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.2045003082305,
-                25.781831193086745
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6578.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.2011181794514,
-                25.78193340980085
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6578.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20098568282002,
-                25.778378915094404
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20436781159911,
-                25.7782766983803
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0035/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p35",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0035/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0035/info.json",
-          "type": "ImageService2",
-          "height": 7678,
-          "width": 6568
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7678.0 -0.0,988.2 335.6,703.2 1005.5,492.9 6568.0,410.5 6568.0,2433.1 6374.8,2715.6 6568.0,2974.7 6568.0,7678.0 5118.5,6533.7 1223.4,6626.1 1231.6,7678.0 -0.0,7678.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0035/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.2068449994014,
-                25.77879640055608
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6568.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20345343455098,
-                25.778871973876633
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6568.0,
-                7678.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20335530071458,
-                25.775300841041496
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7678.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.206746865565,
-                25.77522526772094
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0036/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p36",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0036/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0036/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6578
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4429.6,7190.4 3427.6,6103.3 3416.2,6091.2 1357.3,6069.8 1404.5,2989.5 1380.2,2940.7 1214.7,2728.4 1412.7,2450.1 1443.5,435.9 5767.5,460.6 5760.2,1256.9 6578.0,1266.2 6578.0,6673.9 5349.2,6660.7 4429.6,7190.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0036/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.204200152653,
-                25.778857387372444
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6578.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20081471196993,
-                25.778980912634207
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6578.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.2006557265236,
-                25.775397603520435
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20404116720668,
-                25.775274078258672
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0037/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p37",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0037/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0037/info.json",
-          "type": "ImageService2",
-          "height": 7678,
-          "width": 6568
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7678.0 -0.0,-0.0 302.7,0.0 269.4,1641.1 1508.2,1666.2 1521.3,608.0 4785.5,632.8 4706.2,6996.5 1446.8,6936.2 1441.6,7678.0 -0.0,7678.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0037/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20692296174204,
-                25.775977897595304
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6568.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20355400279469,
-                25.77611444047599
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6568.0,
-                7678.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20337670219504,
-                25.77256703585561
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7678.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20674566114239,
-                25.772430492974923
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0038/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p38",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0038/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0038/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6578
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"491.9,511.8 1149.9,463.3 2530.5,1627.8 2618.0,0.0 4705.6,12.1 6578.0,2271.9 6578.0,6861.5 507.8,6909.3 491.9,511.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0038/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20471270582256,
-                25.776013568292715
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6578.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20135375979964,
-                25.776104422861383
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6578.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20123600097952,
-                25.772573997753828
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20459494700243,
-                25.77248314318516
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0039/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p39",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0039/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0039/info.json",
-          "type": "ImageService2",
-          "height": 7678,
-          "width": 6615
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"682.3,1378.2 678.3,643.5 6615.0,647.8 6615.0,7620.0 6406.2,7620.3 6420.5,6859.2 -0.0,6863.0 -0.0,1386.8 682.3,1378.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0039/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.2063830317003,
-                25.77309338546122
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6615.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20295464633271,
-                25.773193444604587
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6615.0,
-                7678.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20282565215794,
-                25.76960994169196
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7678.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20625403752553,
-                25.769509882548594
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0004/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p4",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0004/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0004/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6522
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4981.7 -0.0,1405.0 6522.0,1403.4 6522.0,1403.4 6522.0,5688.7 180.4,5157.8 -0.0,4981.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0004/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19048429804326,
-                25.77370189552199
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6522.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18708963192068,
-                25.77376600748825
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6522.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18700582360607,
-                25.770167324498455
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19040048972865,
-                25.7701032125322
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0040/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p40",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0040/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0040/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6592
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5991.1,2626.3 5997.2,7618.5 2241.4,7677.0 2249.0,667.6 5495.9,653.3 5991.1,2626.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0040/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20411424236758,
-                25.773166075581543
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6592.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20071728932922,
-                25.773268549293487
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6592.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.2005847144389,
-                25.76970462247854
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20398166747727,
-                25.769602148766594
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0041/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p41",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0041/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0041/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6535
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"905.5,2704.5 386.0,749.0 423.7,0.0 2577.7,0.0 2839.4,428.0 6535.0,346.1 6535.0,2094.1 5108.8,2114.8 5100.0,3929.0 5100.0,3929.0 5089.3,6151.6 2142.1,6203.7 2168.9,7677.0 969.0,7677.0 905.5,2704.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0041/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20147783036616,
-                25.773291416097567
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6535.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19811933133067,
-                25.773359014769337
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6535.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19803174567362,
-                25.769780121464542
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.2013902447091,
-                25.769712522792773
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0042/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p42",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0042/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0042/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6592
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1422.7,2235.5 1414.2,479.6 2258.6,474.5 2281.9,1276.9 5025.0,1237.7 5016.7,2200.6 4847.4,2201.6 4800.9,4243.1 6592.0,4219.3 6592.0,5909.4 2312.7,5878.5 2320.0,6265.3 -0.0,6318.5 -0.0,2263.5 1422.7,2235.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0042/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1988482494046,
-                25.773408971087633
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6592.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19545202277767,
-                25.77346166873966
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6592.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19538384621401,
-                25.769898463295906
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19878007284095,
-                25.76984576564388
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0043/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p43",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0043/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0043/info.json",
-          "type": "ImageService2",
-          "height": 7678,
-          "width": 6615
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,2433.1 -0.0,1339.8 2731.5,1306.8 2732.6,1843.9 4771.3,2691.3 4750.1,6824.4 1535.8,6806.2 -0.0,2433.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0043/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20171047101539,
-                25.770293955992777
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6615.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19829748649484,
-                25.770410684123505
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6615.0,
-                7678.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19814700300688,
-                25.76684327887036
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7678.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20155998752743,
-                25.766726550739634
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0044/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p44",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0044/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0044/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6592
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4868.7,7677.0 4861.0,7010.3 2006.2,6995.0 2036.3,2864.8 -0.0,2843.1 -0.0,-0.0 5249.5,0.0 5218.3,7399.6 6592.0,7410.8 6592.0,7677.0 4868.7,7677.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0044/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.2003062,
-                25.7704215
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6592.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1969046,
-                25.7705446
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6592.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1967454,
-                25.7669756
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.200147,
-                25.7668525
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0045/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p45",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0045/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0045/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6555
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1045.4,0.0 6491.1,119.9 6555.0,5269.9 6121.0,5288.3 5956.9,5517.3 6555.0,6598.1 5409.2,7303.8 5158.3,7677.0 1075.5,7677.0 1045.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0045/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19815183884313,
-                25.770683245695718
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6555.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1947198537814,
-                25.77078219273275
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6555.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19459114336784,
-                25.76716160523674
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19802312842958,
-                25.76706265819971
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0046/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p46",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0046/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0046/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6590
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2901.3,5316.5 2837.2,0.0 5363.2,0.0 5340.2,685.6 5071.4,691.0 5189.6,7422.9 5394.4,7423.1 5360.9,7677.0 1500.9,7677.0 2900.6,6697.4 2279.5,5573.5 2450.2,5335.5 2901.3,5316.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0046/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19617997908296,
-                25.770665725345065
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6590.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19286041676891,
-                25.77076283476655
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6590.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19273476952036,
-                25.767280446007085
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1960543318344,
-                25.7671833365856
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0047/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p47",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0047/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0047/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6575
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"149.4,7677.0 201.4,6580.5 -0.0,6576.3 13.1,-0.0 6575.0,0.0 6575.0,4086.2 6435.7,4572.2 6575.0,4609.0 6575.0,5190.2 5935.9,7594.5 5586.4,7490.0 5535.3,7677.0 149.4,7677.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0047/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19362080402826,
-                25.770426669644856
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6575.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19025744032054,
-                25.770586619172754
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6575.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19005146371417,
-                25.767024259804156
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19341482742189,
-                25.766864310276258
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0048/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p48",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0048/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0048/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6563
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"659.6,6940.7 930.7,6985.5 1225.9,4692.8 1010.6,4664.4 1067.4,4285.5 670.8,1212.8 -0.0,1299.8 -0.0,0.0 471.5,83.6 6563.0,0.0 6563.0,7677.0 551.9,7677.0 659.6,6940.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0048/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19064967501264,
-                25.77135903206205
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6563.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18619687325999,
-                25.771052525738668
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6563.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18659514517368,
-                25.76636138553315
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19104794692633,
-                25.76666789185653
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0049/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p49",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0049/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0049/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6561
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"229.6,7103.1 -0.0,7531.8 -0.0,-0.0 994.9,0.0 992.4,323.1 6013.3,345.9 6015.7,3102.5 6561.0,3102.7 6561.0,7677.0 3220.6,7677.0 3223.9,7154.9 229.6,7103.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0049/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19823422131988,
-                25.78829741354651
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6561.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19485094982736,
-                25.78841193969078
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6561.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19470213214292,
-                25.784847656178755
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19808540363545,
-                25.784733130034486
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0005/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p5",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0005/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0005/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6519
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1844.1,723.6 4272.8,726.8 3987.1,3674.0 3534.4,4168.8 6253.5,4333.9 6519.0,4414.2 6519.0,4910.6 3137.0,4944.4 3157.4,6249.8 1752.2,6233.0 1766.9,2454.8 920.2,1263.1 1844.1,723.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0005/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20226338029403,
-                25.776154857328976
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6519.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19893491219459,
-                25.776257907936582
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6519.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1988010615267,
-                25.772702399923457
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20212952962613,
-                25.77259934931585
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0050/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p50",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0050/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0050/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6638
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4178.7,7145.2 2687.1,7146.5 2687.9,7677.0 1350.1,7677.0 1343.4,3148.2 799.9,3148.8 793.4,401.5 5483.4,401.6 5462.4,7677.0 4176.3,7677.0 4178.7,7145.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0050/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1955446952338,
-                25.78841550980777
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6638.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19211043944235,
-                25.78852723047162
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6638.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19196692922152,
-                25.784950636867453
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19540118501298,
-                25.784838916203604
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0051/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p51",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0051/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0051/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6561
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6548.7,7677.0 -0.0,7603.3 -0.0,377.4 3151.0,374.0 3936.5,531.0 3924.7,1169.4 6561.0,1163.9 6548.7,7677.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0051/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19270685326029,
-                25.78849874423411
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6561.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18928733051976,
-                25.78860109912595
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6561.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18915432782435,
-                25.784998640904927
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19257385056488,
-                25.78489628601309
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0052/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p52",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0052/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0052/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6534
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4168.4,0.0 3597.2,1351.8 6534.0,1510.6 6534.0,7677.0 762.7,7677.0 1018.6,1266.6 1249.3,1275.0 1363.4,0.0 4168.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0052/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18984032844818,
-                25.788614277559624
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6534.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.186464217417,
-                25.788833404186388
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6534.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18618026446889,
-                25.78523621031214
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18955637550008,
-                25.785017083685375
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0053/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p53",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0053/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0053/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6525
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5951.8,0.0 5897.3,6484.3 6467.6,7358.1 -0.0,7391.1 -0.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0053/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19783194722918,
-                25.791633168966296
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6525.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19443110643363,
-                25.791725189493462
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6525.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1943108762845,
-                25.788122558496138
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19771171708005,
-                25.78803053796897
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0054/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p54",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0054/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0054/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6534
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"253.7,6578.3 307.4,185.7 6456.8,123.4 6417.4,7447.6 833.1,7466.8 253.7,6578.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0054/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19488946772137,
-                25.79170638155375
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6534.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1915399469897,
-                25.791798250835594
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6534.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1914200545385,
-                25.788254529974857
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19476957527016,
-                25.788162660693015
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0055/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p55",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0055/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0055/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6528
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5734.7,590.8 5648.4,5477.1 6528.0,5488.6 6528.0,6328.4 5098.4,6380.5 5029.9,7677.0 2103.4,7677.0 2116.4,7029.9 481.1,6869.3 551.3,0.0 5571.2,0.0 5528.4,589.3 5734.7,590.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0055/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19185187154811,
-                25.791530835009738
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6528.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18852056749276,
-                25.791636753384175
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6528.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18838314271079,
-                25.788083037754667
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19171444676614,
-                25.78797711938023
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0056/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p56",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0056/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0056/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6516
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1780.6,7278.1 2227.9,6325.1 863.6,6398.9 849.3,5588.2 -0.0,5592.0 -0.0,-0.0 6516.0,0.0 6516.0,7677.0 1740.7,7677.0 1780.6,7278.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0056/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18892287713363,
-                25.791769504048663
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6516.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18547722225952,
-                25.791823892582418
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6516.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18540652615692,
-                25.788141382516024
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18885218103104,
-                25.78808699398227
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0057/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p57",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0057/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0057/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6581
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7032.8 -0.0,904.4 6502.6,861.4 6501.1,635.3 6581.0,634.1 6581.0,7109.4 219.9,7230.1 222.6,7030.9 -0.0,7032.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0057/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19492203771992,
-                25.794965392812127
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6581.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1915426321892,
-                25.79503104737472
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6581.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1914575735574,
-                25.791481854296777
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19483697908812,
-                25.791416199734183
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0058/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p58",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0058/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0058/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6468
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1179.8,286.4 6072.8,198.9 6468.0,211.6 6468.0,6783.6 6075.5,6779.6 6066.2,7677.0 5861.7,7677.0 5899.8,7092.3 922.1,7128.8 920.3,6699.5 1141.4,6697.0 1179.8,286.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0058/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19214696644865,
-                25.794856379123075
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6468.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18881760662192,
-                25.79494006391742
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6468.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18870801877843,
-                25.79135557431619
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19203737860515,
-                25.791271889521845
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0059/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p59",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0059/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0059/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6552
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,67.6 345.2,67.2 339.2,1039.2 5709.3,1084.7 5723.9,4459.3 6552.0,4457.3 6552.0,7453.9 6552.0,7454.0 6552.0,7677.0 -0.0,7677.0 -0.0,67.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0059/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19509478124543,
-                25.79814295113094
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6552.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19168599091978,
-                25.798229490973632
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6552.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1915733247768,
-                25.794632017289416
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19498211510245,
-                25.794545477446725
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0006/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p6",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0006/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0006/info.json",
-          "type": "ImageService2",
-          "height": 7678,
-          "width": 6544
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5026.3 3415.7,5045.6 3513.4,4577.7 3156.7,4459.1 413.6,4249.4 878.5,3757.0 1213.6,785.4 12.1,769.2 19.5,-0.0 4632.4,0.0 4612.2,818.3 5714.2,838.0 5639.3,6851.4 1023.2,6808.2 769.3,6366.1 -0.0,6344.8 -0.0,5026.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0006/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20070200017817,
-                25.77621807177399
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6544.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19739575880932,
-                25.77636740530224
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6544.0,
-                7678.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19720250320879,
-                25.77284859664402
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7678.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.20050874457763,
-                25.772699263115772
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0060/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p60",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0060/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0060/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6444
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4391.0 -0.0,959.9 680.2,968.6 692.9,0.0 861.1,0.0 855.7,1249.4 2441.1,1260.8 2448.0,231.9 5984.6,254.1 5965.7,1134.9 6444.0,1134.3 6444.0,2407.2 5938.5,2404.9 5832.0,7373.1 828.8,7439.4 842.0,4394.1 -0.0,4391.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0060/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19212450188284,
-                25.798152375022056
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6444.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.1888279014265,
-                25.798248966151913
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6444.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18870005443019,
-                25.794711238402513
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.19199665488652,
-                25.794614647272656
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0061/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p61",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0061/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0061/info.json",
-          "type": "ImageService2",
-          "height": 7677,
-          "width": 6608
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2935.7,7485.6 444.3,7437.3 459.5,2476.4 967.7,2469.8 945.3,1199.1 6504.1,1093.3 6483.2,0.0 6608.0,0.0 6608.0,7677.0 5635.7,7677.0 5625.8,7173.8 3271.4,7220.4 2935.7,7485.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0061/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18930275952513,
-                25.798273524217006
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6608.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.185915132998,
-                25.798318955536534
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6608.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18585649297512,
-                25.79477376879727
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7677.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -80.18924411950225,
-                25.794728337477743
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0062__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p62 [2]",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p326 [2]",
       "metadata": [
         {
           "label": "streets",
@@ -7623,15 +3207,15 @@
         },
         {
           "label": "split_canvas_w",
-          "value": "6437.0"
+          "value": "6742.0"
         },
         {
           "label": "split_canvas_h",
-          "value": "7677.0"
+          "value": "8038.0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7640,21 +3224,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0062__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0326__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0062/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0326/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6437
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3528.4,0.0 6437.0,0.0 6437.0,7677.0 513.1,7677.0 566.4,216.5 3132.3,317.1 3528.4,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7632.5 -0.0,1336.6 1156.5,0.0 4353.5,0.0 5395.3,2233.2 6505.6,5772.5 5916.1,5777.3 5830.1,7670.1 -0.0,7632.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0062__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0326__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7679,8 +3263,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18905447602448,
-                25.794915369209175
+                -77.4411323390127,
+                37.550838179147796
               ]
             }
           },
@@ -7688,7 +3272,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6437.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -7700,8 +3284,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1863638790185,
-                25.794999371899795
+                -77.43879381815218,
+                37.55329343737235
               ]
             }
           },
@@ -7709,8 +3293,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6437.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7721,8 +3305,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18625261684154,
-                25.792110388784394
+                -77.43510184922205,
+                37.55108310614422
               ]
             }
           },
@@ -7731,7 +3315,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7742,8 +3326,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18894321384752,
-                25.792026386093774
+                -77.43744037008257,
+                37.54862784791966
               ]
             }
           }
@@ -7751,13 +3335,167 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0063/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0326__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p63",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p326 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "5359.2"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1382.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2607.8"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0326__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0326/info.json",
+          "type": "ImageService2",
+          "height": 8038,
+          "width": 6742
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5916.4,416.0 6126.4,1035.7 6516.1,2187.8 5359.2,2240.5 5359.2,445.8 5916.4,416.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0326__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5359.2,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43663523902794,
+                37.551541081079094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6742.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43609855830906,
+                37.552054333637955
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6742.0,
+                2607.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43487865616079,
+                37.55125253536979
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5359.2,
+                2607.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43541533687967,
+                37.55073928281093
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0328/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p328",
       "metadata": [
         {
           "label": "streets",
@@ -7768,8 +3506,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7778,21 +3516,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0063/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0328/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0063/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0328/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6566
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,738.0 324.1,731.4 309.1,0.0 6566.0,0.0 6566.0,7678.0 380.9,7678.0 378.4,6689.1 24.9,6692.5 -0.0,738.0\" /></svg>"
+          "value": "<svg><polygon points=\"5870.0,6724.6 0.0,6676.9 0.0,0.0 6742.0,0.0 6742.0,878.3 6380.5,870.1 5870.0,6724.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0063/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0328/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7817,8 +3555,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19517294882057,
-                25.801194029683245
+                -77.43826627578252,
+                37.55918538385815
               ]
             }
           },
@@ -7826,7 +3564,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6566.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -7838,8 +3576,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19183673328804,
-                25.80125321008345
+                -77.43817015228531,
+                37.56226409970515
               ]
             }
           },
@@ -7847,8 +3585,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6566.0,
-                7678.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7859,8 +3597,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1917604105263,
-                25.797716218123426
+                -77.4335401177392,
+                37.56217325661203
               ]
             }
           },
@@ -7869,7 +3607,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7880,8 +3618,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19509662605883,
-                25.797657037723223
+                -77.43363624123641,
+                37.559094540765024
               ]
             }
           }
@@ -7889,13 +3627,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0064/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0329/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p64",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p329",
       "metadata": [
         {
           "label": "streets",
@@ -7906,8 +3644,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7916,21 +3654,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0064/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0329/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0064/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0329/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6388
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2375.3,7677.0 802.8,7677.0 798.9,6299.4 633.3,6299.9 670.8,0.0 5853.7,0.0 5872.0,583.8 5459.8,594.2 5511.7,6653.6 2374.8,6656.4 2375.3,7677.0\" /></svg>"
+          "value": "<svg><polygon points=\"6735.5,6473.6 4868.5,6541.4 4876.3,8038.0 607.1,8038.0 1067.6,0.0 5644.4,0.0 5618.1,3100.4 6691.6,3042.2 6735.5,6473.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0064/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0329/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7955,8 +3693,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1921806712865,
-                25.801147113847474
+                -77.43541206722512,
+                37.55655097406376
               ]
             }
           },
@@ -7964,7 +3702,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6388.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -7976,8 +3714,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18888514761814,
-                25.80122243523182
+                -77.43511504713021,
+                37.559624953565965
               ]
             }
           },
@@ -7985,8 +3723,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6388.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7997,8 +3735,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18878456670527,
-                25.79765529830236
+                -77.43052458537001,
+                37.55934226554851
               ]
             }
           },
@@ -8007,7 +3745,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8018,8 +3756,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19208009037362,
-                25.797579976918012
+                -77.43082160546491,
+                37.556268286046304
               ]
             }
           }
@@ -8027,13 +3765,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0065/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0330/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p65",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p330",
       "metadata": [
         {
           "label": "streets",
@@ -8044,8 +3782,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8054,21 +3792,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0065/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0330/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0065/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0330/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6552
+          "height": 8038,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5826.0,0.0 5820.7,331.8 6552.0,410.9 6552.0,6459.0 402.1,6387.2 408.2,7112.6 88.9,7115.7 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,1323.6 6742.0,1057.3 6742.0,6345.2 1099.7,6466.4 1074.0,3058.1 0.0,3111.4 0.0,1323.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0065/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0330/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8093,8 +3831,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19532666118988,
-                25.80415778421271
+                -77.43518368721688,
+                37.5591060828838
               ]
             }
           },
@@ -8102,7 +3840,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6552.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -8114,8 +3852,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19194759388273,
-                25.804253239746046
+                -77.43490319328332,
+                37.56218056453437
               ]
             }
           },
@@ -8123,8 +3861,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6552.0,
-                7677.0
+                6742.0,
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8135,8 +3873,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19182331362795,
-                25.80068732891802
+                -77.43027952648167,
+                37.56191547912587
               ]
             }
           },
@@ -8145,7 +3883,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8038.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8156,8 +3894,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1952023809351,
-                25.800591873384683
+                -77.43056002041523,
+                37.5588409974753
               ]
             }
           }
@@ -8165,13 +3903,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0066/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0331/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p66",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p331",
       "metadata": [
         {
           "label": "streets",
@@ -8182,8 +3920,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8192,21 +3930,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0066/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0331/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0066/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0331/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6408
+          "height": 8003,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"752.0,6770.3 714.8,521.1 2424.0,515.7 2427.8,222.3 5732.2,209.0 5928.0,6778.5 752.0,6770.3\" /></svg>"
+          "value": "<svg><polygon points=\"5506.4,7315.1 6699.1,7301.8 6695.2,8003.0 -0.0,8003.0 -0.0,0.0 1267.8,-0.0 1537.1,652.4 5498.9,662.6 5506.4,7315.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0066/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0331/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8231,8 +3969,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19231741586883,
-                25.804295864175476
+                -77.42643657877191,
+                37.56035228439158
               ]
             }
           },
@@ -8240,7 +3978,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6408.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -8252,8 +3990,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18900729968722,
-                25.80437624391937
+                -77.42312240705562,
+                37.55873470658415
               ]
             }
           },
@@ -8261,8 +3999,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6408.0,
-                7677.0
+                6742.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8273,8 +4011,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18890031221426,
-                25.800804055487454
+                -77.42554416557083,
+                37.555616618440844
               ]
             }
           },
@@ -8283,7 +4021,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8294,8 +4032,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19221042839587,
-                25.80072367574356
+                -77.42885833728712,
+                37.557234196248274
               ]
             }
           }
@@ -8303,13 +4041,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0067/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0332/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p67",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p332",
       "metadata": [
         {
           "label": "streets",
@@ -8320,8 +4058,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8330,21 +4068,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0067/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0332/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0067/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0332/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6570
+          "height": 8003,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3889.0,228.5 3886.7,724.1 6181.1,734.2 6184.3,0.0 6570.0,0.0 6570.0,7677.0 6246.5,7677.0 6239.9,6616.8 381.5,6653.6 194.6,232.0 3889.0,228.5\" /></svg>"
+          "value": "<svg><polygon points=\"2881.5,668.9 2897.1,0.0 6742.0,0.0 6742.0,8003.0 1850.5,8003.0 1860.6,7347.2 655.0,7348.7 713.9,624.8 2881.5,668.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0067/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0332/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8369,8 +4107,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18945885706192,
-                25.80437745946116
+                -77.4240992356576,
+                37.559183840716834
               ]
             }
           },
@@ -8378,7 +4116,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6570.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -8390,8 +4128,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18601580282036,
-                25.804463208983346
+                -77.42080051605059,
+                37.557609266925915
               ]
             }
           },
@@ -8399,8 +4137,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6570.0,
-                7677.0
+                6742.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8411,8 +4149,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18590451619617,
-                25.800840279047048
+                -77.42315792432531,
+                37.55450576046974
               ]
             }
           },
@@ -8421,7 +4159,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8432,8 +4170,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18934757043773,
-                25.800754529524863
+                -77.42645664393231,
+                37.556080334260656
               ]
             }
           }
@@ -8441,13 +4179,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0068/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0333/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p68",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p333",
       "metadata": [
         {
           "label": "streets",
@@ -8458,8 +4196,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8468,21 +4206,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0068/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0333/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0068/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0333/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6428
+          "height": 8003,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"417.4,648.5 402.6,0.0 6428.0,0.0 6428.0,7677.0 355.4,7677.0 375.6,6792.5 -0.0,6789.6 -0.0,655.5 417.4,648.5\" /></svg>"
+          "value": "<svg><polygon points=\"6297.8,6706.5 360.1,6414.6 340.9,3152.7 786.7,2287.7 6160.6,2164.3 6297.8,6706.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0068/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0333/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8507,8 +4245,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18936755175459,
-                25.8012361853359
+                -77.43765302606238,
+                37.56500965676314
               ]
             }
           },
@@ -8516,7 +4254,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6428.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -8528,8 +4266,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1860928984546,
-                25.801336290733197
+                -77.43382051603704,
+                37.56482019101706
               ]
             }
           },
@@ -8537,8 +4275,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6428.0,
-                7677.0
+                6742.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8549,8 +4287,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18596007020791,
-                25.79781336827859
+                -77.43410220327202,
+                37.56118919415309
               ]
             }
           },
@@ -8559,7 +4297,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8570,8 +4308,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1892347235079,
-                25.79771326288129
+                -77.43793471329735,
+                37.56137865989916
               ]
             }
           }
@@ -8579,13 +4317,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0069/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0334/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p69",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p334",
       "metadata": [
         {
           "label": "streets",
@@ -8596,8 +4334,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8606,21 +4344,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0069/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0334/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0069/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0334/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6550
+          "height": 8003,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2448.8,7129.8 2448.4,7422.4 -0.0,7379.7 -0.0,897.8 855.1,880.2 836.6,0.0 5650.5,0.0 5568.6,1162.1 5763.6,7079.3 2448.8,7129.8\" /></svg>"
+          "value": "<svg><polygon points=\"208.8,1764.2 1996.8,1818.0 1986.8,1517.2 6067.8,1600.1 6055.8,3316.2 5587.3,3296.8 5642.8,6138.9 304.2,6040.3 208.8,1764.2\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0069/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0334/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8645,8 +4383,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19237833277067,
-                25.807534024379805
+                -77.43428319315416,
+                37.56488329046725
               ]
             }
           },
@@ -8654,7 +4392,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6550.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -8666,8 +4404,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18900506966096,
-                25.807581487093426
+                -77.43043802991646,
+                37.56471934853217
               ]
             }
           },
@@ -8675,8 +4413,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6550.0,
-                7678.0
+                6742.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8687,8 +4425,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18894370604032,
-                25.80399667440767
+                -77.43068349753267,
+                37.56110200570608
               ]
             }
           },
@@ -8697,7 +4435,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8708,8 +4446,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19231696915003,
-                25.80394921169405
+                -77.43452866077037,
+                37.56126594764116
               ]
             }
           }
@@ -8717,13 +4455,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0007/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0335/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p7",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p335",
       "metadata": [
         {
           "label": "streets",
@@ -8734,8 +4472,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8744,21 +4482,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0007/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0335/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0007/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0335/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6501
+          "height": 8003,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1199.8,1456.9 3957.3,1474.9 3981.4,7678.0 1246.2,7678.0 1199.8,1456.9\" /></svg>"
+          "value": "<svg><polygon points=\"4130.9,7402.0 5910.6,7507.2 5914.2,8003.0 561.6,8003.0 1088.4,7035.9 1453.9,560.8 5619.2,1270.3 4229.9,5261.5 4130.9,7402.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0007/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0335/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8783,8 +4521,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19841809229413,
-                25.776331526633957
+                -77.43742929379123,
+                37.56761010164661
               ]
             }
           },
@@ -8792,7 +4530,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6501.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -8804,8 +4542,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19511220112605,
-                25.776425411534245
+                -77.43357604890784,
+                37.56749038417585
               ]
             }
           },
@@ -8813,8 +4551,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6501.0,
-                7678.0
+                6742.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8825,8 +4563,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19498908242316,
-                25.772910441352703
+                -77.43375404449907,
+                37.56383987087865
               ]
             }
           },
@@ -8835,7 +4573,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8846,8 +4584,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19829497359125,
-                25.772816556452415
+                -77.43760728938246,
+                37.56395958834941
               ]
             }
           }
@@ -8855,13 +4593,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0070/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0336/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p70",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p336",
       "metadata": [
         {
           "label": "streets",
@@ -8872,8 +4610,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8882,21 +4620,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0070/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0336/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0070/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0336/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6404
+          "height": 8003,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"268.8,0.0 546.5,0.0 561.5,650.1 6404.0,511.5 6404.0,7678.0 4075.5,7678.0 4075.7,7175.0 326.6,7195.2 178.7,1254.4 268.8,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5911.1,7469.5 3721.2,7365.7 3725.9,7667.7 145.2,7469.6 250.4,5303.9 1657.1,1269.5 3703.4,1573.8 3706.5,712.3 5744.7,771.2 5911.1,7469.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0070/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0336/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8921,8 +4659,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18960857086113,
-                25.807613238025475
+                -77.4351626893209,
+                37.56753006563073
               ]
             }
           },
@@ -8930,7 +4668,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6404.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -8942,8 +4680,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18630118449393,
-                25.80768245936802
+                -77.4313274096623,
+                37.56742066370624
               ]
             }
           },
@@ -8951,8 +4689,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6404.0,
-                7678.0
+                6742.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8963,8 +4701,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18620897446507,
-                25.804111650655383
+                -77.43149122828514,
+                37.563812902661894
               ]
             }
           },
@@ -8973,7 +4711,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8984,8 +4722,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18951636083227,
-                25.804042429312837
+                -77.43532650794374,
+                37.563922304586384
               ]
             }
           }
@@ -8993,13 +4731,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0071/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0337/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p71",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p337",
       "metadata": [
         {
           "label": "streets",
@@ -9010,8 +4748,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9020,21 +4758,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0071/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0337/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0071/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0337/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6550
+          "height": 8003,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5475.3 -0.0,1830.0 243.6,608.2 401.5,602.3 378.8,0.0 5774.7,0.0 5627.0,472.4 5843.7,461.3 5815.7,2806.1 6044.4,6931.1 878.9,7148.2 801.8,5450.0 -0.0,5475.3\" /></svg>"
+          "value": "<svg><polygon points=\"5400.8,8003.0 2070.5,8003.0 2096.7,7401.1 198.0,7315.2 154.8,672.4 1833.6,736.7 1775.0,1674.4 5660.3,1917.4 4971.2,3045.1 4744.7,3676.2 4778.8,3952.5 4945.1,3117.9 5896.5,1530.8 6239.3,1460.8 6696.1,1011.3 4510.0,866.3 4875.0,691.4 5366.7,0.0 6742.0,0.0 6742.0,6993.2 5238.2,7092.4 5400.8,8003.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0071/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0337/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9059,8 +4797,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19236157929465,
-                25.810830770080113
+                -77.4319919655108,
+                37.56739636255883
               ]
             }
           },
@@ -9068,7 +4806,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6550.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -9080,8 +4818,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18903909244297,
-                25.810804402840247
+                -77.42814901472777,
+                37.56734199945607
               ]
             }
           },
@@ -9089,8 +4827,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6550.0,
-                7678.0
+                6742.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9101,8 +4839,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18907318307785,
-                25.80727364839792
+                -77.4282298414607,
+                37.56370123091044
               ]
             }
           },
@@ -9111,7 +4849,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9122,8 +4860,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19239566992954,
-                25.807300015637786
+                -77.43207279224374,
+                37.5637555940132
               ]
             }
           }
@@ -9131,13 +4869,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0072/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0338/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p72",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p338",
       "metadata": [
         {
           "label": "streets",
@@ -9148,8 +4886,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9158,21 +4896,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0072/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0338/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0072/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0338/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6449
+          "height": 8003,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7677.0 -0.0,2002.1 157.7,551.0 -0.0,550.2 114.3,86.7 -0.0,-0.0 6449.0,0.0 6449.0,7677.0 -0.0,7677.0\" /></svg>"
+          "value": "<svg><polygon points=\"784.4,2470.1 1248.6,2491.2 1261.9,1391.3 4543.3,1290.2 4365.8,388.3 5849.5,243.7 5842.0,0.0 6742.0,0.0 6742.0,8003.0 2619.9,8003.0 2607.2,7171.1 862.0,7131.8 784.4,2470.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0072/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0338/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9197,8 +4935,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1894923558363,
-                25.810844907438984
+                -77.43158004491231,
+                37.564401702701154
               ]
             }
           },
@@ -9206,7 +4944,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6449.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -9218,8 +4956,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18622319418783,
-                25.8109832068881
+                -77.42769908020735,
+                37.56425196349841
               ]
             }
           },
@@ -9227,8 +4965,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6449.0,
-                7677.0
+                6742.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9239,8 +4977,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18604161297915,
-                25.807455279274368
+                -77.4279232624307,
+                37.56060061677681
               ]
             }
           },
@@ -9249,7 +4987,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9260,8 +4998,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18931077462761,
-                25.807316979825252
+                -77.43180422713566,
+                37.56075035597956
               ]
             }
           }
@@ -9269,13 +5007,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0073/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0339/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p73",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p339",
       "metadata": [
         {
           "label": "streets",
@@ -9286,8 +5024,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9296,21 +5034,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0073/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0339/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0073/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0339/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6552
+          "height": 8003,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 6384.4,0.0 6380.0,511.8 6229.2,510.7 5943.8,1675.3 5786.1,5173.5 6552.0,5183.8 6552.0,7677.0 -0.0,7677.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"683.2,226.5 6742.0,212.6 6742.0,3543.6 5431.3,3547.0 5427.0,7090.4 4858.6,7026.0 694.7,6411.6 683.2,226.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0073/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0339/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9335,8 +5073,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.195557658534,
-                25.81068603174872
+                -77.43677888236243,
+                37.57026084000706
               ]
             }
           },
@@ -9344,7 +5082,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6552.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -9356,8 +5094,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19207916822442,
-                25.81079989810135
+                -77.43291423900982,
+                37.570069012839426
               ]
             }
           },
@@ -9365,8 +5103,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6552.0,
-                7677.0
+                6742.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9377,8 +5115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19193090966274,
-                25.807129264064272
+                -77.43320147182826,
+                37.56643350979424
               ]
             }
           },
@@ -9387,7 +5125,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9398,8 +5136,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19540939997232,
-                25.80701539771164
+                -77.43706611518087,
+                37.56662533696187
               ]
             }
           }
@@ -9407,13 +5145,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0075/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0340/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p75",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p340",
       "metadata": [
         {
           "label": "streets",
@@ -9424,8 +5162,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9434,21 +5172,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0075/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0340/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0075/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0340/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6548
+          "height": 8003,
+          "width": 6742
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7677.0 28.6,288.8 6548.0,164.6 6548.0,2234.7 4904.3,2271.1 5021.1,7292.6 851.5,7367.3 852.0,7677.0 -0.0,7677.0\" /></svg>"
+          "value": "<svg><polygon points=\"1466.5,7286.1 -0.0,7107.2 -0.0,3590.0 1310.2,3583.8 1306.2,277.4 1409.3,276.9 1407.6,0.0 6742.0,0.0 6742.0,6419.8 1445.9,6438.9 1466.5,7286.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0075/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0340/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9473,8 +5211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20628435343379,
-                25.77002385779129
+                -77.43366059383072,
+                37.57013779191139
               ]
             }
           },
@@ -9482,7 +5220,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6548.0,
+                6742.0,
                 0.0
               ],
               "creator": {
@@ -9494,8 +5232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.2029413668073,
-                25.770065430793892
+                -77.42979488743272,
+                37.56993945046277
               ]
             }
           },
@@ -9503,8 +5241,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6548.0,
-                7677.0
+                6742.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9515,8 +5253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20288760204375,
-                25.766509499262604
+                -77.43008979090817,
+                37.566277255230524
               ]
             }
           },
@@ -9525,7 +5263,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9536,8 +5274,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20623058867024,
-                25.766467926260002
+                -77.43395549730617,
+                37.56647559667915
               ]
             }
           }
@@ -9545,13 +5283,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0076/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0341/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p76",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p341",
       "metadata": [
         {
           "label": "streets",
@@ -9562,8 +5300,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9572,21 +5310,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0076/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0341/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0076/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0341/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6492
+          "height": 8003,
+          "width": 6766
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5621.4,0.0 5579.0,7677.0 -0.0,7677.0 -0.0,192.3 1629.7,194.1 1634.2,0.0 5621.4,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7710.8 -0.0,569.5 6766.0,570.9 6766.0,7233.1 4798.6,7239.1 4798.4,8003.0 2011.3,8003.0 1769.3,7818.5 -0.0,7710.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0076/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0341/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9611,8 +5349,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20376828732275,
-                25.769092858081557
+                -77.44247512085076,
+                37.57222419983811
               ]
             }
           },
@@ -9620,7 +5358,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6492.0,
+                6766.0,
                 0.0
               ],
               "creator": {
@@ -9632,8 +5370,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20042655733666,
-                25.769204908136395
+                -77.43860420823378,
+                37.572030812776504
               ]
             }
           },
@@ -9641,8 +5379,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6492.0,
-                7677.0
+                6766.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9653,8 +5391,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20028039833477,
-                25.765619626486775
+                -77.43889275823379,
+                37.568402429443175
               ]
             }
           },
@@ -9663,7 +5401,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9674,8 +5412,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20362212832086,
-                25.765507576431936
+                -77.44276367085077,
+                37.56859581650478
               ]
             }
           }
@@ -9683,13 +5421,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0077/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0342/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p77",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p342",
       "metadata": [
         {
           "label": "streets",
@@ -9700,8 +5438,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9710,21 +5448,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0077/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0342/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0077/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0342/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6548
+          "height": 8003,
+          "width": 6766
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,297.5 658.2,309.4 663.4,0.0 4800.2,0.0 4812.4,2525.8 6548.0,2516.5 6548.0,7677.0 -0.0,7677.0 -0.0,297.5\" /></svg>"
+          "value": "<svg><polygon points=\"1555.6,7256.9 1502.4,589.4 5608.1,588.6 5625.0,7270.0 1555.6,7256.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0077/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0342/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9749,8 +5487,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20613926932717,
-                25.766607003953318
+                -77.43946222915903,
+                37.57208194904889
               ]
             }
           },
@@ -9758,7 +5496,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6548.0,
+                6766.0,
                 0.0
               ],
               "creator": {
@@ -9770,8 +5508,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20277070651927,
-                25.766703665139467
+                -77.43559491942452,
+                37.57188812604003
               ]
             }
           },
@@ -9779,8 +5517,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6548.0,
-                7677.0
+                6766.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9791,8 +5529,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20264479882698,
-                25.763146126677928
+                -77.43588411901048,
+                37.56826310876551
               ]
             }
           },
@@ -9801,7 +5539,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9812,8 +5550,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20601336163487,
-                25.76304946549178
+                -77.439751428745,
+                37.56845693177437
               ]
             }
           }
@@ -9821,13 +5559,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0078/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0343/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p78",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p343",
       "metadata": [
         {
           "label": "streets",
@@ -9838,8 +5576,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9848,21 +5586,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0078/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0343/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0078/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0343/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6514
+          "height": 8003,
+          "width": 6766
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3656.7,7677.0 3412.0,7505.5 1641.1,7677.0 1588.4,7521.1 1791.1,7662.5 1799.4,2556.1 5620.0,2541.8 5633.1,7677.0 3656.7,7677.0\" /></svg>"
+          "value": "<svg><polygon points=\"6766.0,7264.0 617.5,7248.3 637.8,620.9 6766.0,653.2 6766.0,7264.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0078/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0343/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9887,8 +5625,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20370598834688,
-                25.766702093522607
+                -77.43650969927108,
+                37.57345543458612
               ]
             }
           },
@@ -9896,7 +5634,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6514.0,
+                6766.0,
                 0.0
               ],
               "creator": {
@@ -9908,8 +5646,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.2003313189555,
-                25.76680387893287
+                -77.43262168539826,
+                37.573277432274
               ]
             }
           },
@@ -9917,8 +5655,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6514.0,
-                7677.0
+                6766.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9929,8 +5667,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20019810965316,
-                25.76322173939798
+                -77.43288728512643,
+                37.56963308895782
               ]
             }
           },
@@ -9939,7 +5677,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9950,8 +5688,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20357277904453,
-                25.76311995398772
+                -77.43677529899925,
+                37.56981109126995
               ]
             }
           }
@@ -9959,13 +5697,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0079/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0344/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p79",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p344",
       "metadata": [
         {
           "label": "streets",
@@ -9976,8 +5714,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9986,21 +5724,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0079/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0344/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0079/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0344/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6548
+          "height": 8003,
+          "width": 6766
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"448.9,7677.0 578.2,166.6 6548.0,379.3 6548.0,7279.4 3617.1,7182.8 3608.5,7677.0 448.9,7677.0\" /></svg>"
+          "value": "<svg><polygon points=\"1684.1,6970.5 1673.8,622.6 5758.3,643.9 5756.1,1283.0 6766.0,1225.9 6766.0,7000.0 1684.1,6970.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0079/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0344/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -10025,8 +5763,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.201115393279,
-                25.76727214682787
+                -77.43358153858267,
+                37.573307462617436
               ]
             }
           },
@@ -10034,7 +5772,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6548.0,
+                6766.0,
                 0.0
               ],
               "creator": {
@@ -10046,8 +5784,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1976628502238,
-                25.767433413054555
+                -77.42970430964226,
+                37.57312641377767
               ]
             }
           },
@@ -10055,8 +5793,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6548.0,
-                7677.0
+                6766.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10067,8 +5805,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19745282650838,
-                25.763786551394464
+                -77.4299743915512,
+                37.56949132386802
               ]
             }
           },
@@ -10077,7 +5815,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10088,8 +5826,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20090536956359,
-                25.76362528516778
+                -77.43385162049161,
+                37.569672372707785
               ]
             }
           }
@@ -10097,13 +5835,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0008/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0345/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p8",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p345",
       "metadata": [
         {
           "label": "streets",
@@ -10114,8 +5852,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10124,21 +5862,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0008/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0345/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0008/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0345/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6556
+          "height": 8003,
+          "width": 6766
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"40.1,7677.0 -0.0,1415.8 2189.0,1438.6 2192.4,1485.9 5312.7,1585.6 5297.7,7677.0 40.1,7677.0\" /></svg>"
+          "value": "<svg><polygon points=\"1191.1,6777.4 1181.2,928.8 5641.4,667.5 5641.4,667.5 6145.5,628.4 6191.6,0.0 6766.0,0.0 6766.0,8003.0 1446.5,8003.0 1450.4,6778.3 1191.1,6777.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0008/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0345/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -10163,8 +5901,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19640778121402,
-                25.776366453815296
+                -77.43037747461689,
+                37.573018343596026
               ]
             }
           },
@@ -10172,7 +5910,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6556.0,
+                6766.0,
                 0.0
               ],
               "creator": {
@@ -10184,8 +5922,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19305089158743,
-                25.776473566885848
+                -77.42657609583213,
+                37.57283320946963
               ]
             }
           },
@@ -10193,8 +5931,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6556.0,
-                7677.0
+                6766.0,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10205,8 +5943,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19291153986572,
-                25.77293268253377
+                -77.4268503966271,
+                37.56924486587534
               ]
             }
           },
@@ -10215,7 +5953,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10226,8 +5964,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1962684294923,
-                25.77282556946322
+                -77.43065177541186,
+                37.56943000000174
               ]
             }
           }
@@ -10235,13 +5973,3049 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0081__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0346/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p81 [2]",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p346",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0346/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0346/info.json",
+          "type": "ImageService2",
+          "height": 8003,
+          "width": 6766
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1531.6,1794.2 6766.0,0.0 6766.0,7040.9 4852.3,7037.5 4426.1,7512.9 4089.5,7603.9 3878.7,8003.0 -0.0,8003.0 -0.0,7066.9 1615.4,7035.2 1531.6,1794.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0346/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43063041525942,
+                37.5702631628231
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42677145672376,
+                37.570015636913155
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42713818529177,
+                37.56637280195941
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43099714382743,
+                37.56662032786936
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0347/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p347",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0347/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0347/info.json",
+          "type": "ImageService2",
+          "height": 8003,
+          "width": 6766
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"274.0,7608.4 281.3,1245.9 6766.0,1161.5 6766.0,7606.7 274.0,7608.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0347/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44063635738377,
+                37.57174398078629
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44039687238596,
+                37.574809527925055
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43582268073565,
+                37.57458505425119
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43606216573346,
+                37.57151950711242
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0349/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p349",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0349/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0349/info.json",
+          "type": "ImageService2",
+          "height": 8003,
+          "width": 6766
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"279.9,6939.1 279.9,723.9 3451.6,723.9 3450.8,0.0 6766.0,0.0 6766.0,6562.1 4683.6,6907.4 279.9,6939.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0349/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43658860919489,
+                37.57304952185897
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43634407819363,
+                37.57612196289538
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4317595476917,
+                37.57589276212317
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43200407869296,
+                37.57282032108676
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0350/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p350",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0350/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0350/info.json",
+          "type": "ImageService2",
+          "height": 8003,
+          "width": 6766
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1256.5,6523.0 1386.2,0.0 6766.0,0.0 6766.0,3400.2 5375.0,3788.9 5274.1,3959.4 6766.0,3650.5 6766.0,5751.3 1256.5,6523.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0350/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4363114526228,
+                37.57549590787333
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43614615474388,
+                37.57853533913868
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43161180313592,
+                37.57838037262113
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43177710101484,
+                37.57534094135578
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0351/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p351",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0351/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0351/info.json",
+          "type": "ImageService2",
+          "height": 8003,
+          "width": 6766
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4820.2,3377.9 6666.1,1195.5 6766.0,1277.3 6766.0,8003.0 899.2,8003.0 492.7,1311.1 -0.0,1271.7 -0.0,-0.0 476.3,0.0 313.3,191.8 1165.4,916.2 1409.4,619.8 3986.4,2670.7 4626.8,3303.8 4666.1,3892.1 5358.9,4481.0 5684.4,4111.6 4820.2,3377.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0351/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43320090248709,
+                37.57902116052469
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42928441304687,
+                37.579137022611164
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42911273385319,
+                37.5754403235261
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4330292232934,
+                37.57532446143963
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0352/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p352",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0352/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0352/info.json",
+          "type": "ImageService2",
+          "height": 8003,
+          "width": 6766
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6509.4,8003.0 4499.5,8003.0 4552.6,7372.5 564.7,7038.0 896.6,2690.4 831.9,1902.7 6732.2,1802.1 6766.0,4903.7 6509.4,8003.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0352/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43300964862831,
+                37.5762064227886
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42911406275235,
+                37.576268655843904
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4290218522506,
+                37.5725915428096
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43291743812657,
+                37.572529309754295
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0354/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p354",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0354/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0354/info.json",
+          "type": "ImageService2",
+          "height": 8003,
+          "width": 6766
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6457.5,7434.5 5894.8,7390.9 5803.9,8003.0 1913.9,8003.0 2089.4,0.0 4156.5,0.0 4322.1,2452.4 6247.6,2326.6 6362.5,123.8 6766.0,180.4 6766.0,8003.0 6413.4,8003.0 6457.5,7434.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0354/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43034481757061,
+                37.57618339471219
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42646905140674,
+                37.576234024882154
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4263940325098,
+                37.572575637099064
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43026979867368,
+                37.5725250069291
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0355/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p355",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0355/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0355/info.json",
+          "type": "ImageService2",
+          "height": 8003,
+          "width": 6766
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5761.0,8003.0 5346.7,7576.7 4441.1,7508.5 1121.7,7615.9 1127.9,8003.0 -0.0,8003.0 -0.0,3496.5 1128.4,3266.1 831.1,2191.8 1896.1,2163.8 4549.6,-0.0 6766.0,-0.0 6766.0,5915.3 5667.0,4622.1 5536.8,4624.5 5543.6,7507.3 6686.8,7506.5 6677.9,8003.0 5761.0,8003.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0355/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43017063602163,
+                37.58181896614649
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42711821419962,
+                37.57989912253509
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6766.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42996303393478,
+                37.57701808371333
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8003.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43301545575679,
+                37.57893792732473
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0356/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p356",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0356/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0356/info.json",
+          "type": "ImageService2",
+          "height": 8049,
+          "width": 6821
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8049.0 -0.0,4448.6 3077.5,203.8 2796.4,0.0 3979.5,0.0 4045.1,533.9 6285.8,256.1 6325.0,0.0 6821.0,206.0 6821.0,6633.1 6478.3,6580.7 5933.1,6077.0 5893.4,8049.0 -0.0,8049.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0356/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42887813672601,
+                37.58004886693403
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6821.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42496702027675,
+                37.579923649398715
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6821.0,
+                8049.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42515214494111,
+                37.57624040014094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8049.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42906326139037,
+                37.57636561767625
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0357/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p357",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0357/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0357/info.json",
+          "type": "ImageService2",
+          "height": 8022,
+          "width": 6796
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"737.8,4672.2 947.9,3916.7 1717.4,1267.5 3963.3,0.0 4169.2,0.0 4255.5,0.0 6796.0,0.0 6796.0,5171.9 6796.0,7576.7 6478.0,7630.5 857.9,7413.6 737.8,4672.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0357/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42875001806976,
+                37.574436109270664
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6796.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42800562834464,
+                37.57747770620872
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6796.0,
+                8022.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42347451945452,
+                37.57678112359147
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8022.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42421890917964,
+                37.57373952665342
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0358/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p358",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0358/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0358/info.json",
+          "type": "ImageService2",
+          "height": 8012,
+          "width": 6807
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5187.7,521.7 6150.0,883.4 6807.0,779.2 6807.0,5086.4 6320.1,6286.1 4756.9,5658.9 1631.4,6778.0 2708.1,7186.2 2410.6,8012.0 749.2,8012.0 785.5,1996.7 522.9,1995.8 548.7,608.3 5187.7,521.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0358/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42487076360338,
+                37.573979611269166
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6807.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42416342071785,
+                37.57704102934335
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6807.0,
+                8012.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41961765669087,
+                37.57638126547003
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8012.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42032499957641,
+                37.57331984739585
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0359/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p359",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0359/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0359/info.json",
+          "type": "ImageService2",
+          "height": 8038,
+          "width": 6819
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1432.7,4171.0 749.7,0.0 1524.9,0.0 1493.0,241.4 6819.0,379.7 6819.0,7746.2 6081.9,7676.8 6219.0,3590.5 5489.2,3533.1 5392.2,5959.2 3978.7,5870.5 3930.8,7479.1 5095.4,7589.4 5056.9,8038.0 1411.5,8038.0 1086.9,4227.6 1432.7,4171.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0359/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4268614910891,
+                37.57457040770094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6819.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42297240708376,
+                37.574114200518395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6819.0,
+                8038.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42364621447796,
+                37.570454740401075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8038.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42753529848329,
+                37.57091094758362
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0360/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p360",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0360/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0360/info.json",
+          "type": "ImageService2",
+          "height": 8029,
+          "width": 6835
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8029.0 -0.0,3478.5 1528.1,280.0 -0.0,260.9 -0.0,-0.0 6795.1,0.0 6835.0,2425.0 5802.0,8029.0 -0.0,8029.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0360/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42365625017607,
+                37.57416847935419
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6835.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41978274708352,
+                37.57358711210307
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6835.0,
+                8029.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42063854550915,
+                37.5699544393264
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8029.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4245120486017,
+                37.570535806577524
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0361/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p361",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0361/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0361/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3537.8 464.2,3349.1 -0.0,716.8 0.0,0.0 2719.8,0.0 2900.0,2226.6 4879.2,1274.6 4730.6,0.0 6828.0,0.0 6828.0,7294.5 548.0,7204.0 -0.0,7220.8 -0.0,3537.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0361/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44362153873158,
+                37.575299886037726
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4397100955445,
+                37.57514837873503
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6828.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43993518535032,
+                37.57149798391808
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4438466285374,
+                37.571649491220775
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0362/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p362",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0362/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0362/info.json",
+          "type": "ImageService2",
+          "height": 8053,
+          "width": 6847
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"261.7,2845.7 149.6,2606.4 4599.0,268.3 4459.7,0.0 5262.5,0.0 5634.9,953.3 5128.5,1225.7 5483.5,1948.3 6042.7,1723.8 6471.3,1034.3 6847.0,1035.8 6847.0,7696.0 5928.3,7694.5 5926.7,8053.0 0.0,8053.0 0.0,2943.1 261.7,2845.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0362/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42265594588707,
+                37.57081641063609
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6847.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42058902902613,
+                37.57348824073273
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6847.0,
+                8053.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41662344423335,
+                37.57156099977396
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8053.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41869036109429,
+                37.56888916967732
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0363/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p363",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0363/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0363/info.json",
+          "type": "ImageService2",
+          "height": 8036,
+          "width": 6804
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5896.8,2135.4 5855.5,255.8 2590.2,982.0 2215.5,1490.8 1962.8,0.0 6804.0,0.0 6804.0,7312.2 6334.7,7281.9 5856.9,7612.4 5299.4,6811.0 4426.2,7434.8 2854.6,5086.0 1675.2,6667.5 -0.0,5449.8 0.0,0.0 1591.5,0.0 2260.6,2558.2 5896.8,2135.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0363/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.45055859527956,
+                37.56423627210189
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6804.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44280962455238,
+                37.56419491393465
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6804.0,
+                8036.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44287081293483,
+                37.55688878084525
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8036.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.450619783662,
+                37.556930139012486
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0364/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p364",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0364/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0364/info.json",
+          "type": "ImageService2",
+          "height": 8024,
+          "width": 6842
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2025.4,7102.2 1796.2,6814.2 1617.6,2051.7 2035.7,1986.8 1993.8,459.0 1556.9,434.2 1541.9,34.4 698.8,66.0 687.1,0.0 6354.6,0.0 6109.3,517.2 6091.4,1958.4 5652.8,1966.9 5718.1,5334.8 6842.0,5313.0 6842.0,6799.3 2014.3,6883.2 2025.4,7102.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0364/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44458496352651,
+                37.564288565540735
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6842.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43669948258726,
+                37.564012522287
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6842.0,
+                8024.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43710775195277,
+                37.556683933250774
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8024.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44499323289202,
+                37.55695997650451
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0365/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p365",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0365/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0365/info.json",
+          "type": "ImageService2",
+          "height": 8038,
+          "width": 6857
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5688.4 -0.0,1223.1 269.6,0.0 335.9,0.0 377.7,0.0 4127.6,0.0 4213.0,0.0 4265.6,0.0 5600.7,283.7 6857.0,1194.4 6857.0,6186.7 5454.0,8038.0 371.0,8038.0 -0.0,5688.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0365/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44940447136361,
+                37.568958200151954
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6857.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44176435219875,
+                37.5696261777427
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6857.0,
+                8038.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44077668820117,
+                37.5625284936042
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8038.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44841680736603,
+                37.56186051601345
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0366/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p366",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0366/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0366/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1184.9,4607.3 1210.4,1318.1 2566.9,1565.7 2634.8,1194.0 3593.0,1365.8 3618.3,1370.2 5595.9,1738.1 5314.9,3289.0 5307.9,3296.8 4664.3,6283.6 4364.7,6631.0 1173.3,6110.4 1174.6,5934.3 152.6,5706.6 424.5,4453.9 1184.9,4607.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0366/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44318485743668,
+                37.56961016525478
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43537207092325,
+                37.570341800868164
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4342810708744,
+                37.5630220652071
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44209385738783,
+                37.562290429593716
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0367/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p367",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0367/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0367/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2821.2,623.8 3732.8,546.5 5589.9,428.5 6790.0,3221.7 6790.0,8025.0 4517.8,8025.0 443.7,5784.5 0.0,6804.5 0.0,3316.0 2821.2,623.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0367/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43260501313357,
+                37.55599945866572
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.431608369782,
+                37.56229041960969
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42222797376304,
+                37.56135661725989
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42322461711461,
+                37.55506565631592
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0368/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p368",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0368/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0368/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3520.6,2588.0 6337.8,2210.4 6455.1,2245.1 6369.0,3156.4 6790.0,3094.9 6790.0,8025.0 3575.2,8025.0 3922.0,7212.7 16.0,5534.0 162.9,5237.1 743.7,5296.6 2588.3,5662.2 3297.8,6055.4 3656.8,5480.1 1087.5,4377.7 1059.2,3285.6 3565.8,3028.5 3520.6,2588.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0368/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43183352884013,
+                37.56140175301115
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43063853947415,
+                37.56763363524808
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4213458981555,
+                37.566514033733526
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42254088752148,
+                37.560282151496594
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0369/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p369",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0369/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0369/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3013.7,0.0 3707.4,0.0 5631.5,1328.3 6790.0,2526.5 6790.0,4872.8 5533.1,7091.1 5202.7,8025.0 4725.5,8025.0 4749.8,7275.9 3164.2,7650.0 2698.8,7478.6 1610.0,6847.9 1566.8,260.7 3013.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0369/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4296103086091,
+                37.565989084994804
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4279617608531,
+                37.57211781752905
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41882246225272,
+                37.57057335026567
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42047101000873,
+                37.564444617731425
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0370__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p370 [1]",
       "metadata": [
         {
           "label": "streets",
@@ -10261,15 +9035,15 @@
         },
         {
           "label": "split_canvas_w",
-          "value": "6549.0"
+          "value": "6790.0"
         },
         {
           "label": "split_canvas_h",
-          "value": "7677.0"
+          "value": "8025.0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10278,21 +9052,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0081__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0370__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0081/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0370/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6549
+          "height": 8025,
+          "width": 6790
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7677.0 -0.0,1575.9 498.8,1567.1 485.7,631.3 3764.3,513.4 3754.7,0.0 6549.0,0.0 6549.0,5446.4 6549.0,7677.0 -0.0,7677.0\" /></svg>"
+          "value": "<svg><polygon points=\"369.6,1632.1 472.0,1623.1 413.7,1489.2 871.3,1271.9 928.4,1822.3 4032.1,1500.5 4013.5,1312.7 5596.7,1151.0 5709.1,2264.1 6790.0,2157.0 6790.0,6517.9 6082.9,6517.8 5369.6,7700.1 4949.1,7452.2 4949.0,8025.0 1544.0,8025.0 1119.2,3872.9 538.2,3929.8 369.6,1632.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0081__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0370__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -10317,8 +9091,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20092069778879,
-                25.763921864385754
+                -77.42089667104064,
+                37.56921136368348
               ]
             }
           },
@@ -10326,7 +9100,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6549.0,
+                6790.0,
                 0.0
               ],
               "creator": {
@@ -10338,8 +9112,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1975910571903,
-                25.76396946213604
+                -77.41636948832739,
+                37.5738988079672
               ]
             }
           },
@@ -10347,8 +9121,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6549.0,
-                7677.0
+                6790.0,
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10359,8 +9133,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19752910766606,
-                25.760454501451854
+                -77.40937937384545,
+                37.569657505688525
               ]
             }
           },
@@ -10369,7 +9143,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10380,8 +9154,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20085874826455,
-                25.76040690370157
+                -77.4139065565587,
+                37.56497006140481
               ]
             }
           }
@@ -10389,13 +9163,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0081__2/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0370__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p81 [2]",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p370 [1]",
       "metadata": [
         {
           "label": "streets",
@@ -10411,19 +9185,19 @@
         },
         {
           "label": "split_canvas_y",
-          "value": "5020.8"
+          "value": "5087.7"
         },
         {
           "label": "split_canvas_w",
-          "value": "3663.1"
+          "value": "2353.7"
         },
         {
           "label": "split_canvas_h",
-          "value": "2656.2"
+          "value": "2937.3"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10432,21 +9206,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0081__2/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0370__2/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0081/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0370/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6549
+          "height": 8025,
+          "width": 6790
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5515.4 2689.7,5727.1 2616.7,7677.0 -0.0,7677.0 -0.0,5515.4\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,5970.5 397.2,6204.7 1070.8,5087.7 2353.7,5087.7 2353.7,8025.0 -0.0,8025.0 0.0,5970.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0081__2/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0370__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -10460,7 +9234,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                5020.8
+                5087.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10471,8 +9245,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20230947409226,
-                25.763461229758413
+                -77.41191962362831,
+                37.5691833887189
               ]
             }
           },
@@ -10480,8 +9254,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3663.1,
-                5020.8
+                2353.7,
+                5087.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10492,8 +9266,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20042715161605,
-                25.7635515733813
+                -77.41025786721843,
+                37.57090344373867
               ]
             }
           },
@@ -10501,8 +9275,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3663.1,
-                7677.0
+                2353.7,
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10513,8 +9287,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20035432537541,
-                25.76232086266612
+                -77.40754984098828,
+                37.56925982560686
               ]
             }
           },
@@ -10523,7 +9297,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10534,8 +9308,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.20223664785162,
-                25.762230519043232
+                -77.40921159739815,
+                37.56753977058709
               ]
             }
           }
@@ -10543,13 +9317,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0082/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0371/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p82",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p371",
       "metadata": [
         {
           "label": "streets",
@@ -10560,8 +9334,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10570,21 +9344,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0082/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0371/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0082/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0371/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6554
+          "height": 8025,
+          "width": 6790
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6154.2,7678.0 1443.7,7633.3 1543.6,104.6 6118.3,0.0 6154.2,7678.0\" /></svg>"
+          "value": "<svg><polygon points=\"645.4,1691.9 2232.6,0.0 5056.7,0.0 5993.1,1502.6 6790.0,3645.8 6790.0,8025.0 -0.0,8025.0 -0.0,6643.2 645.4,1691.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0082/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0371/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -10609,8 +9383,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1983926,
-                25.7639973
+                -77.4279395482042,
+                37.5600465700668
               ]
             }
           },
@@ -10618,7 +9392,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6554.0,
+                6790.0,
                 0.0
               ],
               "creator": {
@@ -10630,8 +9404,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1949961,
-                25.7640864
+                -77.42378312623234,
+                37.56534627146344
               ]
             }
           },
@@ -10639,8 +9413,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6554.0,
-                7678.0
+                6790.0,
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10651,8 +9425,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19488009999999,
-                25.7605031
+                -77.41588078350627,
+                37.56145192537367
               ]
             }
           },
@@ -10661,7 +9435,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10672,8 +9446,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1982766,
-                25.760414
+                -77.42003720547812,
+                37.55615222397703
               ]
             }
           }
@@ -10681,13 +9455,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0083/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0372/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p83",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p372",
       "metadata": [
         {
           "label": "streets",
@@ -10698,8 +9472,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10708,21 +9482,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0083/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0372/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0083/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0372/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6535
+          "height": 8025,
+          "width": 6790
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,568.5 248.5,568.5 274.5,498.9 2188.1,498.5 2189.7,926.4 4902.9,871.2 4801.8,1255.1 6535.0,1442.6 6535.0,6190.0 5632.5,6188.2 5555.6,6482.3 4441.3,6185.9 249.3,6177.8 241.1,3888.1 -0.0,3887.3 -0.0,568.5\" /></svg>"
+          "value": "<svg><polygon points=\"380.0,2361.9 2990.2,1269.6 4239.6,1510.4 4740.5,1519.4 4359.0,20.5 6790.0,0.0 6790.0,200.7 6062.8,443.5 6395.3,1491.1 6297.5,1489.1 6234.6,3686.7 6790.0,3692.7 6790.0,8025.0 1152.4,8025.0 1173.7,3632.9 376.3,3634.7 380.0,2361.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0083/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0372/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -10747,8 +9521,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19559345750682,
-                25.767657237377243
+                -77.42445111642245,
+                37.56439368270616
               ]
             }
           },
@@ -10756,7 +9530,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6535.0,
+                6790.0,
                 0.0
               ],
               "creator": {
@@ -10768,8 +9542,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18895331063928,
-                25.767850177681765
+                -77.42039200211781,
+                37.56969941597408
               ]
             }
           },
@@ -10777,8 +9551,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6535.0,
-                7677.0
+                6790.0,
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10789,8 +9563,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18870333878326,
-                25.760773850853624
+                -77.41253577706784,
+                37.56586956256098
               ]
             }
           },
@@ -10799,7 +9573,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10810,8 +9584,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.1953434856508,
-                25.760580910549102
+                -77.41659489137248,
+                37.56056382929306
               ]
             }
           }
@@ -10819,13 +9593,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0009/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0373/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p9",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p373",
       "metadata": [
         {
           "label": "streets",
@@ -10836,8 +9610,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10846,21 +9620,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0009/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0373/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0009/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0373/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6480
+          "height": 8025,
+          "width": 6790
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4779.5,7343.3 1536.0,6727.5 1528.0,717.8 4775.3,714.1 4779.5,7343.3\" /></svg>"
+          "value": "<svg><polygon points=\"1206.0,724.0 0.0,747.7 0.0,-0.0 6790.0,0.0 6790.0,2357.4 5310.9,2507.3 5407.3,5507.7 4371.9,5420.6 4267.1,6569.9 732.0,6222.0 1005.9,5975.9 1318.0,5916.0 1187.8,4630.7 1496.2,4600.3 1486.2,4466.4 1173.9,4497.6 1018.5,2930.4 0.0,3037.3 0.0,851.6 1213.8,828.8 1206.0,724.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0009/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0373/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -10885,8 +9659,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19447138580098,
-                25.77638553844155
+                -77.44988903302975,
+                37.5678605231809
               ]
             }
           },
@@ -10894,7 +9668,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6480.0,
+                6790.0,
                 0.0
               ],
               "creator": {
@@ -10906,8 +9680,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19114236504109,
-                25.77648870888379
+                -77.45016388871213,
+                37.57405783212208
               ]
             }
           },
@@ -10915,8 +9689,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6480.0,
-                7678.0
+                6790.0,
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10927,8 +9701,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19100658000977,
-                25.772935732448047
+                -77.4409219874237,
+                37.57431532541088
               ]
             }
           },
@@ -10937,7 +9711,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10948,8 +9722,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19433560076966,
-                25.772832562005807
+                -77.44064713174133,
+                37.5681180164697
               ]
             }
           }
@@ -10957,13 +9731,1945 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0090__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0374/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p90 [2]",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p374",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0374/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0374/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1584.7,0.0 1584.7,0.0 3716.4,0.0 6182.9,0.0 6790.0,95.4 6790.0,1827.4 6790.0,3562.5 5577.1,8025.0 3513.8,8025.0 1657.9,8025.0 0.0,5334.1 0.0,3001.4 0.0,360.5 1584.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0374/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44976844841443,
+                37.572652077177246
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4502830997306,
+                37.57870830923464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4412511404281,
+                37.57919042684651
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44073648911193,
+                37.57313419478911
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0375/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p375",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0375/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0375/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3779.7,764.2 3720.6,289.3 6790.0,227.6 6790.0,7460.7 4569.5,7403.8 4467.3,6548.1 1068.2,6724.5 1147.1,7328.0 1005.6,7324.5 1041.9,8025.0 -0.0,8025.0 -0.0,1266.2 3779.7,764.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0375/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.45152210866735,
+                37.584822090942616
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44372102257553,
+                37.58491739192085
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44357888175475,
+                37.57761015845074
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.45137996784656,
+                37.57751485747251
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0376/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p376",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0376/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0376/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1821.8,250.0 4479.2,251.8 4510.1,0.0 5335.7,0.0 5744.9,377.7 6484.6,870.7 6790.0,876.8 6790.0,8025.0 3801.7,8025.0 3786.8,7543.2 2086.9,7467.9 2192.1,8025.0 1657.2,8010.2 1821.8,250.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0376/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44581418982098,
+                37.58487751101942
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43803679581772,
+                37.585105589261026
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43769900572512,
+                37.577769063909535
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44547639972838,
+                37.57754098566793
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0377/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p377",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0377/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0377/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5150.2,8025.0 1869.5,8025.0 -0.0,5948.9 -0.0,1288.8 1482.5,181.0 2565.9,158.1 2589.9,-0.0 3292.9,-0.0 3249.4,160.2 4011.3,206.5 6790.0,3106.2 6790.0,3773.3 6159.8,5935.6 5150.2,8025.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0377/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43471003685914,
+                37.58134085861427
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4330192365337,
+                37.57539676723013
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44188415099582,
+                37.573812885956634
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44357495132127,
+                37.57975697734077
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0378/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p378",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0378/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0378/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3267.5 2905.0,0.0 6790.0,0.0 6790.0,7160.4 6008.8,8025.0 270.1,8025.0 55.5,5222.7 -0.0,3267.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0378/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44041520247379,
+                37.58610608384722
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43256619715824,
+                37.58654667923046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43190904706736,
+                37.579194613753785
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43975805238291,
+                37.578754018370546
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0379/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p379",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0379/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0379/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2089.5,4901.9 1044.1,4993.2 1002.7,5082.6 1146.0,6747.5 -0.0,6531.4 -0.0,3445.5 238.2,3184.8 -0.0,2941.1 7.9,0.0 6790.0,0.0 6790.0,4332.0 6552.8,4319.7 6488.8,5268.9 4994.7,5066.5 4621.2,4691.2 4336.2,5168.4 3868.3,4839.9 3295.4,5388.3 3428.8,3553.5 2991.3,4236.3 3109.5,5566.2 2193.6,6117.5 2089.5,4901.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0379/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43665040014193,
+                37.58445182668073
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42886389542022,
+                37.58534211156593
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42753604944414,
+                37.578048490051884
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43532255416585,
+                37.57715820516668
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0380/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p380",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0380/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0380/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1126.7,5383.0 900.6,1013.6 -0.0,1060.2 -0.0,-0.0 6790.0,0.0 6790.0,4232.9 5447.9,3819.3 5514.0,5404.8 4066.4,5397.7 3746.1,6350.5 5645.0,6298.2 5799.5,7230.5 6355.3,7130.5 6790.0,6574.0 6790.0,8025.0 3636.8,8025.0 3720.0,7395.7 3779.3,7386.9 3501.1,7195.3 3455.7,7351.5 2326.3,7342.7 2329.0,7071.8 1742.4,6993.9 1063.6,6345.6 871.7,6343.6 886.7,5382.9 1126.7,5383.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0380/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42999912791191,
+                37.586184958661114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42224232397183,
+                37.58674965014544
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42140010471032,
+                37.57948376954926
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4291569086504,
+                37.578919078064935
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0381/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p381",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0381/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0381/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"717.6,3804.0 1167.9,3809.7 1032.5,3444.3 1809.7,3151.1 1803.1,2712.4 1227.4,2711.4 2491.8,1636.4 3333.8,1653.9 3354.1,834.4 3579.8,576.3 4852.3,580.8 4894.4,0.0 6790.0,0.0 6790.0,3863.9 6343.4,3857.1 6300.6,7183.4 690.7,7138.2 717.6,3804.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0381/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42426596597095,
+                37.57447258791753
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.420225754181,
+                37.579792547642995
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.412293544822,
+                37.57600692185809
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41633375661195,
+                37.570686962132626
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0382/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p382",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0382/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0382/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"965.2,3769.1 952.4,2100.9 2046.9,1710.8 2045.3,1642.8 2044.5,1606.7 2100.8,1606.1 2348.7,1603.2 4536.0,823.6 4242.5,0.0 6790.0,0.0 6790.0,8025.0 2808.1,8025.0 2635.0,7597.7 1596.9,8025.0 -0.0,8025.0 -0.0,7108.9 499.3,7107.6 516.5,3765.9 965.2,3769.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0382/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.42067714450162,
+                37.579013299285464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41660280224986,
+                37.584283086752556
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4087433311052,
+                37.58046648665292
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41281767335697,
+                37.575196699185824
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0383/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p383 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0383/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0383/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2603.7,8025.0 1384.6,6403.3 -0.0,1225.0 -0.0,-0.0 6790.0,0.0 6790.0,8025.0 2603.7,8025.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0383/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41252275140369,
+                37.58355350507034
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.40498315916349,
+                37.58198327038728
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4073250939235,
+                37.57492079406096
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4148646861637,
+                37.576491028744016
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0384/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p384",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0384/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0384/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5757.6,6873.4 1673.9,6215.1 669.2,5895.4 -0.0,4094.8 -0.0,2517.9 4364.8,0.0 6278.5,0.0 6548.3,0.0 6790.0,1467.9 6790.0,6652.0 5757.6,6873.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0384/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41525548114845,
+                37.57789320978207
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.40758771575818,
+                37.576375581823804
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.40985101678896,
+                37.56919249382437
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.41751878217923,
+                37.57071012178263
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0385/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p385",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0385/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0385/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8025.0 0.0,0.0 4564.4,-0.0 4464.0,697.3 5397.5,831.7 5382.1,1632.3 5451.6,1486.1 5642.3,1575.7 5640.4,1762.7 5386.9,1634.7 5302.3,8025.0 -0.0,8025.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0385/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44499274385849,
+                37.59568820568776
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44375892883207,
+                37.58957608381312
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.45281244961747,
+                37.58841237605216
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.45404626464389,
+                37.5945244979268
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0386/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p386",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0386/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0386/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1627.0 254.7,1751.1 254.2,1565.6 62.6,1478.9 -0.0,1614.3 -0.0,830.6 2793.8,1198.3 4030.5,-0.0 6737.0,-0.0 6693.3,394.5 4038.8,357.4 3951.5,481.9 3940.1,1349.2 6548.7,1692.6 6312.8,3779.0 6790.0,3783.0 6790.0,8025.0 -0.0,8025.0 -0.0,1627.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0386/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44400332761825,
+                37.590820395611914
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44285351302686,
+                37.58468701802438
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.45200191784612,
+                37.583610053205035
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.4531517324375,
+                37.589743430792566
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0387/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p387",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0387/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0387/info.json",
+          "type": "ImageService2",
+          "height": 8025,
+          "width": 6790
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7518.0 0.0,-0.0 6790.0,0.0 6790.0,8025.0 2473.7,8025.0 -0.0,7518.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0387/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44496821220656,
+                37.59156876570017
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43716984383943,
+                37.591672799027606
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6790.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.43701575382752,
+                37.58431714795433
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8025.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.44481412219466,
+                37.58421311462689
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0388__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Richmond, Va. | 1925 | Vol. 3 p388",
       "metadata": [
         {
           "label": "streets",
@@ -10983,15 +11689,15 @@
         },
         {
           "label": "split_canvas_w",
-          "value": "6579.0"
+          "value": "6292.5"
         },
         {
           "label": "split_canvas_h",
-          "value": "7678.0"
+          "value": "8025.0"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11000,21 +11706,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0090__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0388__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0090/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0388/info.json",
           "type": "ImageService2",
-          "height": 7678,
-          "width": 6579
+          "height": 8025,
+          "width": 6790
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1588.6 371.8,1589.1 369.7,0.0 4510.0,0.0 5611.0,292.6 5686.6,0.0 6579.0,0.0 6579.0,7678.0 -0.0,7678.0 -0.0,1588.6\" /></svg>"
+          "value": "<svg><polygon points=\"357.0,4476.1 3319.2,3563.1 2899.1,2199.7 2651.8,2848.5 2158.7,3103.4 1743.6,2272.1 -0.0,2862.8 -0.0,1882.2 1361.9,1470.6 840.8,0.0 6292.5,0.0 6292.5,2285.6 6195.2,2568.9 6292.5,2601.0 6292.5,3744.8 4235.2,3029.2 3619.9,4799.8 4148.6,5027.8 3731.4,6215.0 3929.5,6573.0 1930.7,6625.4 1961.7,6792.5 751.8,6811.5 357.0,4476.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0090__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0388__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -11039,8 +11745,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19551933399879,
-                25.761959803147743
+                -77.42433493539485,
+                37.583340089752916
               ]
             }
           },
@@ -11048,7 +11754,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6579.0,
+                6292.5,
                 0.0
               ],
               "creator": {
@@ -11060,8 +11766,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18875066432851,
-                25.762144564964768
+                -77.41714865177313,
+                37.58214206713063
               ]
             }
           },
@@ -11069,8 +11775,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6579.0,
-                7678.0
+                6292.5,
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11081,8 +11787,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.18851122031299,
-                25.755029445273667
+                -77.4190761244236,
+                37.574879896697695
               ]
             }
           },
@@ -11091,7 +11797,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7678.0
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11102,8 +11808,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.19527988998327,
-                25.754844683456643
+                -77.42626240804532,
+                37.57607791931998
               ]
             }
           }
@@ -11111,13 +11817,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0091__3/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0389/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Miami, Fla. | 1950 | Vol. 1 p91 [3]",
+      "label": "Richmond, Va. | 1925 | Vol. 3 p389",
       "metadata": [
         {
           "label": "streets",
@@ -11126,26 +11832,10 @@
         {
           "label": "intersections",
           "value": "0"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "4921.7"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6555.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "2755.3"
         }
       ],
-      "created": "2026-08-15T01:12:58Z",
-      "modified": "2026-08-15T01:12:58Z",
+      "created": "2026-08-15T01:59:46Z",
+      "modified": "2026-08-15T01:59:46Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11154,21 +11844,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0091__3/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0389/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0091/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0389/info.json",
           "type": "ImageService2",
-          "height": 7677,
-          "width": 6555
+          "height": 8025,
+          "width": 6790
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7677.0 -0.0,4921.7 6555.0,4921.7 6555.0,7677.0 -0.0,7677.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1918.0 717.9,1763.5 788.7,781.3 607.2,0.0 1806.3,0.0 2008.7,433.4 2351.5,359.6 3808.8,1275.2 4059.2,1911.3 4580.2,1810.6 6073.1,5037.5 6107.7,6539.1 6790.0,6528.1 6790.0,8025.0 -0.0,8025.0 -0.0,6181.9 1473.2,6311.3 1275.2,5692.6 1093.1,5699.3 1206.1,5521.2 564.5,3744.0 -0.0,3690.4 -0.0,1918.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd393m:g3934m:g3934mm:g3934mm_g01309195001:01309_01_1950-0091__3/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd388m:g3884m:g3884rm:g3884rm_g09064192503:09064_03_1925-0389/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -11182,7 +11872,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                4921.7
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11193,8 +11883,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.17191816902951,
-                25.791425761905664
+                -77.43330796304107,
+                37.55293274799882
               ]
             }
           },
@@ -11202,8 +11892,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6555.0,
-                4921.7
+                6790.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11214,8 +11904,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.16560065497555,
-                25.791739538383126
+                -77.42915135090439,
+                37.55820969803604
               ]
             }
           },
@@ -11223,8 +11913,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6555.0,
-                7677.0
+                6790.0,
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11235,8 +11925,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.16545395227286,
-                25.78934474108582
+                -77.42128345264825,
+                37.55431491632893
               ]
             }
           },
@@ -11245,7 +11935,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                7677.0
+                8025.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11256,8 +11946,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -80.17177146632682,
-                25.789030964608358
+                -77.42544006478494,
+                37.549037966291706
               ]
             }
           }

--- a/gallery/washington_dc_1916_vol_2.iiif.json
+++ b/gallery/washington_dc_1916_vol_2.iiif.json
@@ -7,25 +7,41 @@
   "label": "Mosaic of main content, Washington, D.C. | 1916 | Vol. 2",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001660",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001250 [1]",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
           "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5936.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8381.0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -34,21 +50,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250/info.json",
           "type": "ImageService2",
-          "height": 8479,
-          "width": 6029
+          "height": 8381,
+          "width": 5936
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8272.3 -0.0,0.0 6029.0,-0.0 6029.0,8158.7 5334.5,8159.6 4958.4,8276.9 -0.0,8272.3\" /></svg>"
+          "value": "<svg><polygon points=\"5833.0,1621.1 4932.9,1585.4 4920.3,7069.4 4630.7,7062.7 4601.8,8381.0 3087.4,8381.0 3091.3,6682.5 -0.0,6704.7 0.0,0.0 5936.0,-0.0 5833.0,1621.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -73,8 +89,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.003368,
-                38.9165975
+                -77.01412639109229,
+                38.92243645717089
               ]
             }
           },
@@ -82,7 +98,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6029.0,
+                5936.0,
                 0.0
               ],
               "creator": {
@@ -94,8 +110,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.003362,
-                38.9133017
+                -77.01361340745008,
+                38.91922734194126
               ]
             }
           },
@@ -103,8 +119,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6029.0,
-                8479.0
+                5936.0,
+                8381.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -115,8 +131,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0093169,
-                38.9132951
+                -77.01943843244773,
+                38.91866356697244
               ]
             }
           },
@@ -125,7 +141,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8479.0
+                8381.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -136,8 +152,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0093229,
-                38.9165909
+                -77.01995141608994,
+                38.92187268220207
               ]
             }
           }
@@ -178,8 +194,8 @@
           "value": "2090.2"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -198,7 +214,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4176.5,-0.0 4209.9,2090.2 -0.0,2090.2 -0.0,1.7 4176.5,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"4168.0,0.0 4203.8,2090.2 0.0,2090.2 -0.0,11.5 333.0,6.8 332.9,0.0 4168.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -227,8 +243,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01127127454245,
-                38.92148884384188
+                -77.01126433428352,
+                38.921491973562
               ]
             }
           },
@@ -248,8 +264,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01131964173658,
-                38.918929546319035
+                -77.01131656088741,
+                38.9189239854104
               ]
             }
           },
@@ -269,8 +285,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01279745557646,
-                38.91894669140434
+                -77.01279939295253,
+                38.91894249856989
               ]
             }
           },
@@ -290,8 +306,162 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01274908838234,
-                38.92150598892718
+                -77.01274716634865,
+                38.92151048672149
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001260 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5948.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8371.0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/info.json",
+          "type": "ImageService2",
+          "height": 8371,
+          "width": 5948
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8371.0 0.0,0.0 3190.4,-0.0 3174.3,1698.9 4688.7,1709.7 4507.8,7929.9 4507.8,7929.9 4495.0,8371.0 -0.0,8371.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01879538786068,
+                38.9220389365915
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5948.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0182516795791,
+                38.91882629158247
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5948.0,
+                8371.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02406301715287,
+                38.91823080894479
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8371.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02460672543445,
+                38.92144345395382
               ]
             }
           }
@@ -316,8 +486,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -336,7 +506,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1329.4 313.2,1321.9 305.2,695.8 5137.6,596.7 5203.6,3842.8 5964.9,4331.8 4268.8,6812.4 3671.4,8382.0 -0.0,8406.0 -0.0,1329.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6839.9 -0.0,0.0 289.4,-0.0 305.6,692.7 5139.6,596.0 5203.9,3843.2 5965.2,4332.8 4267.3,6813.4 3668.5,8386.2 -0.0,8406.0 -0.0,6839.9 -0.0,6839.9\" /></svg>"
         }
       },
       "body": {
@@ -365,8 +535,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01863250982873,
-                38.919457797280394
+                -77.0186349727608,
+                38.91945792871008
               ]
             }
           },
@@ -386,8 +556,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01821074798755,
-                38.91618560252408
+                -77.01821117405561,
+                38.9161869742029
               ]
             }
           },
@@ -407,8 +577,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0240319078668,
-                38.915724964651574
+                -77.02403012756076,
+                38.91572411171788
               ]
             }
           },
@@ -428,8 +598,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02445366970798,
-                38.91899715940789
+                -77.02445392626595,
+                38.91899506622506
               ]
             }
           }
@@ -454,8 +624,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -474,7 +644,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5677.7,8414.0 338.2,8414.0 374.5,7897.6 764.8,6789.2 2186.9,4140.9 1377.4,3735.9 1047.9,1162.0 5629.9,1129.5 5677.7,8414.0\" /></svg>"
+          "value": "<svg><polygon points=\"5624.2,834.8 5677.2,8414.0 341.1,8414.0 377.1,7895.0 766.7,6787.0 2186.8,4139.8 1377.6,3735.4 964.2,516.4 4361.7,83.8 3979.6,794.6 5624.2,834.8\" /></svg>"
         }
       },
       "body": {
@@ -503,8 +673,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01832394535867,
-                38.91716114842541
+                -77.01832218720064,
+                38.91716086683313
               ]
             }
           },
@@ -524,8 +694,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01835046625374,
-                38.91388833491724
+                -77.01835050863285,
+                38.913885965057865
               ]
             }
           },
@@ -545,8 +715,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02420526889318,
-                38.9139174640304
+                -77.02420904701576,
+                38.9139170717834
               ]
             }
           },
@@ -566,8 +736,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02417874799812,
-                38.91719027753857
+                -77.02418072558355,
+                38.917191973558666
               ]
             }
           }
@@ -592,8 +762,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -612,7 +782,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5710.9,547.0 5664.6,8403.0 -0.0,8403.0 -0.0,8062.4 266.2,8065.5 304.0,508.6 1058.5,512.7 1189.0,1904.1 2327.1,1861.7 2412.0,2035.6 3009.9,1978.6 3025.0,533.1 5710.9,547.0\" /></svg>"
+          "value": "<svg><polygon points=\"5709.2,541.8 5669.0,8403.0 259.9,8403.0 268.3,7937.6 297.9,507.5 1052.7,511.0 1184.3,1903.4 2323.6,1860.1 2408.8,2034.2 3007.1,1976.7 3019.2,1685.4 3021.1,530.0 5709.2,541.8\" /></svg>"
         }
       },
       "body": {
@@ -641,8 +811,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01857618216711,
-                38.91426295232015
+                -77.01857703154857,
+                38.91425924817942
               ]
             }
           },
@@ -662,8 +832,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01855444115792,
-                38.91100195792733
+                -77.01855853179384,
+                38.91100089244386
               ]
             }
           },
@@ -683,8 +853,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02441860820886,
-                38.91097795190332
+                -77.0244179538115,
+                38.91098046535364
               ]
             }
           },
@@ -704,8 +874,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02444034921805,
-                38.91423894629614
+                -77.02443645356622,
+                38.9142388210892
               ]
             }
           }
@@ -730,8 +900,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -750,7 +920,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5319.7,8491.0 641.6,8452.9 555.1,590.2 5246.7,518.1 5319.7,8491.0\" /></svg>"
+          "value": "<svg><polygon points=\"6006.0,8491.0 648.3,8491.0 641.7,7811.6 622.1,6345.3 615.7,5583.1 605.3,4873.5 598.2,4086.7 589.3,3567.7 576.2,2193.2 554.9,598.7 5245.0,522.6 5326.1,8380.4 6006.0,8373.7 6006.0,8491.0\" /></svg>"
         }
       },
       "body": {
@@ -779,8 +949,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0185210861632,
-                38.9114368049363
+                -77.01851471301084,
+                38.911436429334714
               ]
             }
           },
@@ -800,8 +970,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01856995065384,
-                38.90815475742319
+                -77.01856717214557,
+                38.908153420050645
               ]
             }
           },
@@ -821,8 +991,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02448989310534,
-                38.908208880300656
+                -77.02448884971027,
+                38.90821152439439
               ]
             }
           },
@@ -842,8 +1012,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0244410286147,
-                38.911490927813766
+                -77.02443639057554,
+                38.91149453367846
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001310",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/info.json",
+          "type": "ImageService2",
+          "height": 8423,
+          "width": 5966
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"352.3,8423.0 349.0,525.1 5763.4,521.0 5781.5,8420.4 352.3,8423.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01855993446019,
+                38.908760767746095
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5966.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01857081199023,
+                38.90553834346442
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5966.0,
+                8423.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02441603653641,
+                38.905550291345776
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8423.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02440515900636,
+                38.90877271562745
               ]
             }
           }
@@ -868,8 +1176,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -888,7 +1196,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5966.0,8361.0 104.9,8408.2 54.4,938.1 5750.5,917.7 5749.4,533.8 5966.0,532.4 5966.0,8361.0\" /></svg>"
+          "value": "<svg><polygon points=\"97.3,8411.0 46.3,564.7 2715.7,543.8 2681.4,-0.0 2965.0,-0.0 3201.2,542.0 5966.0,521.0 5966.0,8368.3 5788.5,8369.5 5966.0,8411.0 97.3,8411.0\" /></svg>"
         }
       },
       "body": {
@@ -917,8 +1225,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01852731324855,
-                38.90567476757236
+                -77.01853724979598,
+                38.90567175273895
               ]
             }
           },
@@ -938,8 +1246,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01855695479878,
-                38.90240004753491
+                -77.01856573573578,
+                38.902404608728986
               ]
             }
           },
@@ -959,8 +1267,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02444677456599,
-                38.90243279019686
+                -77.02444190519465,
+                38.90243607501004
               ]
             }
           },
@@ -980,8 +1288,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02441713301576,
-                38.90570751023431
+                -77.02441341925486,
+                38.90570321902
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001330",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/info.json",
+          "type": "ImageService2",
+          "height": 8450,
+          "width": 6035
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5703.6,577.7 5694.9,8450.0 868.9,8450.0 923.1,575.9 5703.6,577.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01852875823076,
+                38.9029067042536
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6035.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01852874279761,
+                38.8996369364853
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6035.0,
+                8450.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02441203311095,
+                38.89963691966741
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8450.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0244120485441,
+                38.90290668743571
               ]
             }
           }
@@ -1006,8 +1452,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1026,7 +1472,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"648.6,562.2 5182.9,567.9 5177.5,4612.9 5332.1,4859.2 4356.1,4858.3 4361.3,7807.5 5290.0,7805.4 5160.7,8427.0 632.4,8427.0 648.6,562.2\" /></svg>"
+          "value": "<svg><polygon points=\"657.2,567.5 5184.1,578.0 5174.5,4616.4 5328.6,4862.4 4988.9,4859.7 4348.0,4860.5 4347.5,7805.0 5283.5,7803.8 5153.7,8427.0 632.7,8427.0 657.2,567.5\" /></svg>"
         }
       },
       "body": {
@@ -1055,8 +1501,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01854013006154,
-                38.900170633187514
+                -77.01853632519477,
+                38.90017624305791
               ]
             }
           },
@@ -1076,8 +1522,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01853607817759,
-                38.89690899324659
+                -77.01852786903356,
+                38.89690932276776
               ]
             }
           },
@@ -1097,8 +1543,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02440127709293,
-                38.896904517587956
+                -77.02440255865169,
+                38.89689998219406
               ]
             }
           },
@@ -1118,8 +1564,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02440532897688,
-                38.90016615752888
+                -77.0244110148129,
+                38.90016690248421
               ]
             }
           }
@@ -1144,8 +1590,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1164,7 +1610,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4956.9,7816.2 4959.6,8454.0 800.9,8423.3 931.7,7799.9 -0.0,7800.4 -0.0,4841.9 979.1,4844.5 824.4,4597.2 835.9,899.4 5504.9,900.5 5487.5,7814.9 4956.9,7816.2\" /></svg>"
+          "value": "<svg><polygon points=\"5501.5,552.0 5489.5,7798.8 5345.7,7798.7 4956.4,7800.6 4959.9,8454.0 809.2,8413.2 939.3,7787.8 -0.0,7789.1 -0.0,4834.2 984.2,4836.0 829.4,4589.2 838.5,536.6 5501.5,552.0\" /></svg>"
         }
       },
       "body": {
@@ -1193,8 +1639,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0185591775282,
-                38.897798940078985
+                -77.0185602517867,
+                38.897800090592945
               ]
             }
           },
@@ -1214,8 +1660,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01854771035093,
-                38.89452171802857
+                -77.01855236871192,
+                38.89451874064172
               ]
             }
           },
@@ -1235,8 +1681,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02441321388777,
-                38.894509110192445
+                -77.02442525828636,
+                38.89451007342169
               ]
             }
           },
@@ -1256,8 +1702,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02442468106504,
-                38.89778633224286
+                -77.02443314136113,
+                38.897791423372915
               ]
             }
           }
@@ -1282,8 +1728,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1302,7 +1748,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8438.0 -0.0,7204.9 529.6,7205.8 563.6,2705.5 5974.0,2723.9 5974.0,8438.0 -0.0,8438.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8438.0 -0.0,7203.4 532.7,7204.5 567.7,2698.5 5974.0,2722.6 5974.0,8438.0 -0.0,8438.0\" /></svg>"
         }
       },
       "body": {
@@ -1331,8 +1777,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01896525320873,
-                38.8951194399488
+                -77.0189667397154,
+                38.89512194449392
               ]
             }
           },
@@ -1352,8 +1798,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01893617171295,
-                38.891864787764185
+                -77.01893675982409,
+                38.891867591593225
               ]
             }
           },
@@ -1373,8 +1819,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02480067531054,
-                38.891832595332524
+                -77.02480070810468,
+                38.89183440457115
               ]
             }
           },
@@ -1394,8 +1840,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02482975680633,
-                38.89508724751714
+                -77.02483068799599,
+                38.89508875747185
               ]
             }
           }
@@ -1420,8 +1866,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1440,7 +1886,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"760.6,791.6 6101.0,402.9 6101.0,7168.1 5590.6,7125.6 5275.6,7424.9 4963.4,7244.2 5021.3,6865.5 4928.8,7065.4 3528.3,6958.6 1226.7,7138.7 760.6,791.6\" /></svg>"
+          "value": "<svg><polygon points=\"762.2,791.1 6101.0,402.0 6101.0,7168.6 5594.1,7126.5 5279.1,7425.9 4966.8,7245.2 5024.7,6866.3 4932.1,7066.3 3531.2,6959.5 1229.0,7139.9 762.2,791.1\" /></svg>"
         }
       },
       "body": {
@@ -1469,8 +1915,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01965079629313,
-                38.91966691924408
+                -77.01965164510115,
+                38.91966652864074
               ]
             }
           },
@@ -1490,8 +1936,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01539033211488,
-                38.91982780873722
+                -77.01539236656443,
+                38.91982705702934
               ]
             }
           },
@@ -1511,8 +1957,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01510479935241,
-                38.91518575304549
+                -77.01510747465909,
+                38.91518629317197
               ]
             }
           },
@@ -1532,8 +1978,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01936526353067,
-                38.915024863552354
+                -77.01936675319581,
+                38.91502576478337
               ]
             }
           }
@@ -1558,8 +2004,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1578,7 +2024,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1225.4,1327.8 3701.3,1096.5 3597.0,0.0 4926.5,0.0 4871.8,1226.5 5924.0,1255.5 5924.0,8394.0 5569.8,8394.0 5584.4,7889.8 5043.4,7889.6 5592.9,7654.4 5625.0,6521.4 2392.6,6433.9 2436.9,7151.7 1331.5,7080.3 1225.4,1327.8\" /></svg>"
+          "value": "<svg><polygon points=\"2075.7,1151.9 3697.5,1102.3 3592.1,0.0 4917.7,0.0 4862.1,1230.1 5924.0,1258.8 5924.0,8394.0 5564.3,8394.0 5563.5,8394.0 515.3,8394.0 513.1,7349.3 821.5,7045.2 1327.4,7077.6 1200.8,337.5 2026.2,260.2 2075.7,1151.9\" /></svg>"
         }
       },
       "body": {
@@ -1607,8 +2053,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0162284733963,
-                38.919769218245335
+                -77.01622737210478,
+                38.919773302524284
               ]
             }
           },
@@ -1628,8 +2074,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01208222836159,
-                38.91986579657867
+                -77.01207568041538,
+                38.91986859124908
               ]
             }
           },
@@ -1649,8 +2095,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0119075354944,
-                38.9152613837191
+                -77.01190332021854,
+                38.91525812986927
               ]
             }
           },
@@ -1670,8 +2116,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0160537805291,
-                38.91516480538576
+                -77.01605501190794,
+                38.91516284114448
               ]
             }
           }
@@ -1696,8 +2142,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1716,7 +2162,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"730.8,7170.7 1085.2,7162.1 913.5,17.2 6024.0,0.0 6024.0,4762.9 5001.2,4758.5 4970.1,7986.9 726.9,7954.4 730.8,7170.7\" /></svg>"
+          "value": "<svg><polygon points=\"724.0,7177.6 1084.4,7169.1 915.7,18.6 6024.0,0.0 6024.0,4763.5 4994.2,4759.1 4963.1,7987.9 720.2,7955.3 724.0,7177.6\" /></svg>"
         }
       },
       "body": {
@@ -1745,8 +2191,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01269516293779,
-                38.91918372296381
+                -77.01269049014732,
+                38.91918451284556
               ]
             }
           },
@@ -1766,8 +2212,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0084811482466,
-                38.919202504899374
+                -77.0084762163727,
+                38.919203305415955
               ]
             }
           },
@@ -1787,8 +2233,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00844743694518,
-                38.91455881895194
+                -77.00844248603494,
+                38.91455932682439
               ]
             }
           },
@@ -1808,8 +2254,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01266145163636,
-                38.91454003701637
+                -77.01265675980956,
+                38.914540534253995
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001400",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/info.json",
+          "type": "ImageService2",
+          "height": 8468,
+          "width": 5978
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"645.7,7701.2 633.0,837.4 4922.5,841.1 4939.8,2589.1 5059.7,2970.8 5065.6,5657.3 4406.5,5656.7 4404.6,7925.4 4009.9,7700.2 645.7,7701.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01259239702966,
+                38.91527716053346
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5978.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00845551074806,
+                38.915273517482916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5978.0,
+                8468.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0084621407692,
+                38.91071542431352
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8468.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0125990270508,
+                38.91071906736407
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001410",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/info.json",
+          "type": "ImageService2",
+          "height": 8459,
+          "width": 6017
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"362.3,3053.9 1078.7,3409.2 889.5,1545.2 3477.4,1284.8 4581.7,1350.2 4673.6,1599.0 4939.4,1700.1 4987.2,2290.2 4807.0,4953.8 4751.8,5172.4 300.9,5108.6 362.3,3053.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01919366344501,
+                38.91662856019287
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6017.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0149810978865,
+                38.9166798543522
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6017.0,
+                8459.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01488845443964,
+                38.912073603051034
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8459.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01910101999815,
+                38.9120223088917
               ]
             }
           }
@@ -1834,8 +2556,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1854,7 +2576,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2275.6,1385.9 2199.3,665.6 5454.4,610.9 5472.1,1752.3 4929.8,2013.3 5474.0,1989.6 5570.1,8439.0 1218.2,8439.0 1202.6,7424.9 -0.0,7441.5 -0.0,1387.1 78.1,1579.2 348.6,1672.2 645.9,1352.3 2275.6,1385.9\" /></svg>"
+          "value": "<svg><polygon points=\"312.4,4932.4 397.0,2733.7 5474.2,2514.7 5560.3,8439.0 1215.3,8439.0 1183.2,5957.6 199.0,5441.4 312.4,4932.4\" /></svg>"
         }
       },
       "body": {
@@ -1883,8 +2605,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01594284203553,
-                38.91665862624556
+                -77.01594415812428,
+                38.91666578963253
               ]
             }
           },
@@ -1904,8 +2626,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0117744991778,
-                38.916612333390304
+                -77.01176917482931,
+                38.9166206122519
               ]
             }
           },
@@ -1925,8 +2647,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01185765901823,
-                38.912014794629584
+                -77.01185033081072,
+                38.91201574727794
               ]
             }
           },
@@ -1946,8 +2668,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01602600187596,
-                38.91206108748484
+                -77.01602531410569,
+                38.912060924658576
               ]
             }
           }
@@ -1972,8 +2694,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1992,7 +2714,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"307.3,2270.1 1792.2,2273.8 1585.9,207.4 318.7,314.9 323.4,0.0 4763.0,0.0 4692.9,294.6 5661.6,816.4 5651.4,7668.9 312.8,7664.5 307.3,2270.1\" /></svg>"
+          "value": "<svg><polygon points=\"308.5,2263.9 1798.0,2268.6 1592.6,196.7 321.3,303.6 326.0,0.0 4774.6,0.0 4706.2,286.7 5676.9,810.5 5661.8,7679.6 310.2,7671.4 308.5,2263.9\" /></svg>"
         }
       },
       "body": {
@@ -2021,8 +2743,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01915402453773,
-                38.913855591702614
+                -77.01915546716127,
+                38.9138490326311
               ]
             }
           },
@@ -2042,8 +2764,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01494422274178,
-                38.91385762797648
+                -77.01495586397513,
+                38.913853400726325
               ]
             }
           },
@@ -2063,8 +2785,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01494057708767,
-                38.90922958210891
+                -77.01494804353585,
+                38.90923656432598
               ]
             }
           },
@@ -2084,8 +2806,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01915037888361,
-                38.90922754583504
+                -77.01914764672199,
+                38.909232196230754
               ]
             }
           }
@@ -2110,8 +2832,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2130,7 +2852,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"754.7,7766.3 782.3,3317.3 5142.9,3402.4 5114.0,7790.3 754.7,7766.3\" /></svg>"
+          "value": "<svg><polygon points=\"758.9,7767.0 783.7,3318.8 5143.4,3399.5 5117.3,7788.2 758.9,7767.0\" /></svg>"
         }
       },
       "body": {
@@ -2159,8 +2881,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01573268838088,
-                38.91384925361739
+                -77.01573232169372,
+                38.91385074823932
               ]
             }
           },
@@ -2180,8 +2902,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01153736288278,
-                38.91386675894725
+                -77.011536137698,
+                38.91386618396918
               ]
             }
           },
@@ -2201,8 +2923,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01150611717665,
-                38.90926861816177
+                -77.0115085860876,
+                38.90926709986307
               ]
             }
           },
@@ -2222,8 +2944,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01570144267475,
-                38.90925111283191
+                -77.01570477008332,
+                38.90925166413321
               ]
             }
           }
@@ -2248,8 +2970,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2268,7 +2990,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"357.0,526.7 5945.0,508.0 5945.0,7015.7 5672.1,5888.6 5756.8,4891.6 5360.8,4893.0 4311.7,4896.4 4317.7,6383.3 376.6,6383.4 357.0,526.7\" /></svg>"
+          "value": "<svg><polygon points=\"5945.0,506.8 5945.0,7027.2 5669.5,5888.1 5754.8,4890.9 5358.8,4892.1 5235.8,4447.8 367.7,4460.6 357.1,521.8 5945.0,506.8\" /></svg>"
         }
       },
       "body": {
@@ -2297,8 +3019,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01917942874321,
-                38.90992772330199
+                -77.01917977367108,
+                38.90992484110649
               ]
             }
           },
@@ -2318,8 +3040,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.015020161546,
-                38.909916155067506
+                -77.01502110917824,
+                38.909915457688555
               ]
             }
           },
@@ -2339,8 +3061,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01504100900071,
-                38.90531308572245
+                -77.01503801931025,
+                38.90531305517072
               ]
             }
           },
@@ -2360,8 +3082,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01920027619792,
-                38.90532465395694
+                -77.0191966838031,
+                38.905322438588655
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001460",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/info.json",
+          "type": "ImageService2",
+          "height": 8425,
+          "width": 5999
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1218.1,8291.8 891.7,7119.1 918.0,494.1 5044.5,499.4 5035.7,6615.5 1218.1,8291.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01565854600935,
+                38.9099037009765
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5999.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01150205504308,
+                38.90990727609775
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5999.0,
+                8425.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01149560155346,
+                38.90536399556152
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8425.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01565209251973,
+                38.905360420440275
               ]
             }
           }
@@ -2386,8 +3246,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2406,7 +3266,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4963.7,7059.0 -0.0,7076.8 -0.0,1414.5 358.4,1413.4 353.7,0.0 4267.3,0.0 4293.1,2755.6 4995.0,2459.7 4963.7,7059.0\" /></svg>"
+          "value": "<svg><polygon points=\"5012.0,2449.0 4965.8,7060.4 373.7,7072.3 366.1,4533.6 905.5,4301.4 906.8,4019.7 366.7,4051.3 360.1,1992.2 4287.1,1995.1 4297.2,2749.4 5012.0,2449.0\" /></svg>"
         }
       },
       "body": {
@@ -2435,8 +3295,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01918102556812,
-                38.906429650718565
+                -77.01918189395217,
+                38.90642065788389
               ]
             }
           },
@@ -2456,8 +3316,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01495721868756,
-                38.90641804097044
+                -77.01496462447206,
+                38.90641353941964
               ]
             }
           },
@@ -2477,8 +3337,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0149779329103,
-                38.90178957047368
+                -77.01497732528846,
+                38.90179222715825
               ]
             }
           },
@@ -2498,8 +3358,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01920173979086,
-                38.9018011802218
+                -77.01919459476856,
+                38.90179934562251
               ]
             }
           }
@@ -2524,8 +3384,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2544,7 +3404,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4935.6,169.1 5010.0,7071.4 -0.0,7116.9 -0.0,2528.2 1100.3,2170.4 1097.5,1893.0 4935.6,169.1\" /></svg>"
+          "value": "<svg><polygon points=\"4926.1,162.9 5013.5,7073.7 -0.0,7128.7 -0.0,2529.1 1285.1,2084.4 1198.9,1847.7 4926.1,162.9\" /></svg>"
         }
       },
       "body": {
@@ -2573,8 +3433,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01564945543107,
-                38.90646095647667
+                -77.01563811197099,
+                38.90646239322962
               ]
             }
           },
@@ -2594,8 +3454,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01137880357577,
-                38.90642644318631
+                -77.01137293041057,
+                38.90642168860046
               ]
             }
           },
@@ -2615,8 +3475,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01144026083243,
-                38.901755886019025
+                -77.01144541248625,
+                38.90175711412176
               ]
             }
           },
@@ -2636,8 +3496,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01571091268774,
-                38.90179039930938
+                -77.01571059404667,
+                38.901797818750914
               ]
             }
           }
@@ -2662,8 +3522,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2682,7 +3542,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5754.5,7907.7 405.2,7874.9 485.5,246.8 5828.4,302.6 5754.5,7907.7\" /></svg>"
+          "value": "<svg><polygon points=\"5752.1,7913.5 404.1,7877.4 489.0,251.3 5830.6,310.4 5752.1,7913.5\" /></svg>"
         }
       },
       "body": {
@@ -2711,8 +3571,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01927247019889,
-                38.90265400045375
+                -77.01927519710632,
+                38.90265632628498
               ]
             }
           },
@@ -2732,8 +3592,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01501451086801,
-                38.90268943369305
+                -77.0150162008727,
+                38.90269379630386
               ]
             }
           },
@@ -2753,8 +3613,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01495146597945,
-                38.89803599444749
+                -77.014949532091,
+                38.898039219377296
               ]
             }
           },
@@ -2774,8 +3634,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01920942531032,
-                38.89800056120819
+                -77.01920852832463,
+                38.89800174935842
               ]
             }
           }
@@ -2800,8 +3660,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2820,7 +3680,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"716.4,298.0 4997.9,315.8 4988.8,6594.0 5211.2,6807.7 5957.3,6822.9 5429.6,7277.7 5996.0,7600.4 5996.0,7904.8 4871.7,7942.9 5014.6,8442.0 2907.9,8442.0 2835.2,6947.1 701.1,6933.4 716.4,298.0\" /></svg>"
+          "value": "<svg><polygon points=\"696.9,8442.0 718.5,292.1 5003.9,311.2 4992.8,6595.3 5215.3,6809.2 5962.1,6824.7 5433.8,7279.8 5996.0,7599.3 5996.0,7909.0 4875.1,7945.4 5017.1,8442.0 2909.3,8442.0 696.9,8442.0\" /></svg>"
         }
       },
       "body": {
@@ -2849,8 +3709,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01568211538272,
-                38.90268485436731
+                -77.0156831170992,
+                38.90268126875264
               ]
             }
           },
@@ -2870,8 +3730,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01145994153846,
-                38.90269464940969
+                -77.01146490223556,
+                38.90269212819987
               ]
             }
           },
@@ -2891,8 +3751,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0114423409803,
-                38.89803461428406
+                -77.0114453890664,
+                38.898036462284644
               ]
             }
           },
@@ -2912,8 +3772,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01566451482454,
-                38.89802481924168
+                -77.01566360393004,
+                38.898025602837414
               ]
             }
           }
@@ -2938,8 +3798,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2958,7 +3818,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"338.9,7434.5 -0.0,7433.7 -0.0,2769.8 359.5,2770.8 367.9,972.0 5777.5,961.2 5747.9,7437.3 4293.4,7428.0 4286.5,7590.4 1173.4,7415.4 338.0,7635.3 338.9,7434.5\" /></svg>"
+          "value": "<svg><polygon points=\"346.4,7426.6 378.4,974.2 5158.0,968.8 5118.4,7429.4 4292.3,7423.4 4285.3,7585.6 346.4,7426.6\" /></svg>"
         }
       },
       "body": {
@@ -2987,8 +3847,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01918640147413,
-                38.8988507876636
+                -77.0191946718262,
+                38.89885266502961
               ]
             }
           },
@@ -3008,8 +3868,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0150429323791,
-                38.898858908384554
+                -77.01504471491626,
+                38.898863518398514
               ]
             }
           },
@@ -3029,8 +3889,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01502825183503,
-                38.89425752033382
+                -77.01502509432702,
+                38.89425492465373
               ]
             }
           },
@@ -3050,8 +3910,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01917172093007,
-                38.89424939961286
+                -77.01917505123696,
+                38.894244071284824
               ]
             }
           }
@@ -3076,8 +3936,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3096,7 +3956,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"612.2,0.0 2767.0,0.0 2850.1,1509.1 4286.8,1499.9 4351.0,5459.1 4941.0,5449.5 4942.7,7430.1 627.0,7406.6 612.2,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"4295.5,1484.0 4355.8,5449.2 4947.0,5440.2 4947.4,7426.0 -0.0,7399.0 -0.0,945.6 620.7,941.1 621.1,1506.3 4295.5,1484.0\" /></svg>"
         }
       },
       "body": {
@@ -3125,8 +3985,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01560093811818,
-                38.898859857308736
+                -77.01560265244862,
+                38.89885000627203
               ]
             }
           },
@@ -3146,8 +4006,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01141641257261,
-                38.898848516721486
+                -77.0114241678127,
+                38.89884084072391
               ]
             }
           },
@@ -3167,8 +4027,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01143689142582,
-                38.89420663997117
+                -77.01144071893515,
+                38.894205653615934
               ]
             }
           },
@@ -3188,8 +4048,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01562141697138,
-                38.89421798055842
+                -77.01561920357106,
+                38.89421481916405
               ]
             }
           }
@@ -3214,8 +4074,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3234,7 +4094,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4729.4,5897.0 4658.6,8420.0 -0.0,8420.0 -0.0,781.6 2721.0,787.4 2717.6,986.5 3299.7,793.8 3334.2,5076.3 3414.1,5105.7 3261.0,5374.2 4729.4,5897.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,785.0 3303.9,793.5 3413.5,5107.5 3260.6,5376.2 3347.4,5407.1 3375.7,8420.0 -0.0,8420.0 -0.0,785.0\" /></svg>"
         }
       },
       "body": {
@@ -3263,8 +4123,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02084484584948,
-                38.89523117904
+                -77.02084071588732,
+                38.89523288194409
               ]
             }
           },
@@ -3284,8 +4144,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01666499857151,
-                38.89524299860021
+                -77.01666217299997,
+                38.895241953947625
               ]
             }
           },
@@ -3305,8 +4165,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01664372343922,
-                38.89062072109273
+                -77.01664584342582,
+                38.890621126307536
               ]
             }
           },
@@ -3326,8 +4186,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02082357071717,
-                38.890608901532524
+                -77.02082438631317,
+                38.890612054304
               ]
             }
           }
@@ -3352,8 +4212,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3372,7 +4232,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8460.0 -0.0,7840.1 1311.3,7879.8 1403.9,5300.1 -0.0,4791.2 80.5,4489.1 -0.0,4458.7 -0.0,128.0 2085.0,139.5 3367.6,309.5 3376.0,146.8 4833.6,169.5 4763.1,2349.5 4255.2,2415.8 4756.9,2476.9 4644.2,5959.6 4722.4,6185.5 4696.2,8079.0 6085.0,8085.3 6085.0,8460.0 -0.0,8460.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,131.0 2071.5,144.2 3350.9,314.6 3359.4,152.2 4813.5,175.6 4742.1,2350.3 4235.4,2416.2 4735.8,2477.4 4621.6,5951.9 4699.5,6177.2 4671.8,8130.8 6085.0,8075.6 6085.0,8460.0 -0.0,8460.0 -0.0,131.0\" /></svg>"
         }
       },
       "body": {
@@ -3401,8 +4261,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01853210081082,
-                38.89487147735499
+                -77.01852625345893,
+                38.89487372651768
               ]
             }
           },
@@ -3422,8 +4282,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01431578424,
-                38.89491007057907
+                -77.01429989677561,
+                38.89491411349935
               ]
             }
           },
@@ -3443,8 +4303,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01424736258546,
-                38.89031764487457
+                -77.01422829498091,
+                38.89031075207169
               ]
             }
           },
@@ -3464,8 +4324,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01846367915628,
-                38.89027905165049
+                -77.01845465166423,
+                38.890270365090025
               ]
             }
           }
@@ -3490,8 +4350,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3510,7 +4370,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5186.3,1252.8 5036.3,7572.1 2881.0,8486.0 761.3,8486.0 804.6,643.6 4148.0,655.9 5186.3,1252.8\" /></svg>"
+          "value": "<svg><polygon points=\"2878.2,8486.0 762.8,8486.0 803.7,638.1 4148.7,649.4 5187.8,1246.2 5039.5,7568.6 2878.2,8486.0\" /></svg>"
         }
       },
       "body": {
@@ -3539,8 +4399,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01271309630071,
-                38.91148126750493
+                -77.0127120860094,
+                38.911478220062385
               ]
             }
           },
@@ -3560,8 +4420,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00852336781278,
-                38.911490583459646
+                -77.00852436579058,
+                38.91148655681098
               ]
             }
           },
@@ -3581,8 +4441,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00850660590584,
-                38.90686136600078
+                -77.00850936573869,
+                38.90685955828215
               ]
             }
           },
@@ -3602,8 +4462,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01269633439377,
-                38.90685205004606
+                -77.01269708595751,
+                38.90685122153356
               ]
             }
           }
@@ -3628,8 +4488,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3648,7 +4508,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"551.8,6759.6 688.5,444.5 4437.0,2442.1 6022.0,3487.6 6022.0,6986.5 888.5,6995.1 814.9,6646.2 551.8,6759.6\" /></svg>"
+          "value": "<svg><polygon points=\"947.4,7000.7 874.3,6852.1 997.0,6798.0 998.5,6598.5 613.5,6766.7 733.8,467.7 4451.0,2451.2 6022.0,3489.4 6022.0,6979.9 947.4,7000.7\" /></svg>"
         }
       },
       "body": {
@@ -3677,8 +4537,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00957929658988,
-                38.911048281556965
+                -77.00961503043283,
+                38.91106255068438
               ]
             }
           },
@@ -3698,8 +4558,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00538280419183,
-                38.9110506867528
+                -77.00537789320076,
+                38.91105706246895
               ]
             }
           },
@@ -3719,8 +4579,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00537849376481,
-                38.90643233096356
+                -77.00538779821196,
+                38.9064266518124
               ]
             }
           },
@@ -3740,8 +4600,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00957498616286,
-                38.906429925767725
+                -77.00962493544402,
+                38.90643214002783
               ]
             }
           }
@@ -3766,8 +4626,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3786,7 +4646,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"767.1,2566.9 1732.8,2146.9 1732.5,1619.0 2897.9,1618.0 4553.6,919.7 4575.3,7348.3 750.4,7316.9 767.1,2566.9\" /></svg>"
+          "value": "<svg><polygon points=\"751.9,7315.9 771.7,1625.4 2893.1,1624.6 5063.3,702.9 5174.8,7353.1 751.9,7315.9\" /></svg>"
         }
       },
       "body": {
@@ -3815,8 +4675,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01269911427737,
-                38.90773150800104
+                -77.01270140094465,
+                38.90773425994989
               ]
             }
           },
@@ -3836,8 +4696,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00854716788598,
-                38.907737971988226
+                -77.008545978091,
+                38.907741281873335
               ]
             }
           },
@@ -3857,8 +4717,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00853558503898,
-                38.90316879648971
+                -77.00853339547963,
+                38.90316827908743
               ]
             }
           },
@@ -3878,8 +4738,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01268753143037,
-                38.90316233250252
+                -77.01268881833327,
+                38.90316125716399
               ]
             }
           }
@@ -3904,8 +4764,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3924,7 +4784,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"842.5,951.5 5986.0,966.8 5986.0,3845.7 5227.4,3880.3 5212.8,6605.5 587.0,6580.1 597.0,7319.6 -0.0,7312.7 -0.0,933.7 770.7,603.0 842.5,951.5\" /></svg>"
+          "value": "<svg><polygon points=\"891.8,553.0 889.1,752.6 765.1,805.9 837.8,955.1 5953.3,966.7 5986.0,3845.9 5224.9,3881.0 5212.1,6605.2 586.2,6582.9 502.7,718.8 891.8,553.0\" /></svg>"
         }
       },
       "body": {
@@ -3953,8 +4813,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00954818765966,
-                38.90774795484451
+                -77.00954448967543,
+                38.90775024676254
               ]
             }
           },
@@ -3974,8 +4834,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00537002713502,
-                38.90776550883059
+                -77.00536642515236,
+                38.90776555765066
               ]
             }
           },
@@ -3995,8 +4855,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00533824575783,
-                38.90311978293073
+                -77.00533870488937,
+                38.903119938495635
               ]
             }
           },
@@ -4016,8 +4876,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00951640628247,
-                38.903102228944654
+                -77.00951676941244,
+                38.90310462760751
               ]
             }
           }
@@ -4042,8 +4902,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4062,7 +4922,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"653.9,7358.8 641.9,869.9 4608.4,884.0 4620.3,7350.5 653.9,7358.8\" /></svg>"
+          "value": "<svg><polygon points=\"675.7,7366.7 651.4,871.0 4621.9,877.6 4646.0,7350.8 675.7,7366.7\" /></svg>"
         }
       },
       "body": {
@@ -4091,8 +4951,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01261525553993,
-                38.90423694362677
+                -77.01262027087346,
+                38.904237742773944
               ]
             }
           },
@@ -4112,8 +4972,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00846141182059,
-                38.90423048011241
+                -77.00847077446598,
+                38.90422513209988
               ]
             }
           },
@@ -4133,8 +4993,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.008473066444,
-                38.899630092653936
+                -77.00849351328054,
+                38.89962955921706
               ]
             }
           },
@@ -4154,8 +5014,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01262691016333,
-                38.899636556168296
+                -77.01264300968802,
+                38.89964216989112
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001600",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/info.json",
+          "type": "ImageService2",
+          "height": 8110,
+          "width": 5610
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5038.1,4056.7 4791.4,4736.4 4867.1,7105.0 -0.0,7216.9 -0.0,737.9 432.4,740.2 418.3,0.0 5028.5,0.0 5038.1,4056.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00940687853799,
+                38.904151377019375
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5610.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00547773400967,
+                38.90415094786284
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5610.0,
+                8110.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00547853123506,
+                38.899731650966984
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8110.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00940767576337,
+                38.89973208012352
               ]
             }
           }
@@ -4180,8 +5178,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4200,7 +5198,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4994.5,7767.0 591.2,7738.7 583.7,8222.0 -0.0,8222.0 -0.0,2820.5 1705.6,3643.4 1703.8,3757.2 1987.7,3744.0 1108.7,3152.1 1640.1,2702.9 895.1,2680.4 687.2,2521.0 681.4,355.4 5722.0,400.9 5722.0,7454.7 4994.5,7767.0\" /></svg>"
+          "value": "<svg><polygon points=\"5001.2,7767.3 1637.1,7765.4 1633.5,7752.8 592.0,7740.4 584.8,8222.0 -0.0,8222.0 -0.0,2831.0 1696.2,3635.6 1694.4,3753.8 1989.1,3740.0 1108.7,3147.6 1640.7,2697.6 894.7,2675.3 686.5,2515.8 679.9,347.3 5022.6,400.7 4985.3,5270.8 4759.2,5222.9 5017.0,5395.6 5001.2,7767.3\" /></svg>"
         }
       },
       "body": {
@@ -4229,8 +5227,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01265355038198,
-                38.900410025125055
+                -77.01265175545632,
+                38.900405444224226
               ]
             }
           },
@@ -4250,8 +5248,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00861965156737,
-                38.900450359569895
+                -77.00862318269624,
+                38.90044469546709
               ]
             }
           },
@@ -4271,8 +5269,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00854571126757,
-                38.89590794435361
+                -77.00855122809189,
+                38.89590827826766
               ]
             }
           },
@@ -4292,8 +5290,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01257961008218,
-                38.89586760990877
+                -77.01257980085197,
+                38.8958690270248
               ]
             }
           }
@@ -4318,8 +5316,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4338,7 +5336,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5089.5,236.3 5248.1,4081.6 6042.0,4300.8 6042.0,7406.4 5542.9,8048.2 4389.1,8090.5 3482.9,7604.8 3082.8,7681.1 2958.1,7465.7 1772.5,7456.9 1580.9,7542.5 1470.7,339.3 5089.5,236.3\" /></svg>"
+          "value": "<svg><polygon points=\"768.0,5329.7 752.6,357.9 5265.7,253.6 5283.2,4115.4 6042.0,4328.2 6042.0,7414.1 1742.5,7466.2 811.5,7878.0 801.7,5456.7 536.7,5283.3 768.0,5329.7\" /></svg>"
         }
       },
       "body": {
@@ -4367,8 +5365,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00963093825075,
-                38.90041443580833
+                -77.00963172604797,
+                38.90041157656531
               ]
             }
           },
@@ -4388,8 +5386,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00545902903497,
-                38.90040612211054
+                -77.00546353754294,
+                38.900417106656946
               ]
             }
           },
@@ -4409,8 +5407,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00547391885594,
-                38.895816340570086
+                -77.0054536331592,
+                38.895831417325255
               ]
             }
           },
@@ -4430,8 +5428,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00964582807173,
-                38.89582465426788
+                -77.00962182166424,
+                38.89582588723362
               ]
             }
           }
@@ -4456,8 +5454,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4476,7 +5474,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1594.7,5170.4 762.7,4929.1 775.8,443.4 4644.2,430.9 4546.4,7927.4 5967.0,7988.7 5967.0,8503.0 759.6,8503.0 762.0,5214.2 1594.7,5170.4\" /></svg>"
+          "value": "<svg><polygon points=\"5967.0,8503.0 740.8,8503.0 745.2,5217.7 1580.6,5174.3 746.1,4931.7 762.0,432.0 5266.2,420.2 5297.6,2303.3 4602.5,2939.0 4544.1,7941.7 5967.0,8004.3 5967.0,8503.0\" /></svg>"
         }
       },
       "body": {
@@ -4505,8 +5503,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01270455377433,
-                38.896377790297
+                -77.01269354366119,
+                38.89637067182612
               ]
             }
           },
@@ -4526,8 +5524,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00857887471734,
-                38.89638776378816
+                -77.00858070414499,
+                38.89638261526957
               ]
             }
           },
@@ -4547,8 +5545,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00856074300488,
-                38.89177997356974
+                -77.00855899106875,
+                38.89178916691214
               ]
             }
           },
@@ -4568,8 +5566,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01268642206186,
-                38.89177000007858
+                -77.01267183058495,
+                38.89177722346869
               ]
             }
           }
@@ -4594,8 +5592,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4614,7 +5612,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7875.9 -0.0,429.2 617.3,419.2 1536.0,0.0 2711.6,0.0 2836.9,212.7 3233.1,134.1 3984.8,579.9 5279.1,558.6 5227.4,7948.3 4642.4,8456.0 1417.9,8429.2 1411.3,7918.4 -0.0,7875.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,2917.1 675.5,2283.3 620.7,418.0 1539.3,0.0 5715.8,0.0 5747.2,375.3 5994.0,720.3 5285.5,562.1 5233.8,838.3 5226.6,7956.9 4652.1,8456.0 1416.4,8417.4 1410.2,7923.3 -0.0,7879.2 -0.0,2917.1\" /></svg>"
         }
       },
       "body": {
@@ -4643,8 +5641,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0094895745568,
-                38.896386236232864
+                -77.0094919515757,
+                38.896385142838945
               ]
             }
           },
@@ -4664,8 +5662,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00531613433495,
-                38.89635365790293
+                -77.00532134547183,
+                38.89635577945465
               ]
             }
           },
@@ -4685,8 +5683,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00537475205057,
-                38.89174047339165
+                -77.00537417851992,
+                38.89174572222585
               ]
             }
           },
@@ -4706,8 +5704,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00954819227242,
-                38.89177305172159
+                -77.00954478462378,
+                38.89177508561014
               ]
             }
           }
@@ -4732,8 +5730,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4752,7 +5750,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"700.2,6303.2 797.5,2810.7 294.3,2751.7 803.2,2682.9 864.1,496.9 5218.7,567.1 5211.5,2563.8 5973.0,2794.3 5209.6,2849.1 5193.8,6140.8 5973.0,6144.0 5973.0,8428.0 761.8,8428.0 700.2,6303.2\" /></svg>"
+          "value": "<svg><polygon points=\"684.5,6295.4 787.9,2798.2 284.0,2738.2 793.8,2670.3 858.5,481.3 5219.1,558.9 5208.5,2558.4 5973.0,2817.3 5206.1,2844.2 5184.7,6126.7 5973.0,6130.7 5973.0,8428.0 742.6,8428.0 684.5,6295.4\" /></svg>"
         }
       },
       "body": {
@@ -4781,8 +5779,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01578115418762,
-                38.8950757643487
+                -77.01577692650287,
+                38.89506618510666
               ]
             }
           },
@@ -4802,8 +5800,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01165319790445,
-                38.89509905483603
+                -77.01165481009492,
+                38.8950949195234
               ]
             }
           },
@@ -4823,8 +5821,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01161129131106,
-                38.89053596327639
+                -77.01160310853598,
+                38.89053825688495
               ]
             }
           },
@@ -4844,8 +5842,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01573924759423,
-                38.89051267278906
+                -77.01572522494392,
+                38.89050952246821
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001660",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/info.json",
+          "type": "ImageService2",
+          "height": 8479,
+          "width": 6029
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8271.9 -0.0,0.0 6029.0,-0.0 6029.0,8158.4 5333.4,8159.3 4957.5,8276.5 -0.0,8271.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0033664,
+                38.9165978
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6029.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0033604,
+                38.913301
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6029.0,
+                8479.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0093172,
+                38.9132944
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8479.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0093232,
+                38.9165912
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001670",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/info.json",
+          "type": "ImageService2",
+          "height": 8421,
+          "width": 6002
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4898.1,7706.8 2310.3,7697.6 2331.6,-0.0 6002.0,-0.0 6002.0,1605.8 4926.4,1367.4 4898.1,7706.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.003621731686,
+                38.9145915990426
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6002.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00360378896389,
+                38.91126866506195
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6002.0,
+                8421.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00959568892864,
+                38.91124907657738
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8421.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00961363165075,
+                38.91457201055803
               ]
             }
           }
@@ -4870,8 +6144,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4890,7 +6164,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8380.0 -0.0,7760.5 697.0,7755.3 658.6,1376.2 1735.3,1604.8 1718.5,-0.0 5969.0,-0.0 5969.0,2475.4 5587.1,2431.1 4543.0,4047.5 2250.6,8380.0 -0.0,8380.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8380.0 -0.0,7734.0 667.7,7732.0 656.7,1343.7 1741.5,1577.3 1731.8,-0.0 5969.0,-0.0 5969.0,2469.7 5558.2,2538.1 4562.5,4035.5 2222.7,8380.0 -0.0,8380.0\" /></svg>"
         }
       },
       "body": {
@@ -4919,8 +6193,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00360398961335,
-                38.91222133233795
+                -77.00363027233952,
+                38.91222055275857
               ]
             }
           },
@@ -4940,8 +6214,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00363047240461,
-                38.90891231414577
+                -77.00363857764232,
+                38.9089393518352
               ]
             }
           },
@@ -4961,8 +6235,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00955588885604,
-                38.90894143421965
+                -77.00955573191534,
+                38.90894842009267
               ]
             }
           },
@@ -4982,8 +6256,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00952940606479,
-                38.912250452411826
+                -77.00954742661254,
+                38.91222962101604
               ]
             }
           }
@@ -5008,8 +6282,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5028,7 +6302,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7813.7 200.6,7041.6 133.0,358.3 881.9,310.4 876.3,0.0 5571.7,0.0 5675.7,7520.0 -0.0,7813.7\" /></svg>"
+          "value": "<svg><polygon points=\"5668.1,7670.0 61.2,7776.2 74.0,8446.0 -0.0,8446.0 -0.0,7708.6 184.0,7384.5 238.7,6913.7 141.1,371.5 890.3,323.8 884.7,0.0 5563.6,0.0 5668.1,7670.0\" /></svg>"
         }
       },
       "body": {
@@ -5057,8 +6331,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00597563255583,
-                38.90584022457256
+                -77.00598160295326,
+                38.90584815991865
               ]
             }
           },
@@ -5078,8 +6352,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00174613045785,
-                38.905797174752024
+                -77.00173934660577,
+                38.90580559157777
               ]
             }
           },
@@ -5099,8 +6373,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00182357772886,
-                38.90112392844093
+                -77.00181592763526,
+                38.90111824967897
               ]
             }
           },
@@ -5120,8 +6394,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00605307982684,
-                38.901166978261465
+                -77.00605818398274,
+                38.901160818019854
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001700",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/info.json",
+          "type": "ImageService2",
+          "height": 8452,
+          "width": 6013
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"365.0,8249.0 359.4,20.4 5498.4,76.5 5492.0,8255.1 365.0,8249.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00229230153036,
+                38.90581972326121
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6013.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99808189519791,
+                38.90582012009498
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6013.0,
+                8452.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99808117878435,
+                38.90121678958707
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8452.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0022915851168,
+                38.9012163927533
               ]
             }
           }
@@ -5146,8 +6558,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5166,7 +6578,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"411.2,244.3 2019.4,229.8 2287.4,93.1 2634.9,276.7 2643.3,0.0 5928.0,0.0 5928.0,8145.6 477.6,8196.8 411.2,244.3\" /></svg>"
+          "value": "<svg><polygon points=\"5466.2,8182.8 476.9,8194.8 468.7,0.0 5928.0,0.0 5928.0,323.1 4981.1,316.6 4972.8,1546.1 5316.5,1733.1 5540.2,1844.1 5450.5,2146.8 5466.2,8182.8\" /></svg>"
         }
       },
       "body": {
@@ -5195,8 +6607,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99872662847565,
-                38.9057805430881
+                -76.9987696089493,
+                38.90577885179218
               ]
             }
           },
@@ -5216,8 +6628,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99461613826227,
-                38.905751903318794
+                -76.99462899123051,
+                38.90577352154391
               ]
             }
           },
@@ -5237,8 +6649,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99466816884433,
-                38.901165492502834
+                -76.99463874300093,
+                38.90118579409561
               ]
             }
           },
@@ -5258,8 +6670,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9987786590577,
-                38.90119413227213
+                -76.99877936071972,
+                38.90119112434388
               ]
             }
           }
@@ -5284,8 +6696,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5304,7 +6716,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"974.8,0.0 5982.0,0.0 5982.0,7809.7 950.9,7830.0 974.8,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"540.4,7845.6 483.9,1823.0 572.0,1520.3 -0.0,1226.8 -0.0,-0.0 5982.0,0.0 5982.0,7809.7 540.4,7845.6\" /></svg>"
         }
       },
       "body": {
@@ -5333,8 +6745,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99529555407516,
-                38.905592808280694
+                -76.99529076997638,
+                38.905602273051784
               ]
             }
           },
@@ -5354,8 +6766,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99113759347469,
-                38.90557380469308
+                -76.99113184416126,
+                38.90557481832205
               ]
             }
           },
@@ -5375,8 +6787,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99117194025739,
-                38.90095819973377
+                -76.99118146539841,
+                38.900958141382795
               ]
             }
           },
@@ -5396,8 +6808,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99532990085785,
-                38.90097720332139
+                -76.99534039121353,
+                38.90098559611253
               ]
             }
           }
@@ -5422,8 +6834,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5442,7 +6854,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5195.8,7079.9 -0.0,7041.6 -0.0,0.0 4784.2,-0.0 4779.9,368.9 5323.1,675.3 5193.0,910.1 5195.8,7079.9\" /></svg>"
+          "value": "<svg><polygon points=\"5193.0,7089.3 -0.0,7035.9 -0.0,0.0 4799.1,-0.0 4796.5,379.7 5322.3,676.5 5192.2,911.1 5193.0,7089.3\" /></svg>"
         }
       },
       "body": {
@@ -5471,8 +6883,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98620099762361,
-                38.904187511568495
+                -76.98620117599134,
+                38.90418879460635
               ]
             }
           },
@@ -5492,8 +6904,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98619452614918,
-                38.90087160970325
+                -76.98619328901364,
+                38.9008710825333
               ]
             }
           },
@@ -5513,8 +6925,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99211405936305,
-                38.90086451398153
+                -76.9921160538024,
+                38.90086243476694
               ]
             }
           },
@@ -5534,8 +6946,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9921205308375,
-                38.904180415846774
+                -76.9921239407801,
+                38.90418014683999
               ]
             }
           }
@@ -5560,8 +6972,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5580,7 +6992,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5983.0,8432.0 -0.0,8432.0 -0.0,-0.0 5983.0,0.0 5983.0,8432.0\" /></svg>"
+          "value": "<svg><polygon points=\"5983.0,8432.0 -0.0,8432.0 0.0,-0.0 5983.0,0.0 5983.0,8432.0\" /></svg>"
         }
       },
       "body": {
@@ -5609,8 +7021,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98141083365653,
-                38.909083346019365
+                -76.98141295625561,
+                38.90908024811756
               ]
             }
           },
@@ -5630,8 +7042,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9776969002807,
-                38.907558982452244
+                -76.97770229153349,
+                38.90755513453055
               ]
             }
           },
@@ -5651,8 +7063,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98043782705619,
-                38.903457855042724
+                -76.98044456764597,
+                38.903457617654574
               ]
             }
           },
@@ -5672,8 +7084,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98415176043201,
-                38.904982218609845
+                -76.9841552323681,
+                38.90498273124158
               ]
             }
           }
@@ -5698,8 +7110,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5718,7 +7130,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"116.2,0.0 5882.7,0.0 5861.3,563.9 5497.5,550.2 5215.3,7773.2 1805.6,7674.5 1483.4,8489.0 676.2,8489.0 768.5,6253.0 -0.0,6006.3 -0.0,187.3 116.2,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 5671.2,0.0 5620.8,7736.3 1823.8,7745.4 1552.4,8489.0 736.6,8489.0 746.3,6343.4 -0.0,6129.0 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -5747,8 +7159,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00617809275136,
-                38.9015128669894
+                -77.00600872774797,
+                38.90153209961109
               ]
             }
           },
@@ -5768,8 +7180,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00195302405653,
-                38.90164108739326
+                -77.00180521159106,
+                38.90155233194322
               ]
             }
           },
@@ -5789,8 +7201,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00172162759435,
-                38.89695756281122
+                -77.00176843509472,
+                38.896926105161405
               ]
             }
           },
@@ -5810,8 +7222,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00594669628917,
-                38.896829342407365
+                -77.00597195125162,
+                38.89690587282927
               ]
             }
           }
@@ -5836,8 +7248,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5856,7 +7268,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5534.4,444.5 5526.3,7758.6 -0.0,7771.9 -0.0,441.4 5534.4,444.5\" /></svg>"
+          "value": "<svg><polygon points=\"364.0,444.9 5043.3,442.7 5030.4,7755.4 372.1,7702.3 364.0,444.9\" /></svg>"
         }
       },
       "body": {
@@ -5885,8 +7297,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00229242620617,
-                38.901567044101824
+                -77.00228833820448,
+                38.90156935762518
               ]
             }
           },
@@ -5906,8 +7318,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99812161647537,
-                38.901565913187035
+                -76.99812012728567,
+                38.90156437759299
               ]
             }
           },
@@ -5927,8 +7339,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99812365260425,
-                38.89695342224207
+                -76.99812909344313,
+                38.89695474828334
               ]
             }
           },
@@ -5948,8 +7360,422 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00229446233503,
-                38.89695455315685
+                -77.00229730436193,
+                38.89695972831553
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001770",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/info.json",
+          "type": "ImageService2",
+          "height": 8438,
+          "width": 5946
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5509.8,7707.9 -0.0,7703.0 -0.0,361.8 5491.5,340.7 5509.8,7707.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9987849714583,
+                38.901520364452814
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5946.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99464367645828,
+                38.90150984664793
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5946.0,
+                8438.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99466285319052,
+                38.896936547111025
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8438.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99880414819054,
+                38.896947064915906
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001780",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/info.json",
+          "type": "ImageService2",
+          "height": 8476,
+          "width": 5996
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5417.0,418.2 5422.2,8476.0 502.8,8476.0 502.5,410.9 5417.0,418.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9953118700174,
+                38.90154963759402
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5996.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9911222321004,
+                38.90154719821241
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5996.0,
+                8476.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99112666298025,
+                38.896938005042934
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8476.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99531630089726,
+                38.896940444424544
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001790",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/info.json",
+          "type": "ImageService2",
+          "height": 8464,
+          "width": 6032
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4419.8,7717.2 5299.5,7720.5 5296.6,8464.0 713.2,8464.0 743.5,415.1 4483.9,428.9 4419.8,7717.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99205066826316,
+                38.90154556133347
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6032.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98781095258384,
+                38.901557611808755
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6032.0,
+                8464.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98778922556255,
+                38.89692773576993
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8464.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99202894124187,
+                38.896915685294644
               ]
             }
           }
@@ -5974,8 +7800,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5994,7 +7820,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7796.4 -0.0,468.5 2958.6,424.6 3197.8,553.3 3501.3,0.0 5976.0,0.0 5976.0,515.4 5359.3,1648.5 4660.4,1327.9 4887.1,1695.2 4949.4,7747.5 -0.0,7796.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7825.5 -0.0,436.8 2975.5,407.8 3214.3,538.9 3511.4,0.0 5976.0,0.0 5976.0,552.0 5372.9,1654.4 4674.8,1327.6 4899.9,1699.1 4931.5,7802.0 -0.0,7825.5\" /></svg>"
         }
       },
       "body": {
@@ -6023,8 +7849,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98888563585743,
-                38.90157481721771
+                -76.9888964228355,
+                38.90155562090117
               ]
             }
           },
@@ -6044,8 +7870,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98473711716994,
-                38.901541438676155
+                -76.98475295251819,
+                38.901539037366256
               ]
             }
           },
@@ -6065,8 +7891,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98479763633908,
-                38.896921180505565
+                -76.98478323275644,
+                38.896956765556666
               ]
             }
           },
@@ -6086,8 +7912,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98894615502657,
-                38.89695455904712
+                -76.98892670307374,
+                38.89697334909158
               ]
             }
           }
@@ -6112,8 +7938,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6132,7 +7958,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4244.2,7767.5 1105.9,7752.5 736.7,7972.3 1067.0,7281.7 -0.0,6677.9 -0.0,0.0 5619.3,-0.0 4459.5,5002.8 4254.0,5316.6 4244.2,7767.5\" /></svg>"
+          "value": "<svg><polygon points=\"4236.4,7769.4 1099.4,7753.5 730.3,7973.1 1060.7,7282.8 -0.0,6682.3 -0.0,0.0 5614.5,-0.0 4452.5,5005.9 4246.9,5319.4 4236.4,7769.4\" /></svg>"
         }
       },
       "body": {
@@ -6161,8 +7987,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98010486278679,
-                38.901255189050005
+                -76.9801021844211,
+                38.90125310948875
               ]
             }
           },
@@ -6182,8 +8008,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98007972607932,
-                38.8979833061705
+                -76.9800758454315,
+                38.89797990298814
               ]
             }
           },
@@ -6203,8 +8029,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98598622954901,
-                38.897955433152994
+                -76.98598474031054,
+                38.89795069682123
               ]
             }
           },
@@ -6224,8 +8050,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98601136625648,
-                38.9012273160325
+                -76.98601107930014,
+                38.90122390332184
               ]
             }
           }
@@ -6250,8 +8076,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6270,7 +8096,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5847.6,2987.1 5847.9,3061.4 4850.5,3064.9 4852.1,5108.7 3940.4,5111.9 3347.8,5121.1 3307.8,5121.9 3308.0,5351.6 3646.6,5573.1 3648.8,7772.7 771.7,7779.1 758.3,5336.8 960.1,5022.3 2074.4,-0.0 4574.6,-0.0 5098.1,336.8 6019.0,325.1 6019.0,2424.0 5846.2,2424.2 5847.6,2987.1\" /></svg>"
+          "value": "<svg><polygon points=\"5851.7,2423.3 5853.3,3060.6 4855.7,3064.0 4857.2,5108.2 3945.3,5111.2 3352.6,5120.4 3312.5,5121.2 3312.7,5350.9 3493.1,5471.4 3651.4,5572.5 3653.3,7772.5 775.8,7778.5 762.6,5335.8 964.6,5021.3 2079.2,-0.0 4583.3,-0.0 5126.1,354.1 6019.0,323.9 6019.0,2423.2 5851.7,2423.3\" /></svg>"
         }
       },
       "body": {
@@ -6299,8 +8125,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98005772858085,
-                38.89931811244047
+                -76.9800590633075,
+                38.899320774385224
               ]
             }
           },
@@ -6320,8 +8146,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98007244658592,
-                38.89601729995289
+                -76.98007329309216,
+                38.896020480086975
               ]
             }
           },
@@ -6341,8 +8167,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98604411878296,
-                38.89603365642631
+                -76.98604401888063,
+                38.896036294012944
               ]
             }
           },
@@ -6362,8 +8188,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98602940077788,
-                38.8993344689139
+                -76.98602978909597,
+                38.89933658831119
               ]
             }
           }
@@ -6388,8 +8214,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6408,7 +8234,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"294.4,2976.2 785.4,2336.6 780.1,1521.9 1583.9,1483.5 1845.9,644.7 5703.0,577.2 5766.5,7443.0 225.9,7442.3 294.4,2976.2\" /></svg>"
+          "value": "<svg><polygon points=\"287.4,2969.2 995.7,3128.3 749.4,2783.0 718.4,2407.8 716.1,2379.8 1486.2,1774.4 1842.7,638.7 5701.7,576.0 5756.4,7445.1 213.2,7437.4 287.4,2969.2\" /></svg>"
         }
       },
       "body": {
@@ -6437,8 +8263,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00600405450953,
-                38.89767791726559
+                -77.00600177906793,
+                38.897673157599364
               ]
             }
           },
@@ -6458,8 +8284,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0018610860288,
-                38.89764866923376
+                -77.00186076740958,
+                38.89764804422344
               ]
             }
           },
@@ -6479,8 +8305,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00191420209518,
-                38.89302668542203
+                -77.00190637430717,
+                38.89302820278852
               ]
             }
           },
@@ -6500,8 +8326,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00605717057591,
-                38.893055933453866
+                -77.00604738596552,
+                38.89305331616445
               ]
             }
           }
@@ -6526,8 +8352,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6546,7 +8372,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"278.5,640.0 5462.2,541.0 5583.8,8481.0 410.3,8481.0 278.5,640.0\" /></svg>"
+          "value": "<svg><polygon points=\"5556.7,7002.7 381.1,7105.4 271.0,554.3 5458.0,535.2 5556.7,7002.7\" /></svg>"
         }
       },
       "body": {
@@ -6575,8 +8401,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00222313698765,
-                38.89768425866591
+                -77.00221885982015,
+                38.897680835304676
               ]
             }
           },
@@ -6596,8 +8422,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99807952514801,
-                38.89763023458614
+                -76.99807690007688,
+                38.897626977121845
               ]
             }
           },
@@ -6617,8 +8443,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99817705316177,
-                38.893034921190164
+                -76.99817412848752,
+                38.89303349051319
               ]
             }
           },
@@ -6638,8 +8464,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0023206650014,
-                38.89308894526994
+                -77.00231608823078,
+                38.89308734869602
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001850",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/info.json",
+          "type": "ImageService2",
+          "height": 8492,
+          "width": 5995
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5456.0,7565.6 469.9,7557.3 493.7,694.5 5453.5,709.3 5456.0,7565.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99880051303101,
+                38.89772206144639
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5995.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9945839770359,
+                38.897721140684716
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5995.0,
+                8492.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99458565257567,
+                38.89307336638256
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8492.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99880218857078,
+                38.89307428714423
               ]
             }
           }
@@ -6664,8 +8628,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6684,7 +8648,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"454.0,7575.9 470.8,683.9 5421.7,700.1 5418.9,1440.2 5743.3,1440.8 5429.9,1602.3 5395.6,7597.8 454.0,7575.9\" /></svg>"
+          "value": "<svg><polygon points=\"473.0,1407.2 5415.4,1426.7 5387.0,8429.0 451.8,8429.0 473.0,1407.2\" /></svg>"
         }
       },
       "body": {
@@ -6713,8 +8677,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99529316407072,
-                38.897704728022156
+                -76.99529703516752,
+                38.89770673771238
               ]
             }
           },
@@ -6734,8 +8698,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99112662866729,
-                38.8977129992741
+                -76.99112426772197,
+                38.89771721480404
               ]
             }
           },
@@ -6755,8 +8719,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99111179825792,
-                38.89312364185678
+                -76.99110548220901,
+                38.893120997417874
               ]
             }
           },
@@ -6776,8 +8740,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99527833366135,
-                38.89311537060484
+                -76.99527824965456,
+                38.89311052032622
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001870",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/info.json",
+          "type": "ImageService2",
+          "height": 8444,
+          "width": 5999
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5290.1,1212.5 5276.3,7363.2 669.3,7353.3 689.3,1181.4 5290.1,1212.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9920118822712,
+                38.89758118892412
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5999.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9878114481178,
+                38.89758770122513
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5999.0,
+                8444.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98779967229993,
+                38.89298692070773
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8444.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99200010645333,
+                38.89298040840672
               ]
             }
           }
@@ -6802,8 +8904,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6822,7 +8924,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4916.0,466.2 4912.6,3855.8 4060.2,5156.9 4914.9,5159.2 4916.3,8452.0 883.2,8452.0 878.6,462.2 4916.0,466.2\" /></svg>"
+          "value": "<svg><polygon points=\"881.1,7363.8 895.3,482.0 6026.0,496.0 6026.0,7372.8 881.1,7363.8\" /></svg>"
         }
       },
       "body": {
@@ -6851,8 +8953,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98891570597144,
-                38.89758401219314
+                -76.9889350135328,
+                38.897595313424056
               ]
             }
           },
@@ -6872,8 +8974,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.984735093304,
-                38.89758575530241
+                -76.98470556008624,
+                38.89760130547764
               ]
             }
           },
@@ -6893,8 +8995,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98473197500824,
-                38.89299145129058
+                -76.98469476511326,
+                38.89298588930302
               ]
             }
           },
@@ -6914,8 +9016,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98891258767569,
-                38.892989708181304
+                -76.98892421855982,
+                38.89297989724943
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001890",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/info.json",
+          "type": "ImageService2",
+          "height": 8478,
+          "width": 6021
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2773.7,7254.4 1836.3,7259.0 1806.2,341.9 2865.3,341.8 3087.7,0.0 3318.1,0.0 3329.9,1560.1 5379.4,1560.4 5382.0,2568.0 6021.0,2566.9 6021.0,7721.2 4194.9,7744.5 2773.7,7254.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98596452323086,
+                38.89751853757792
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6021.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98176358785065,
+                38.89751023008238
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6021.0,
+                8478.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98177861366568,
+                38.89290766585427
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8478.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9859795490459,
+                38.89291597334981
               ]
             }
           }
@@ -6940,8 +9180,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6960,7 +9200,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"605.6,8398.0 597.1,3823.1 1671.0,3246.4 599.3,3404.8 608.7,542.4 2805.7,546.2 4094.9,1025.1 5909.3,1007.2 5912.1,0.0 6024.0,0.0 6024.0,8398.0 605.6,8398.0\" /></svg>"
+          "value": "<svg><polygon points=\"595.8,8398.0 595.8,8398.0 -0.0,8398.0 -0.0,533.3 2813.0,544.6 4099.6,1026.2 6024.0,1004.6 6024.0,8398.0 595.8,8398.0\" /></svg>"
         }
       },
       "body": {
@@ -6989,8 +9229,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98592711987592,
-                38.89387226048715
+                -76.98593549332159,
+                38.89386782085662
               ]
             }
           },
@@ -7010,8 +9250,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98169691478662,
-                38.89387304647652
+                -76.98170045409438,
+                38.893876936987766
               ]
             }
           },
@@ -7031,8 +9271,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.981695516519,
-                38.88924948710331
+                -76.98168423658362,
+                38.88924809396825
               ]
             }
           },
@@ -7052,8 +9292,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9859257216083,
-                38.889248701113935
+                -76.98591927581083,
+                38.8892389778371
               ]
             }
           }
@@ -7078,8 +9318,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7098,7 +9338,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5773.6,476.2 5736.4,7237.3 272.5,7214.2 264.7,8417.0 -0.0,8417.0 -0.0,3547.8 326.1,3256.2 357.3,398.3 5773.6,476.2\" /></svg>"
+          "value": "<svg><polygon points=\"5775.2,472.1 5737.3,7234.6 272.2,7210.9 264.3,8417.0 -0.0,8417.0 -0.0,3543.7 326.3,3252.1 357.7,393.6 5775.2,472.1\" /></svg>"
         }
       },
       "body": {
@@ -7127,8 +9367,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.006149360721,
-                38.89383784875631
+                -77.00614962259426,
+                38.89383514905823
               ]
             }
           },
@@ -7148,8 +9388,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00188177201103,
-                38.89385542029128
+                -77.00188296600317,
+                38.89385304903673
               ]
             }
           },
@@ -7169,8 +9409,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00185029139149,
-                38.88915810272019
+                -77.00185089722122,
+                38.88915671836304
               ]
             }
           },
@@ -7190,8 +9430,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00611788010146,
-                38.88914053118523
+                -77.00611755381232,
+                38.889138818384545
               ]
             }
           }
@@ -7216,8 +9456,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7236,7 +9476,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"396.2,1363.8 5001.5,1450.4 5023.9,7358.2 381.6,7347.2 396.2,1363.8\" /></svg>"
+          "value": "<svg><polygon points=\"399.4,0.0 5531.3,0.0 5528.5,1214.8 5528.2,1320.5 5514.1,7361.6 374.0,7344.1 399.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -7265,8 +9505,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00231531291814,
-                38.8938299755498
+                -77.00231539153447,
+                38.89382829198903
               ]
             }
           },
@@ -7286,8 +9526,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99815304626183,
-                38.893837107971834
+                -76.99815288387813,
+                38.89383885247203
               ]
             }
           },
@@ -7307,8 +9547,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99814021070652,
-                38.889235078573634
+                -76.99813387915844,
+                38.88923655721509
               ]
             }
           },
@@ -7328,8 +9568,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00230247736283,
-                38.8892279461516
+                -77.00229638681478,
+                38.889225996732094
               ]
             }
           }
@@ -7354,8 +9594,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7374,7 +9614,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7333.7 -0.0,1398.0 522.8,1462.9 524.6,1214.3 511.0,1206.3 513.3,465.7 5522.8,505.3 5508.4,3371.5 5081.1,3366.1 5078.3,3645.0 5509.8,3876.3 5480.6,7370.4 -0.0,7333.7\" /></svg>"
+          "value": "<svg><polygon points=\"5510.5,3877.6 5482.4,7371.2 498.5,7339.1 523.9,1403.2 1148.2,1583.3 511.7,1209.5 513.7,469.0 5522.5,507.1 5509.0,3372.9 5066.9,3367.5 5065.2,3639.2 5510.5,3877.6\" /></svg>"
         }
       },
       "body": {
@@ -7403,8 +9643,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99883273671377,
-                38.89383965899518
+                -76.99883304255049,
+                38.89384160526684
               ]
             }
           },
@@ -7424,8 +9664,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9946410732479,
-                38.89385928963182
+                -76.99464073370312,
+                38.89386027842002
               ]
             }
           },
@@ -7445,8 +9685,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99460594058094,
-                38.88925031135061
+                -76.99460731463049,
+                38.88925059050423
               ]
             }
           },
@@ -7466,8 +9706,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9987976040468,
-                38.889230680713965
+                -76.99879962347785,
+                38.889231917351054
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001940",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/info.json",
+          "type": "ImageService2",
+          "height": 8424,
+          "width": 5979
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"446.8,3899.8 -0.0,3662.2 -0.0,3388.5 442.2,3391.3 439.5,1365.0 5342.9,1347.3 5360.0,6434.4 5979.0,6429.5 5979.0,8424.0 5362.5,8424.0 5363.7,7718.8 5185.5,7480.4 4911.1,7424.0 439.9,7420.0 446.8,3899.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99527131869259,
+                38.8938549501049
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5979.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99108622147037,
+                38.89385368621601
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5979.0,
+                8424.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99108850898632,
+                38.889265039060696
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8424.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99527360620854,
+                38.889266302949586
               ]
             }
           }
@@ -7492,8 +9870,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7512,7 +9890,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5304.3,504.3 5325.8,2677.8 5097.7,3371.0 5346.6,3374.2 5312.7,5890.2 4478.8,6379.0 691.3,6409.3 674.3,503.7 5304.3,504.3\" /></svg>"
+          "value": "<svg><polygon points=\"671.2,482.4 5312.8,489.7 5331.2,2684.1 5101.5,3383.6 5351.0,3387.1 5313.3,5927.2 4490.6,6421.4 679.7,6445.1 671.2,482.4\" /></svg>"
         }
       },
       "body": {
@@ -7541,8 +9919,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99200279416698,
-                38.89385056772768
+                -76.99199997674961,
+                38.893835914156796
               ]
             }
           },
@@ -7562,8 +9940,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98783922839003,
-                38.89385048336633
+                -76.98784678722994,
+                38.89384048096903
               ]
             }
           },
@@ -7583,8 +9961,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98783938032194,
-                38.88924355022594
+                -76.9878385044724,
+                38.88927725556334
               ]
             }
           },
@@ -7604,8 +9982,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99200294609889,
-                38.88924363458729
+                -76.99199169399208,
+                38.889272688751106
               ]
             }
           }
@@ -7630,8 +10008,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7650,7 +10028,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"781.5,6416.6 41.3,6312.4 915.4,5833.5 953.4,3329.4 705.8,3325.9 933.9,2636.4 924.9,1539.0 4921.3,1543.5 4912.8,3353.2 5988.0,3195.8 4910.0,3772.7 4912.0,8361.3 892.4,8434.0 892.9,6741.6 781.5,6416.6\" /></svg>"
+          "value": "<svg><polygon points=\"871.0,6773.0 759.2,6445.5 18.4,6341.1 892.8,5857.7 928.8,3334.0 680.9,3330.7 908.6,2635.5 889.1,455.3 4280.8,460.1 4295.9,8419.5 4894.7,8418.3 4894.7,8434.0 871.4,8434.0 871.0,6773.0\" /></svg>"
         }
       },
       "body": {
@@ -7679,8 +10057,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98894918811386,
-                38.89383388113528
+                -76.98892944920796,
+                38.893822586404326
               ]
             }
           },
@@ -7700,8 +10078,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9847568582434,
-                38.893839345133706
+                -76.98474040769844,
+                38.893825267700045
               ]
             }
           },
@@ -7721,8 +10099,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.984747037493,
-                38.88920987914026
+                -76.98473555445801,
+                38.88923183740503
               ]
             }
           },
@@ -7742,8 +10120,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98893936736346,
-                38.88920441514183
+                -76.98892459596753,
+                38.88922915610931
               ]
             }
           }
@@ -7768,8 +10146,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7788,7 +10166,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5775.3,7858.8 316.9,7841.1 296.7,4900.9 -0.0,4902.0 -0.0,2227.5 265.3,2226.8 270.0,1010.4 5796.9,1019.2 5775.3,7858.8\" /></svg>"
+          "value": "<svg><polygon points=\"5779.7,7852.1 321.8,7828.5 304.8,4887.5 -0.0,4887.8 9.0,2218.2 276.3,2217.8 282.2,998.4 5808.6,1013.2 5779.7,7852.1\" /></svg>"
         }
       },
       "body": {
@@ -7817,8 +10195,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00612029049995,
-                38.89036981285591
+                -77.00612967319522,
+                38.89036305664479
               ]
             }
           },
@@ -7838,8 +10216,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00193710492518,
-                38.890378386736955
+                -77.00194611184689,
+                38.89037514134602
               ]
             }
           },
@@ -7859,8 +10237,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00192164019853,
-                38.88574224373779
+                -77.00192431467174,
+                38.88573857656898
               ]
             }
           },
@@ -7880,8 +10258,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0061048257733,
-                38.88573366985674
+                -77.00610787602007,
+                38.88572649186775
               ]
             }
           }
@@ -7906,8 +10284,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7926,7 +10304,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"416.2,6188.2 411.8,997.4 5578.7,989.2 5589.7,7135.2 2543.7,7933.5 420.3,7944.2 416.2,6188.2\" /></svg>"
+          "value": "<svg><polygon points=\"408.5,992.3 5581.9,988.6 5587.6,8432.0 411.7,8432.0 408.5,992.3\" /></svg>"
         }
       },
       "body": {
@@ -7955,8 +10333,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00232243058078,
-                38.89035803479374
+                -77.00232043366098,
+                38.89035435671886
               ]
             }
           },
@@ -7976,8 +10354,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99815517957265,
-                38.89035224353168
+                -76.99815836063597,
+                38.89035147652347
               ]
             }
           },
@@ -7997,8 +10375,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99816554155886,
-                38.88577079175037
+                -76.998163514015,
+                38.88577572100481
               ]
             }
           },
@@ -8018,8 +10396,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00233279256699,
-                38.88577658301243
+                -77.00232558704002,
+                38.8857786012002
               ]
             }
           }
@@ -8044,8 +10422,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8064,7 +10442,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5455.6,7790.6 470.1,7798.2 452.3,922.7 5435.8,912.1 5449.8,4406.4 4948.9,4670.0 4949.5,4937.4 5451.1,4933.8 5455.6,7790.6\" /></svg>"
+          "value": "<svg><polygon points=\"468.9,7796.4 450.4,927.3 4944.6,917.4 4963.4,7789.2 468.9,7796.4\" /></svg>"
         }
       },
       "body": {
@@ -8093,8 +10471,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99876967104628,
-                38.8903223351144
+                -76.99876854537584,
+                38.89032536082308
               ]
             }
           },
@@ -8114,8 +10492,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99459511084245,
-                38.89031291826161
+                -76.99459013767418,
+                38.890315614979876
               ]
             }
           },
@@ -8135,8 +10513,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99461199879418,
-                38.885712823262246
+                -76.9946076156293,
+                38.885711280310396
               ]
             }
           },
@@ -8156,8 +10534,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.998786558998,
-                38.88572224011504
+                -76.99878602333096,
+                38.8857210261536
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002000",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/info.json",
+          "type": "ImageService2",
+          "height": 8404,
+          "width": 5995
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,903.2 5256.5,964.9 5435.6,1204.5 5424.8,6827.2 490.4,6828.8 489.3,7867.9 -0.0,7867.4 -0.0,903.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99530496032712,
+                38.890302930586365
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5995.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99112912107715,
+                38.89030218108635
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5995.0,
+                8404.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99113047067094,
+                38.885746417436174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8404.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9953063099209,
+                38.88574716693619
               ]
             }
           }
@@ -8182,8 +10698,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8202,7 +10718,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"652.3,7877.1 711.9,2001.2 1327.4,2008.6 1351.7,0.0 5041.0,0.0 5236.0,143.5 5320.5,430.0 5309.2,2129.7 6055.0,2134.4 6055.0,8449.0 5812.3,8449.0 5820.4,7884.6 5264.7,8064.8 5215.1,7840.5 652.3,7877.1\" /></svg>"
+          "value": "<svg><polygon points=\"711.0,1982.6 1330.0,1987.5 1345.8,0.0 5059.9,0.0 5233.7,141.2 5318.3,427.6 5307.5,2082.6 6055.0,2087.7 6055.0,8449.0 5809.4,8449.0 5816.7,7882.7 5265.7,8061.6 5216.0,7837.3 653.7,7875.8 711.0,1982.6\" /></svg>"
         }
       },
       "body": {
@@ -8231,8 +10747,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99202747630125,
-                38.89034599683104
+                -76.99202621987523,
+                38.890345906096925
               ]
             }
           },
@@ -8252,8 +10768,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98780659418713,
-                38.89037241826507
+                -76.98780487046268,
+                38.89037096755979
               ]
             }
           },
@@ -8273,8 +10789,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98775955187907,
-                38.88575479783943
+                -76.98776024952899,
+                38.88575283591239
               ]
             }
           },
@@ -8294,8 +10810,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99198043399319,
-                38.885728376405396
+                -76.99198159894154,
+                38.88572777444953
               ]
             }
           }
@@ -8320,8 +10836,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8340,7 +10856,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"514.4,1051.6 5123.9,945.6 5126.3,1173.5 5679.0,985.4 5679.0,5991.7 539.6,6041.5 514.4,1051.6\" /></svg>"
+          "value": "<svg><polygon points=\"1157.7,7115.8 -0.0,6525.4 -0.0,1054.1 5127.9,948.7 5130.1,1176.8 5679.0,990.7 5679.0,6871.2 1367.9,6906.3 1157.7,7115.8\" /></svg>"
         }
       },
       "body": {
@@ -8369,8 +10885,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99188311522717,
-                38.88662061817613
+                -76.99188380137514,
+                38.88661911979822
               ]
             }
           },
@@ -8390,8 +10906,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98792192648418,
-                38.88660108808258
+                -76.98792571372479,
+                38.88660268627416
               ]
             }
           },
@@ -8411,8 +10927,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9879577181309,
-                38.882140092163496
+                -76.98795583049953,
+                38.882145186830435
               ]
             }
           },
@@ -8432,8 +10948,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99191890687388,
-                38.882159622257056
+                -76.99191391814988,
+                38.882161620354495
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002030",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/info.json",
+          "type": "ImageService2",
+          "height": 8228,
+          "width": 5702
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5702.0,2055.8 5702.0,8228.0 -0.0,8228.0 -0.0,2625.0 233.4,2619.4 231.5,1459.8 229.3,1296.1 5319.2,1282.7 5328.9,2057.4 5702.0,2055.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01902269975777,
+                38.88769064824545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5702.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01904066766075,
+                38.884640331114355
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5702.0,
+                8228.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02465379827551,
+                38.884660648450776
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8228.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02463583037253,
+                38.88771096558187
               ]
             }
           }
@@ -8458,8 +11112,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8478,7 +11132,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1277.8,3113.3 -0.0,3087.8 0.0,-0.0 5699.0,0.0 5699.0,183.1 4661.6,164.3 4509.8,8193.0 2562.7,8193.0 2202.1,8054.3 1176.9,8032.4 1277.8,3113.3\" /></svg>"
+          "value": "<svg><polygon points=\"1277.6,3106.4 -0.0,3079.9 0.0,0.0 4664.9,0.0 4518.7,7378.8 1188.1,7313.4 1277.6,3106.4\" /></svg>"
         }
       },
       "body": {
@@ -8507,8 +11161,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02085010798965,
-                38.88928079980246
+                -77.02085229881,
+                38.889277947727116
               ]
             }
           },
@@ -8528,8 +11182,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01682803614567,
-                38.889339181188475
+                -77.01682669921637,
+                38.88933873243862
               ]
             }
           },
@@ -8549,8 +11203,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01672094522885,
-                38.88480576306367
+                -77.01671519976867,
+                38.884801339328185
               ]
             }
           },
@@ -8570,8 +11224,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02074301707283,
-                38.88474738167765
+                -77.0207407993623,
+                38.884740554616684
               ]
             }
           }
@@ -8596,8 +11250,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8616,7 +11270,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4544.5,7734.5 1110.9,7708.0 1110.4,0.0 5668.0,0.0 5668.0,152.3 4529.1,171.8 4544.5,7734.5\" /></svg>"
+          "value": "<svg><polygon points=\"1332.9,7523.5 1101.6,24.9 4459.7,0.0 4704.8,7421.9 1332.9,7523.5\" /></svg>"
         }
       },
       "body": {
@@ -8645,8 +11299,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0183219968242,
-                38.88923736364884
+                -77.01832754753251,
+                38.889359561352144
               ]
             }
           },
@@ -8666,8 +11320,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0144223899596,
-                38.88923868218753
+                -77.01436104218322,
+                38.88926537099201
               ]
             }
           },
@@ -8687,8 +11341,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01441995409958,
-                38.884812019905254
+                -77.0145363369973,
+                38.8847958555096
               ]
             }
           },
@@ -8708,8 +11362,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01831956096417,
-                38.88481070136656
+                -77.01850284234658,
+                38.88489004586974
               ]
             }
           }
@@ -8734,8 +11388,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8754,7 +11408,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5722.0,8203.0 731.4,8203.0 821.1,4067.3 297.0,4061.0 314.1,1303.5 5345.7,1409.4 5332.9,8148.7 5722.0,8203.0\" /></svg>"
+          "value": "<svg><polygon points=\"717.5,7444.6 -0.0,7443.4 -0.0,671.0 316.2,670.1 311.6,1341.2 5339.7,1124.6 5313.4,8128.8 5722.0,8203.0 723.9,8203.0 717.5,7444.6\" /></svg>"
         }
       },
       "body": {
@@ -8783,8 +11437,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01472820262214,
-                38.885239300659286
+                -77.01472603537479,
+                38.88523876281241
               ]
             }
           },
@@ -8804,8 +11458,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0147325756497,
-                38.88211606748471
+                -77.0147276161056,
+                38.8821119857544
               ]
             }
           },
@@ -8825,8 +11479,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02044291293399,
-                38.88212098082582
+                -77.02044443281956,
+                38.882113761793896
               ]
             }
           },
@@ -8846,8 +11500,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02043853990642,
-                38.885244214000394
+                -77.02044285208875,
+                38.88524053885191
               ]
             }
           }
@@ -8872,8 +11526,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8892,7 +11546,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5549.1,-0.0 5571.5,8177.0 -0.0,8177.0 -0.0,1438.3 2437.9,1484.9 2466.3,-0.0 5549.1,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5549.2,-0.0 5581.1,8177.0 -0.0,8177.0 -0.0,1161.9 2248.0,1056.6 2199.1,-0.0 5549.2,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -8921,8 +11575,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01471214072443,
-                38.88231995318948
+                -77.01470273505153,
+                38.88231852055507
               ]
             }
           },
@@ -8942,8 +11596,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01472396886973,
-                38.87922332242011
+                -77.01471912636745,
+                38.87922338776432
               ]
             }
           },
@@ -8963,8 +11617,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02041662114515,
-                38.87923668570579
+                -77.02040902760731,
+                38.87924190645223
               ]
             }
           },
@@ -8984,8 +11638,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02040479299984,
-                38.88233331647516
+                -77.02039263629139,
+                38.88233703924298
               ]
             }
           }
@@ -9010,8 +11664,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9030,7 +11684,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5675.0,-0.0 5675.0,8209.0 220.6,8206.7 195.6,631.6 4257.5,615.5 4251.8,-0.0 5675.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"202.0,8193.3 199.7,-0.0 3461.3,-0.0 3468.3,678.3 5317.5,681.1 5315.4,7242.7 5014.9,8194.7 202.0,8193.3\" /></svg>"
         }
       },
       "body": {
@@ -9059,8 +11713,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01476850090015,
-                38.87939575230326
+                -77.01473038755438,
+                38.8793997013516
               ]
             }
           },
@@ -9080,8 +11734,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01478297295948,
-                38.8763347599758
+                -77.01473252386084,
+                38.87633847697264
               ]
             }
           },
@@ -9101,8 +11755,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02043188029879,
-                38.87635117498885
+                -77.0204216957306,
+                38.876340883123056
               ]
             }
           },
@@ -9122,8 +11776,592 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02041740823945,
-                38.87941216731632
+                -77.02041955942414,
+                38.87940210750202
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002120/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002120",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002120/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002120/info.json",
+          "type": "ImageService2",
+          "height": 8177,
+          "width": 5675
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1344.4,714.8 1349.9,-0.0 5675.0,-0.0 5675.0,8177.0 833.3,8177.0 1125.8,7230.6 1102.9,715.2 1344.4,714.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002120/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01470182590622,
+                38.877133191223265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5675.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01471918741858,
+                38.87402843968289
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5675.0,
+                8177.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02042633644739,
+                38.87404805597976
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8177.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02040897493502,
+                38.87715280752014
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002130 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5691.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5763.5"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/info.json",
+          "type": "ImageService2",
+          "height": 8241,
+          "width": 5691
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4943.1,5651.5 1144.6,5763.5 1129.7,2329.2 382.7,2326.6 368.3,153.7 1072.2,140.7 1071.1,0.0 5691.0,0.0 5691.0,2003.0 5012.4,2003.1 4899.2,2281.6 4943.1,5651.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01544686696536,
+                38.87761057276183
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5691.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01164655221585,
+                38.877584904084394
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5691.0,
+                5763.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01167993985824,
+                38.87458880985536
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5763.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01548025460775,
+                38.8746144785328
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002130 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "5730.3"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5691.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2510.7"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/info.json",
+          "type": "ImageService2",
+          "height": 8241,
+          "width": 5691
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5016.2,8133.0 0.0,7899.3 0.0,5730.3 4839.0,5730.3 4812.0,6298.0 5087.1,6412.1 5016.2,8133.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5730.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0055536342384,
+                38.88044604597545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5691.0,
+                5730.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00165479758019,
+                38.88058317934769
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5691.0,
+                8241.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0015770309819,
+                38.879244136168
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8241.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00547586764011,
+                38.879107002795756
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002140",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/info.json",
+          "type": "ImageService2",
+          "height": 8189,
+          "width": 5723
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6063.1 -0.0,1190.2 447.9,1068.2 447.9,671.8 1452.5,759.8 4005.4,77.6 4745.0,2100.4 3980.1,2109.2 3969.6,6062.2 -0.0,6063.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01469448614621,
+                38.90747947282556
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5723.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01469544781325,
+                38.90436765666422
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5723.0,
+                8189.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0204181277003,
+                38.904368727739126
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8189.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02041716603325,
+                38.90748054390046
               ]
             }
           }
@@ -9148,8 +12386,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9168,7 +12406,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5528.4,8205.0 5578.4,6948.9 572.0,6749.9 674.3,0.0 5691.0,0.0 5691.0,8205.0 5528.4,8205.0\" /></svg>"
+          "value": "<svg><polygon points=\"5691.0,0.0 5691.0,2673.2 4981.8,2699.7 5037.4,5087.9 4937.1,5259.1 4432.8,4790.5 4498.2,6507.8 5533.6,6437.9 5652.8,8205.0 776.1,8205.0 551.4,0.0 5691.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -9197,8 +12435,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01567788605442,
-                38.88913920652958
+                -77.01559173509021,
+                38.889129264991645
               ]
             }
           },
@@ -9218,8 +12456,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01169408684041,
-                38.88919417116142
+                -77.01160782884902,
+                38.88905163684328
               ]
             }
           },
@@ -9239,8 +12477,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01159297344726,
-                38.884691015152335
+                -77.01175169107906,
+                38.88458144192126
               ]
             }
           },
@@ -9260,8 +12498,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01557677266128,
-                38.88463605052049
+                -77.01573559732024,
+                38.88465907006963
               ]
             }
           }
@@ -9286,8 +12524,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9306,7 +12544,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4053.9 -0.0,697.9 638.9,688.4 622.0,0.0 2859.0,0.0 2865.1,0.0 5684.0,0.0 5684.0,8204.0 -0.0,8204.0 -0.0,4053.9 -0.0,4053.9\" /></svg>"
+          "value": "<svg><polygon points=\"5684.0,1829.5 5684.0,8204.0 -0.0,8204.0 -0.0,4123.2 -0.0,4123.1 -0.0,665.1 689.2,699.3 656.9,1490.2 5684.0,1829.5\" /></svg>"
         }
       },
       "body": {
@@ -9335,8 +12573,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01562516784297,
-                38.885447671612155
+                -77.0156798826528,
+                38.88541934393343
               ]
             }
           },
@@ -9356,8 +12594,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01168730583768,
-                38.88537932412497
+                -77.01183089894027,
+                38.88554630267329
               ]
             }
           },
@@ -9377,8 +12615,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01181314747292,
-                38.880923768631455
+                -77.01159549287335,
+                38.88122181971496
               ]
             }
           },
@@ -9398,8 +12636,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01575100947821,
-                38.88099211611864
+                -77.01544447658588,
+                38.8810948609751
               ]
             }
           }
@@ -9424,8 +12662,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9444,7 +12682,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1191.1,5352.2 1353.5,5351.5 1331.7,0.0 5683.0,0.0 5683.0,127.8 5028.9,125.0 4979.1,285.4 4969.8,4841.4 4824.2,8202.3 1089.4,8204.0 1191.1,5352.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,3832.2 -0.0,2127.8 485.4,2611.4 592.0,2445.5 627.4,76.7 5683.0,0.0 5683.0,137.2 5028.3,134.7 4951.4,6947.4 4827.6,8200.7 1165.9,8204.0 1035.9,3802.2 -0.0,3832.2\" /></svg>"
         }
       },
       "body": {
@@ -9473,8 +12711,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01259268372799,
-                38.88762169596485
+                -77.01259217222339,
+                38.88762811473057
               ]
             }
           },
@@ -9494,8 +12732,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00860814288265,
-                38.887663940601136
+                -77.00860782626631,
+                38.887669115756836
               ]
             }
           },
@@ -9515,8 +12753,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00853035958839,
-                38.883155704100254
+                -77.00853233263075,
+                38.88316110864266
               ]
             }
           },
@@ -9536,8 +12774,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01251490043373,
-                38.88311345946397
+                -77.01251667858783,
+                38.88312010761639
               ]
             }
           }
@@ -9562,8 +12800,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9582,7 +12820,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1229.1,107.4 1228.3,0.0 5086.7,0.0 5057.8,2612.8 4962.5,2612.7 4960.6,8188.0 430.5,8188.0 551.0,4826.2 526.3,270.3 574.9,109.5 1229.1,107.4\" /></svg>"
+          "value": "<svg><polygon points=\"1223.3,114.0 1222.4,0.0 5082.2,0.0 5057.0,2607.6 4959.9,2607.7 4963.5,7974.2 5171.7,7964.4 4963.6,8188.0 435.8,8188.0 549.1,6933.1 568.3,117.0 1223.3,114.0\" /></svg>"
         }
       },
       "body": {
@@ -9611,8 +12849,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00946919587543,
-                38.887648671732144
+                -77.00946428926305,
+                38.88765319295894
               ]
             }
           },
@@ -9632,8 +12870,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0054674924486,
-                38.88766769294593
+                -77.00546457469723,
+                38.88766782549234
               ]
             }
           },
@@ -9653,8 +12891,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00543268488659,
-                38.88316785100179
+                -77.00543779798063,
+                38.88317024503913
               ]
             }
           },
@@ -9674,8 +12912,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00943438831341,
-                38.883148829788
+                -77.00943751254646,
+                38.88315561250573
               ]
             }
           }
@@ -9683,13 +12921,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002190/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002190",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002210",
       "metadata": [
         {
           "label": "streets",
@@ -9700,8 +12938,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9710,21 +12948,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002190/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002190/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/info.json",
           "type": "ImageService2",
-          "height": 8203,
-          "width": 5722
+          "height": 8217,
+          "width": 5692
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"633.2,8203.0 654.9,4176.9 858.6,4177.8 1346.1,4179.8 1372.8,1088.7 5555.1,1204.9 5588.5,0.0 5722.0,0.0 5722.0,4213.7 3896.1,4203.4 3686.4,4929.3 3502.9,8203.0 633.2,8203.0\" /></svg>"
+          "value": "<svg><polygon points=\"5295.6,3057.3 4416.7,3036.4 4375.0,4994.2 4565.8,4999.6 5126.1,5012.7 5089.5,6438.2 3197.6,6376.6 3137.7,8217.0 -0.0,8217.0 0.0,-0.0 243.8,-0.0 233.8,387.2 5356.3,510.4 5295.6,3057.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002190/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9749,8 +12987,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01567462985913,
-                38.88156237170221
+                -77.0071943287509,
+                38.87942726281898
               ]
             }
           },
@@ -9758,7 +12996,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5722.0,
+                5692.0,
                 0.0
               ],
               "creator": {
@@ -9770,8 +13008,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01170196836583,
-                38.88157993641088
+                -77.00709822824332,
+                38.8762969940256
               ]
             }
           },
@@ -9779,8 +13017,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5722.0,
-                8203.0
+                5692.0,
+                8217.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9791,8 +13029,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01166985588138,
-                38.87711617824054
+                -77.01290504990533,
+                38.87618895449788
               ]
             }
           },
@@ -9801,7 +13039,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8203.0
+                8217.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9812,8 +13050,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01564251737469,
-                38.877098613531864
+                -77.0130011504129,
+                38.879319223291255
               ]
             }
           }
@@ -9838,8 +13076,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9858,7 +13096,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5440.4,8085.3 -0.0,8207.0 -0.0,637.6 221.4,635.6 201.8,356.6 5385.3,298.1 5397.0,1612.6 5239.2,1615.6 5315.9,7870.9 5440.4,8085.3\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5266.8 221.7,5256.4 219.3,-0.0 5365.9,-0.0 5364.2,1671.5 5207.5,1672.9 5220.2,7836.9 5341.6,8049.5 217.6,8055.7 217.8,7668.1 -0.0,7673.6 -0.0,5266.8\" /></svg>"
         }
       },
       "body": {
@@ -9887,8 +13125,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00179283958774,
-                38.879393378543675
+                -77.00177275975813,
+                38.87940724681751
               ]
             }
           },
@@ -9908,8 +13146,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00183875855359,
-                38.87628106832497
+                -77.00177825415017,
+                38.87627060870466
               ]
             }
           },
@@ -9929,8 +13167,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00755139054071,
-                38.87633287126303
+                -77.00757619700697,
+                38.87627676367253
               ]
             }
           },
@@ -9950,8 +13188,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00750547157485,
-                38.879445181481735
+                -77.00757070261493,
+                38.87941340178538
               ]
             }
           }
@@ -9976,8 +13214,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9996,7 +13234,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5001.0,1287.5 5018.2,4219.3 4847.9,4217.0 4837.2,4408.6 4847.0,8143.2 -0.0,8188.0 -0.0,1029.5 5001.0,1287.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,4197.8 553.4,4178.4 547.7,998.5 658.2,736.9 2736.9,750.2 2739.4,0.0 4708.9,0.0 4706.7,877.8 5012.0,882.0 5021.5,4206.8 4851.2,4204.0 4842.3,7199.9 5104.8,7202.2 5100.9,8133.6 -0.0,8188.0 -0.0,4197.8\" /></svg>"
         }
       },
       "body": {
@@ -10025,8 +13263,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01256520676608,
-                38.87696758372185
+                -77.0125752369881,
+                38.87695173936927
               ]
             }
           },
@@ -10046,8 +13284,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00856396098627,
-                38.876966338585966
+                -77.00857527030233,
+                38.876959804117554
               ]
             }
           },
@@ -10067,8 +13305,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00856624556396,
-                38.87245368564121
+                -77.0085604730861,
+                38.87244859399311
               ]
             }
           },
@@ -10088,8 +13326,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01256749134376,
-                38.872454930777096
+                -77.01256043977187,
+                38.87244052924483
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002240",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/info.json",
+          "type": "ImageService2",
+          "height": 8205,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"416.9,7253.0 422.2,4197.1 594.7,4199.8 580.8,808.4 5125.5,682.0 5118.9,8205.0 680.2,8205.0 682.9,7255.0 416.9,7253.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00945446011512,
+                38.876909175363004
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5692.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00550670675703,
+                38.87691315190998
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5692.0,
+                8205.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00549934111278,
+                38.872481248342616
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8205.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00944709447087,
+                38.87247727179564
               ]
             }
           }
@@ -10114,8 +13490,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10134,7 +13510,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"114.8,8221.0 103.0,677.8 4281.6,674.2 4282.9,830.4 5684.0,832.5 5684.0,8221.0 114.8,8221.0\" /></svg>"
+          "value": "<svg><polygon points=\"114.7,8221.0 106.7,680.1 4284.1,678.6 4285.3,834.8 5087.2,836.5 5218.2,8204.9 114.7,8221.0\" /></svg>"
         }
       },
       "body": {
@@ -10163,8 +13539,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0059709433762,
-                38.87691841646051
+                -77.00597381378367,
+                38.87691976467656
               ]
             }
           },
@@ -10184,8 +13560,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0019725431599,
-                38.87691503516883
+                -77.00197427293848,
+                38.87691797472326
               ]
             }
           },
@@ -10205,8 +13581,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00197878320755,
-                38.872379390148204
+                -77.0019775762305,
+                38.87238103581322
               ]
             }
           },
@@ -10226,8 +13602,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00597718342385,
-                38.87238277143989
+                -77.00597711707569,
+                38.872382825766515
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002260/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002260",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002260/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002260/info.json",
+          "type": "ImageService2",
+          "height": 8205,
+          "width": 5684
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,706.5 5684.0,811.3 5684.0,8205.0 -0.0,8205.0 -0.0,706.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002260/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00240297040256,
+                38.8768396636012
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5684.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99844495213539,
+                38.87689228451731
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5684.0,
+                8205.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99834734510625,
+                38.872442677446706
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8205.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00230536337342,
+                38.8723900565306
               ]
             }
           }
@@ -10252,8 +13766,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10272,7 +13786,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5437.1 0.0,0.0 95.5,0.0 134.7,340.0 5622.0,374.9 5572.5,8205.0 -0.0,8205.0 -0.0,5457.1 -0.0,5437.1\" /></svg>"
+          "value": "<svg><polygon points=\"208.0,5348.9 -0.0,5358.6 -0.0,0.0 97.0,0.0 136.2,346.9 5613.1,379.6 5566.6,8205.0 -0.0,8205.0 -0.0,5454.4 208.0,5348.9\" /></svg>"
         }
       },
       "body": {
@@ -10301,8 +13815,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00597844726973,
-                38.88622934342102
+                -77.00597967215336,
+                38.88623354491229
               ]
             }
           },
@@ -10322,8 +13836,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00201558670328,
-                38.8862471482233
+                -77.00200925360018,
+                38.88625018177287
               ]
             }
           },
@@ -10343,8 +13857,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00198264903138,
-                38.88174214733214
+                -77.00197847666048,
+                38.88173657138405
               ]
             }
           },
@@ -10364,8 +13878,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00594550959782,
-                38.88172434252986
+                -77.00594889521366,
+                38.88171993452347
               ]
             }
           }
@@ -10390,8 +13904,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10410,7 +13924,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5422.8,6863.1 251.0,6935.4 222.5,1758.9 2350.1,1742.0 2348.6,1283.2 2347.5,1159.5 213.4,0.0 899.1,0.0 2642.9,896.5 5125.2,817.9 5399.8,933.7 5422.8,6863.1\" /></svg>"
+          "value": "<svg><polygon points=\"5409.2,2212.3 5432.8,6858.8 252.9,6937.4 221.4,2238.0 5409.2,2212.3\" /></svg>"
         }
       },
       "body": {
@@ -10439,8 +13953,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00218905678013,
-                38.886995867167506
+                -77.00218435902659,
+                38.886991156284026
               ]
             }
           },
@@ -10460,8 +13974,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99825082708912,
-                38.88698154871529
+                -76.99825237725624,
+                38.886973150061365
               ]
             }
           },
@@ -10481,8 +13995,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99827714082213,
-                38.882534083348474
+                -76.99828546820756,
+                38.8825327430357
               ]
             }
           },
@@ -10502,8 +14016,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00221537051313,
-                38.88254840180069
+                -77.0022174499779,
+                38.882550749258364
               ]
             }
           }
@@ -10528,8 +14042,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10548,7 +14062,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"366.5,7078.9 333.7,1015.9 4443.5,995.5 4482.3,7055.9 366.5,7078.9\" /></svg>"
+          "value": "<svg><polygon points=\"5337.3,999.3 5363.5,7062.8 362.1,7090.9 329.1,1024.4 5337.3,999.3\" /></svg>"
         }
       },
       "body": {
@@ -10577,8 +14091,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99868446058333,
-                38.886598053961585
+                -76.99868102273048,
+                38.88660234806923
               ]
             }
           },
@@ -10598,8 +14112,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99471553120594,
-                38.88657838722942
+                -76.99471441032367,
+                38.88658257556956
               ]
             }
           },
@@ -10619,8 +14133,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99475170875694,
-                38.882091849515454
+                -76.99475078255165,
+                38.88209867110264
               ]
             }
           },
@@ -10640,8 +14154,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99872063813433,
-                38.88211151624762
+                -76.99871739495846,
+                38.88211844360231
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002300",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/info.json",
+          "type": "ImageService2",
+          "height": 8199,
+          "width": 5707
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3706.4,5934.5 3706.3,6020.6 3871.2,6020.1 5298.1,6762.0 5298.2,8199.0 369.5,8199.0 384.1,0.0 5308.0,0.0 5305.7,1018.8 4791.7,1019.9 4762.3,6483.4 3706.4,5934.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99523258526139,
+                38.88660101436835
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5707.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99124884707938,
+                38.88660127414544
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5707.0,
+                8199.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99124837101401,
+                38.88211501019828
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8199.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99523210919602,
+                38.88211475042119
               ]
             }
           }
@@ -10666,8 +14318,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10686,7 +14338,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3061.8 267.4,3059.5 269.6,311.9 5438.9,250.6 5459.0,6308.3 5153.3,6814.6 5155.8,7371.6 -0.0,7602.3 -0.0,3061.8\" /></svg>"
+          "value": "<svg><polygon points=\"288.3,7585.3 277.4,5892.3 -0.0,5793.1 -0.0,3074.9 275.4,3072.8 277.9,316.6 5444.0,255.7 5463.5,6309.7 5154.4,6818.9 5157.4,7595.8 4541.1,7381.9 2411.3,7341.8 2413.3,7568.8 288.3,7585.3\" /></svg>"
         }
       },
       "body": {
@@ -10715,8 +14367,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00222373982123,
-                38.883402881104445
+                -77.00222960023925,
+                38.88340552703801
               ]
             }
           },
@@ -10736,8 +14388,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99828279957349,
-                38.883395068929076
+                -76.99828620387176,
+                38.88339796667701
               ]
             }
           },
@@ -10757,8 +14409,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99829712067613,
-                38.87895517902756
+                -76.99830006334892,
+                38.87895530806003
               ]
             }
           },
@@ -10778,8 +14430,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00223806092389,
-                38.87896299120292
+                -77.00224345971641,
+                38.87896286842103
               ]
             }
           }
@@ -10804,8 +14456,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10824,7 +14476,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3583.5,8189.0 1798.1,8189.0 -0.0,7558.5 -0.0,6771.2 308.3,6266.1 310.3,1188.8 5349.4,1202.6 5335.3,7543.1 3587.8,7537.8 3583.5,8189.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6777.1 311.6,6268.7 310.7,1193.1 5692.0,1205.1 5692.0,7543.8 5337.7,7526.0 5338.1,7246.6 -0.0,7277.7 -0.0,6777.1\" /></svg>"
         }
       },
       "body": {
@@ -10853,8 +14505,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99867642901009,
-                38.8833706581438
+                -76.99867631806845,
+                38.883373265449826
               ]
             }
           },
@@ -10874,8 +14526,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99473866286542,
-                38.88337680576191
+                -76.99473724701055,
+                38.883377685918646
               ]
             }
           },
@@ -10895,8 +14547,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99472737666507,
-                38.878933981331414
+                -76.9947291316241,
+                38.8789333892071
               ]
             }
           },
@@ -10916,8 +14568,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99866514280974,
-                38.8789278337133
+                -76.998668202682,
+                38.87892896873828
               ]
             }
           }
@@ -10942,8 +14594,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10962,7 +14614,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"427.8,7432.3 447.9,1075.9 2205.5,1084.4 2206.8,0.0 3185.7,0.0 3821.5,331.5 3822.9,0.0 3972.8,0.0 5729.0,918.1 5729.0,7459.1 427.8,7432.3\" /></svg>"
+          "value": "<svg><polygon points=\"776.8,7440.0 782.5,2199.1 5425.6,2210.4 5413.4,7462.0 776.8,7440.0\" /></svg>"
         }
       },
       "body": {
@@ -10991,8 +14643,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9952855285231,
-                38.88330553085423
+                -76.99527828123422,
+                38.883301695989346
               ]
             }
           },
@@ -11012,8 +14664,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99132854894873,
-                38.88331463837255
+                -76.99132835495813,
+                38.88330951079754
               ]
             }
           },
@@ -11033,8 +14685,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99131190489986,
-                38.8788704710883
+                -76.99131407334542,
+                38.878873265221245
               ]
             }
           },
@@ -11054,8 +14706,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99526888447423,
-                38.87886136356997
+                -76.99526399962151,
+                38.87886545041305
               ]
             }
           }
@@ -11080,8 +14732,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11100,7 +14752,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"462.7,759.4 466.2,0.0 5664.0,0.0 5664.0,8157.0 5069.5,8157.0 5071.8,7426.4 757.3,7410.2 760.4,913.7 462.7,759.4\" /></svg>"
+          "value": "<svg><polygon points=\"439.7,7412.7 463.1,752.1 1082.8,1073.5 1295.9,864.9 5627.8,868.6 5664.0,8157.0 5075.3,8157.0 5077.8,7431.5 439.7,7412.7\" /></svg>"
         }
       },
       "body": {
@@ -11129,8 +14781,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99185717262576,
-                38.88331422892671
+                -76.9918570388379,
+                38.88330948231246
               ]
             }
           },
@@ -11150,8 +14802,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98792181684449,
-                38.88332473745214
+                -76.98792819558194,
+                38.88332088786804
               ]
             }
           },
@@ -11171,8 +14823,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9879025048911,
-                38.87888013005375
+                -76.98790723513433,
+                38.878883632505215
               ]
             }
           },
@@ -11192,8 +14844,146 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99183786067236,
-                38.87886962152832
+                -76.99183607839029,
+                38.87887222694964
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002350",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/info.json",
+          "type": "ImageService2",
+          "height": 8180,
+          "width": 5696
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"224.9,5508.0 -0.0,5509.7 42.6,3414.2 1241.3,-0.0 5696.0,-0.0 5696.0,2465.5 5401.7,2470.9 5399.9,7217.5 235.8,7216.0 224.9,5508.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99669114105608,
+                38.8794116188527
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99669546501791,
+                38.87628892255583
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                8180.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00245600109386,
+                38.87629375665266
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8180.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00245167713203,
+                38.87941645294953
               ]
             }
           }
@@ -11218,8 +15008,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11238,7 +15028,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5469.4,4660.9 923.1,4648.8 927.5,3844.5 280.1,3836.8 278.0,558.0 2770.6,576.2 2865.0,407.4 5652.0,409.6 5652.0,6059.3 5459.5,5986.0 5469.4,4660.9\" /></svg>"
+          "value": "<svg><polygon points=\"280.2,7409.1 -0.0,7407.5 -0.0,2099.7 278.1,2101.7 283.2,-0.0 5343.2,-0.0 5342.7,399.6 5652.0,409.1 5652.0,4612.6 1290.1,4576.2 280.2,7409.1\" /></svg>"
         }
       },
       "body": {
@@ -11267,8 +15057,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99351389119279,
-                38.879453447656125
+                -76.99351362841816,
+                38.87945290046295
               ]
             }
           },
@@ -11288,8 +15078,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99348458283815,
-                38.8763692092963
+                -76.99348509472357,
+                38.87637009594358
               ]
             }
           },
@@ -11309,8 +15099,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99916436273399,
-                38.87633603636286
+                -76.99916223413015,
+                38.87633779981631
               ]
             }
           },
@@ -11330,8 +15120,284 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99919367108863,
-                38.87942027472268
+                -76.99919076782474,
+                38.879420604335685
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002370",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/info.json",
+          "type": "ImageService2",
+          "height": 8182,
+          "width": 5642
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"207.5,7634.8 264.0,192.8 989.9,194.3 989.6,-0.0 5642.0,-0.0 5642.0,2993.7 5642.0,8182.0 5596.1,8016.2 5285.7,8008.3 5284.2,7610.0 207.5,7634.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98818149586533,
+                38.87942084276489
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98817234797767,
+                38.87635362901671
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                8182.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9938855051835,
+                38.87634330268856
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8182.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99389465307117,
+                38.879410516436735
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002380",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/info.json",
+          "type": "ImageService2",
+          "height": 8170,
+          "width": 5664
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8170.0 -0.0,482.3 5664.0,533.5 5664.0,8170.0 -0.0,8170.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99401954410479,
+                38.876628685413024
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5664.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99010134180217,
+                38.87663953999475
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5664.0,
+                8170.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9900813664983,
+                38.87220736621487
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8170.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99399956880092,
+                38.87219651163315
               ]
             }
           }
@@ -11372,8 +15438,8 @@
           "value": "8183.0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11392,7 +15458,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5663.0,8183.0 -0.0,8183.0 -0.0,0.0 3214.6,-0.0 3300.1,413.1 4847.0,462.9 5663.0,156.6 5663.0,5995.1 5663.0,6048.8 5663.0,8183.0\" /></svg>"
+          "value": "<svg><polygon points=\"4781.0,160.9 5214.3,2480.7 4007.1,5699.9 2405.0,5078.8 2666.3,4408.8 535.0,4307.5 322.3,8183.0 -0.0,8183.0 -0.0,0.0 5204.1,-0.0 4781.0,160.9\" /></svg>"
         }
       },
       "body": {
@@ -11421,8 +15487,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99238931060714,
-                38.86653996863853
+                -76.99239758335563,
+                38.86654359993958
               ]
             }
           },
@@ -11442,8 +15508,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98912221087963,
-                38.86485641091179
+                -76.98912231744256,
+                38.86486061682483
               ]
             }
           },
@@ -11463,8 +15529,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99222449082123,
-                38.86115477098494
+                -76.99222353177245,
+                38.86114971645908
               ]
             }
           },
@@ -11484,8 +15550,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99549159054874,
-                38.862838328711675
+                -76.99549879768551,
+                38.862832699573836
               ]
             }
           }
@@ -11493,13 +15559,167 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002400/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002390__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002400",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002390 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3438.4"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2982.3"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "4744.6"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002390__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002390/info.json",
+          "type": "ImageService2",
+          "height": 8183,
+          "width": 5663
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8183.0 -0.0,3438.4 1055.9,3438.4 944.9,3776.4 1754.8,4041.8 1875.2,3694.9 2051.5,4096.9 2533.5,4171.5 2982.3,3974.8 2982.3,8183.0 -0.0,8183.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002390__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                3438.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99372059397872,
+                38.86443119414978
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2982.3,
+                3438.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99034742910048,
+                38.862512426968514
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2982.3,
+                8183.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9942710702233,
+                38.858336101306875
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8183.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99764423510155,
+                38.86025486848814
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002410",
       "metadata": [
         {
           "label": "streets",
@@ -11510,8 +15730,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11520,21 +15740,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002400/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002400/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/info.json",
           "type": "ImageService2",
-          "height": 8156,
-          "width": 5649
+          "height": 8155,
+          "width": 5696
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5214.9,2613.3 5361.2,7474.2 2322.6,7581.2 1036.6,7041.9 1086.8,6625.9 -0.0,6260.2 -0.0,-0.0 5649.0,0.0 5649.0,2100.3 5059.5,2052.3 5214.9,2613.3\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,818.4 520.5,0.0 1393.4,0.0 3400.4,1722.0 5696.0,2127.5 5696.0,4655.0 5378.8,4651.6 5356.2,6616.0 5353.1,8155.0 0.0,8155.0 0.0,818.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002400/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -11559,8 +15779,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99009539711926,
-                38.86922697469531
+                -76.99202410438137,
+                38.86225301128221
               ]
             }
           },
@@ -11568,7 +15788,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5649.0,
+                5696.0,
                 0.0
               ],
               "creator": {
@@ -11580,8 +15800,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98629637810674,
-                38.86844426670779
+                -76.99115624383481,
+                38.865302175596476
               ]
             }
           },
@@ -11589,8 +15809,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5649.0,
-                8156.0
+                5696.0,
+                8155.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11601,8 +15821,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98773684595892,
-                38.86414575820258
+                -76.98554901472222,
+                38.8643345731783
               ]
             }
           },
@@ -11611,7 +15831,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8156.0
+                8155.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11622,8 +15842,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99153586497144,
-                38.864928466190094
+                -76.98641687526879,
+                38.861285408864035
               ]
             }
           }
@@ -11648,8 +15868,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11668,7 +15888,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,8184.0 0.0,3545.9 373.5,3541.6 374.3,3248.6 374.6,3122.0 349.9,291.1 5197.1,271.3 5697.0,148.4 5697.0,8184.0 0.0,8184.0\" /></svg>"
+          "value": "<svg><polygon points=\"373.3,3121.6 348.4,0.0 5697.0,0.0 5697.0,8184.0 0.0,8184.0 0.0,3545.5 372.0,3541.4 372.9,3248.2 373.3,3121.6\" /></svg>"
         }
       },
       "body": {
@@ -11697,8 +15917,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98806333780855,
-                38.86439521299493
+                -76.98806170966367,
+                38.86439516382317
               ]
             }
           },
@@ -11718,8 +15938,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98715414333527,
-                38.86742708723988
+                -76.98715436909704,
+                38.86742566967926
               ]
             }
           },
@@ -11739,8 +15959,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98160248934882,
-                38.86640349470325
+                -76.98160522608568,
+                38.86640416333447
               ]
             }
           },
@@ -11760,3191 +15980,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9825116838221,
-                38.863371620458295
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002620",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/info.json",
-          "type": "ImageService2",
-          "height": 8160,
-          "width": 5536
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"353.3,5833.3 368.6,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0 -0.0,6434.2 353.3,5833.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.98034627194663,
-                38.89996116535282
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5536.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.97657186384093,
-                38.89998842013753
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5536.0,
-                8160.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.97652060671116,
-                38.895628028649796
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8160.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.98029501481686,
-                38.895600773865084
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001250 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5936.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8381.0"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250/info.json",
-          "type": "ImageService2",
-          "height": 8381,
-          "width": 5936
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5936.0,2487.3 4934.1,2411.1 4918.6,8381.0 3088.1,8381.0 3092.0,6683.9 -0.0,6706.1 0.0,0.0 5936.0,-0.0 5936.0,2487.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01412786610278,
-                38.92243606603096
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5936.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01361506903089,
-                38.91922811794509
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5936.0,
-                8381.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01943797548773,
-                38.918664548019215
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8381.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01995077255962,
-                38.92187249610509
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1244.0,
-                5989.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.018182,
-                38.921361
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001260 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5948.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8371.0"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/info.json",
-          "type": "ImageService2",
-          "height": 8371,
-          "width": 5948
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8371.0 0.0,-0.0 3191.1,-0.0 3175.0,1697.4 4689.9,1708.3 4492.6,8371.0 -0.0,8371.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01879614529928,
-                38.92203859837687
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5948.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01825263476246,
-                38.91882712179537
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5948.0,
-                8371.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02406185877349,
-                38.9182318557326
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8371.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02460536931031,
-                38.921443332314105
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1304.0,
-                3171.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.020878,
-                38.921109
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001310",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/info.json",
-          "type": "ImageService2",
-          "height": 8423,
-          "width": 5966
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5763.4,521.0 5781.5,8423.0 352.3,8423.0 349.0,525.1 5763.4,521.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2823.1,
-                7787.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.023969,
-                38.907247
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2823.1,
-                535.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.018937,
-                38.9072367
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001330",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/info.json",
-          "type": "ImageService2",
-          "height": 8450,
-          "width": 6035
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5703.6,577.7 5694.9,8439.8 875.0,8449.6 931.3,575.9 5703.6,577.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                711.9,
-                1979.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.019907,
-                38.902521
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                711.9,
-                575.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0189297,
-                38.902521
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001400",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/info.json",
-          "type": "ImageService2",
-          "height": 8468,
-          "width": 5978
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"645.7,7701.2 633.0,837.4 4922.5,841.1 4939.8,2589.1 5059.7,2970.8 5065.6,5621.3 4432.5,5618.0 4420.7,7934.5 4009.9,7700.2 645.7,7701.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5062.3,
-                3592.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.009092,
-                38.9133406
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                631.8,
-                3592.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.012158,
-                38.9133433
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001410",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/info.json",
-          "type": "ImageService2",
-          "height": 8459,
-          "width": 6017
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"829.5,1607.9 3406.3,1309.7 4508.4,1358.5 4529.2,1412.5 4473.8,5158.8 295.7,5158.3 291.6,4719.7 -0.0,4719.6 -0.0,144.1 642.2,65.9 829.5,1607.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4221.9,
-                6215.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0161698,
-                38.9132801
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                343.8,
-                3075.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0188942,
-                38.9149924
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001460",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/info.json",
-          "type": "ImageService2",
-          "height": 8425,
-          "width": 5999
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"887.3,7107.1 927.2,496.3 5051.4,507.4 5036.7,5668.7 5999.0,5668.3 5999.0,6199.4 1215.3,8291.9 887.3,7107.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                707.9,
-                6381.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0151644,
-                38.9064627
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2887.5,
-                4954.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.013655,
-                38.9072357
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001600",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/info.json",
-          "type": "ImageService2",
-          "height": 8110,
-          "width": 5610
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5030.1,0.0 5010.2,4301.8 4621.6,5085.3 4699.5,7106.0 -0.0,7218.4 -0.0,737.0 432.3,739.4 418.3,0.0 5030.1,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00940673706788,
-                38.90415078180215
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5610.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00547902155542,
-                38.90415035280169
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5610.0,
-                8110.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00547981849085,
-                38.89973266318836
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8110.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00940753400332,
-                38.89973309218881
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                555.8,
-                3003.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0091072,
-                38.9025147
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                555.8,
-                3003.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0090179,
-                38.9025148
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                555.8,
-                3003.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0091072,
-                38.9025147
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001670",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/info.json",
-          "type": "ImageService2",
-          "height": 8421,
-          "width": 6002
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4898.1,7706.8 2227.3,7697.3 2330.4,-0.0 6002.0,-0.0 6002.0,1605.8 4926.4,1367.4 4898.1,7706.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2227.3,
-                7697.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.009092,
-                38.9133406
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4926.4,
-                1367.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00458,
-                38.911861
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001700",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/info.json",
-          "type": "ImageService2",
-          "height": 8452,
-          "width": 6013
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5500.4,8232.8 386.3,8234.6 368.4,0.0 3984.2,0.0 3982.0,320.0 5493.4,317.7 5500.4,8232.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3982.0,
-                6044.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9995097,
-                38.9025203
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3982.0,
-                320.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.999504,
-                38.9056457
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001770",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/info.json",
-          "type": "ImageService2",
-          "height": 8438,
-          "width": 5946
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5509.8,7707.9 501.2,7707.9 487.9,360.7 5491.5,340.7 5509.8,7707.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3766.7,
-                2419.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.996167,
-                38.9002024
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                487.8,
-                2419.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9984507,
-                38.9002082
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001780",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/info.json",
-          "type": "ImageService2",
-          "height": 8476,
-          "width": 5996
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5453.1,401.3 5461.0,7791.7 503.9,7793.2 501.8,395.4 5453.1,401.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2240.0,
-                2476.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.993757,
-                38.900202
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                504.0,
-                2476.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.994961,
-                38.900203
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001790",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/info.json",
-          "type": "ImageService2",
-          "height": 8464,
-          "width": 6032
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4418.2,7724.7 5323.8,7725.3 5323.1,8464.0 730.3,8464.0 736.7,418.4 4497.7,421.1 4418.2,7724.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5328.0,
-                3664.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.988305,
-                38.89955
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2568.0,
-                1440.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.990242,
-                38.900763
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001850",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/info.json",
-          "type": "ImageService2",
-          "height": 8492,
-          "width": 5995
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5436.1,7627.4 427.9,7582.6 502.0,689.5 5483.7,740.7 5436.1,7627.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5463.1,
-                4216.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9949624,
-                38.8954393
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                487.9,
-                1828.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9984577,
-                38.8967215
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001870",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/info.json",
-          "type": "ImageService2",
-          "height": 8444,
-          "width": 5999
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"700.2,1362.1 1010.9,1200.5 5290.1,1206.1 5276.3,7363.2 669.3,7353.3 700.2,1362.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2515.6,
-                3944.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.990245,
-                38.895435
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5279.1,
-                3944.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.98831,
-                38.895438
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001890",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/info.json",
-          "type": "ImageService2",
-          "height": 8478,
-          "width": 6021
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4194.9,7744.5 2773.7,7254.4 684.8,7264.7 672.9,5040.9 -0.0,5041.1 -0.0,4765.4 666.5,3735.8 659.5,341.9 2865.3,341.8 3087.7,0.0 3318.1,0.0 3329.9,1560.1 5379.4,1560.4 5382.0,2568.0 6021.0,2566.9 6021.0,7721.2 4194.9,7744.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                667.7,
-                3903.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9855056,
-                38.8953987
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5389.3,
-                3767.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.982211,
-                38.895466
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001940",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/info.json",
-          "type": "ImageService2",
-          "height": 8424,
-          "width": 5979
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"433.9,3899.0 -0.0,3670.3 -0.0,3389.2 427.4,3390.4 412.9,502.1 5315.2,491.5 5356.1,6415.6 5979.0,6408.0 5979.0,8424.0 5366.0,8424.0 5364.6,7700.7 5185.5,7462.9 439.9,7420.0 433.9,3899.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99525217191703,
-                38.893854878783955
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5979.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99106693603026,
-                38.893841601745905
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5979.0,
-                8424.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99109097265475,
-                38.889254039074544
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8424.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99527620854151,
-                38.889267316112594
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                439.9,
-                7420.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9949654,
-                38.8898131
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                439.9,
-                7420.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9949654,
-                38.8898131
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002000",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/info.json",
-          "type": "ImageService2",
-          "height": 8404,
-          "width": 5995
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3809.0,7824.0 499.6,7835.3 501.8,4956.6 -0.0,4959.0 -0.0,4689.6 501.8,4425.1 495.9,904.0 5242.0,963.7 5420.3,1202.1 5407.0,6406.2 3799.3,6408.2 3809.0,7824.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2215.6,
-                904.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9937618,
-                38.8898126
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                495.9,
-                904.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9949654,
-                38.8898131
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002030",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/info.json",
-          "type": "ImageService2",
-          "height": 8228,
-          "width": 5702
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5702.0,1927.6 5702.0,8228.0 -0.0,8228.0 -0.0,2377.6 561.8,2367.8 564.5,1281.8 4773.9,1294.2 4778.4,1925.7 5702.0,1927.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1623.4,
-                1288.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0199119,
-                38.886887
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4470.4,
-                1288.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0199096,
-                38.8850455
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002140",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/info.json",
-          "type": "ImageService2",
-          "height": 8189,
-          "width": 5723
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"447.8,411.1 1491.0,502.5 3536.3,-0.0 4234.0,-0.0 4910.2,1894.6 447.8,1913.4 447.8,411.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                447.9,
-                6017.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.018937,
-                38.9072367
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                447.9,
-                7449.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0199003,
-                38.9072369
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002210",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/info.json",
-          "type": "ImageService2",
-          "height": 8217,
-          "width": 5692
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"471.7,8051.4 382.1,6262.0 -0.0,6283.2 71.9,304.0 4393.0,88.6 4519.9,2630.7 5312.0,2591.1 5300.3,2288.0 5692.0,2266.3 5692.0,8217.0 1199.4,8217.0 471.7,8051.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1776.0,
-                2591.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0091405,
-                38.8784194
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5312.0,
-                2591.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0092655,
-                38.8764748
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002240",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/info.json",
-          "type": "ImageService2",
-          "height": 8205,
-          "width": 5692
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"425.9,8205.0 416.8,4395.4 427.7,4199.9 600.2,4202.3 581.3,811.8 272.0,808.3 271.9,0.0 2868.0,0.0 2868.0,744.8 5124.8,678.7 5129.2,8205.0 425.9,8205.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2868.0,
-                4202.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.007465,
-                38.8746408
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2868.0,
-                807.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0074646,
-                38.8764749
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002300",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/info.json",
-          "type": "ImageService2",
-          "height": 8199,
-          "width": 5707
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3401.9,1664.1 3394.7,517.9 4696.3,517.1 4691.7,6333.2 3406.4,5660.3 3405.9,5989.9 2897.2,5724.8 2115.0,5727.0 2116.5,6599.2 -0.0,6595.8 -0.0,1670.5 3401.9,1664.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2111.6,
-                5315.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9937643,
-                38.8835872
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2111.6,
-                3799.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9937644,
-                38.8846064
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002350",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/info.json",
-          "type": "ImageService2",
-          "height": 8180,
-          "width": 5696
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"178.0,7588.9 -0.0,2748.3 225.0,2748.9 864.5,961.1 867.2,-0.0 5435.3,-0.0 5428.6,1395.1 5694.9,1395.3 5696.0,7515.9 5388.7,7514.1 5388.1,7615.1 178.0,7588.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1792.0,
-                7596.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0020423,
-                38.8784089
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5320.0,
-                5488.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0005599,
-                38.8764983
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002370",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/info.json",
-          "type": "ImageService2",
-          "height": 8182,
-          "width": 5642
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2722.4,8182.0 224.4,8182.0 266.6,196.3 997.6,196.2 997.0,-0.0 5642.0,-0.0 5608.7,7995.2 2877.8,7995.2 2722.4,8182.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1863.3,
-                2959.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.990248,
-                38.8784074
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1863.3,
-                196.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9883153,
-                38.8784076
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002380",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/info.json",
-          "type": "ImageService2",
-          "height": 8170,
-          "width": 5664
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8170.0 -0.0,543.9 5664.0,509.4 5664.0,8170.0 -0.0,8170.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                380.0,
-                307.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9937667,
-                38.8764942
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5392.0,
-                307.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9902047,
-                38.876463
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002410",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/info.json",
-          "type": "ImageService2",
-          "height": 8155,
-          "width": 5696
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,914.9 5382.9,2941.3 5353.1,8155.0 0.0,8155.0 0.0,914.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1876.0,
-                7391.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.986656,
-                38.862381
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3760.0,
-                3863.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9887945,
-                38.8638066
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002440 [3]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5664.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8224.0"
-        }
-      ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440/info.json",
-          "type": "ImageService2",
-          "height": 8224,
-          "width": 5664
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1984.6 -0.0,-0.0 5664.0,0.0 5664.0,2140.8 2160.9,7967.8 647.1,8036.6 -0.0,1984.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00080415722887,
-                38.90690191140915
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5664.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99684304494077,
-                38.9067819923394
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5664.0,
-                8224.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99706681563661,
-                38.902306694885944
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8224.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00102792792472,
-                38.902426613955704
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                428.0,
-                2292.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0005672,
-                38.9056456
+                -76.9825125666523,
+                38.863373657478384
               ]
             }
           }
@@ -14962,11 +15999,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -14985,8 +16022,8 @@
           "value": "8160.0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15012,27 +16049,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3767.3,
-                2288.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9995279,
-                38.9201209
+                -77.00218457504158,
+                38.92140758011708
               ]
             }
           },
@@ -15040,20 +16080,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                204.0,
-                204.0
+                5551.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00203,
-                38.921298
+                -76.9982367422962,
+                38.92140833023885
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5551.0,
+                8160.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99823532562954,
+                38.91689284690551
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8160.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00218315837492,
+                38.91689209678374
               ]
             }
           }
@@ -15071,11 +16153,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -15094,8 +16176,8 @@
           "value": "2122.4"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15114,7 +16196,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2636.7,7247.5 2817.3,7178.9 2882.8,6037.6 5551.0,6037.6 5551.0,8151.4 2636.7,7850.2 2636.7,7247.5\" /></svg>"
+          "value": "<svg><polygon points=\"2817.3,7178.8 2882.8,6037.6 5551.0,6037.6 5551.0,8151.1 2636.7,7850.0 2636.7,7247.4 2817.3,7178.8\" /></svg>"
         }
       },
       "body": {
@@ -15143,8 +16225,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02007209013655,
-                38.91359374114371
+                -77.02007215867829,
+                38.913593940391294
               ]
             }
           },
@@ -15164,8 +16246,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01804133027441,
-                38.91375141322785
+                -77.01804065996731,
+                38.913751669841076
               ]
             }
           },
@@ -15185,8 +16267,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01789373348674,
-                38.91260042611965
+                -77.01789300947968,
+                38.912600263970674
               ]
             }
           },
@@ -15206,29 +16288,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01992449334888,
-                38.91244275403551
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2804.6,
-                7064.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0198837,
-                38.9130461
+                -77.01992450819066,
+                38.91244253452089
               ]
             }
           }
@@ -15246,11 +16307,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -15269,8 +16330,8 @@
           "value": "5302.0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15296,27 +16357,30 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1939.5,
-                5601.9
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0090875,
-                38.9251261
+                -77.00648407466112,
+                38.927839611667224
               ]
             }
           },
@@ -15324,20 +16388,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                911.8,
-                4898.2
+                3399.2,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0090823,
-                38.9258397
+                -77.0050837159716,
+                38.92623356101673
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3399.2,
+                5302.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00830314635687,
+                38.92453348364718
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5302.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00970350504639,
+                38.926139534297675
               ]
             }
           }
@@ -15355,11 +16461,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "0"
         },
         {
           "label": "split_canvas_x",
@@ -15378,8 +16484,8 @@
           "value": "8160.0"
         }
       ],
-      "created": "2026-08-07T17:17:44Z",
-      "modified": "2026-08-07T17:17:44Z",
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15398,34 +16504,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8160.0 0.0,0.0 3116.1,0.0 3267.0,458.2 3266.8,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7632.2 0.0,0.0 3116.1,0.0 3267.0,458.2 3266.8,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0 6.9,7632.2 -0.0,7632.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3264.0,
-                5668.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0089892,
-                38.922372
+                -77.01126285464147,
+                38.92545808270196
               ]
             }
           },
@@ -15433,20 +16542,200 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3264.0,
-                1728.0
+                5536.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.008984,
-                38.9245149
+                -77.00739387034388,
+                38.92545239668696
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5536.0,
+                8160.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00740463988703,
+                38.92101430937731
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8160.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01127362418462,
+                38.921019995392314
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002620",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-08-15T02:07:17Z",
+      "modified": "2026-08-15T02:07:17Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/info.json",
+          "type": "ImageService2",
+          "height": 8160,
+          "width": 5536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"352.2,5833.4 375.8,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0 -0.0,6431.9 352.2,5833.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98034805097286,
+                38.8999605235899
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5536.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.97657280780989,
+                38.899988861965774
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5536.0,
+                8160.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.97651951280878,
+                38.89562750569076
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8160.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98029475597176,
+                38.895599167314884
               ]
             }
           }


### PR DESCRIPTION
Regenerates the results table from the 2026-08-14 baseline under the #300 sheet-equal metric — first table since the weighting change, so the "not comparable" note is replaced with the dated result line (**mean 82.0% across 18 volumes**, vs 80.6 at #300's merge). Rows re-sorted by score; champaign 97.1 tops, LA crosses to 89.8.

Also: adds the missing **richmond** row (LoC-sourced volume — links to its LoC item, as it has no OIM map page), and refreshes all 18 gallery IIIFs from the tagged volume-root copies (the split-resolving ones, per the release recipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)