### PR TITLE
Fit prints the #300 score; guard mis-invocations (#330)

### DIFF
--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -572,8 +572,12 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
             for r in landed
             if r.get("rmse_ft") is not None and r["rmse_ft"] >= 200.0
         )
+        # The pre-#300 land-weighted figures, clearly labelled as such: the
+        # authoritative sheet-equal score prints from `mapsnap fit` (via the
+        # manifest) and `mapsnap score`. An unlabelled "Score:" here spent a
+        # week being mistaken for the project metric (#330).
         print(
-            f"Score: {100 * (good - disaster) / total_land:.1f}% "
+            f"Land-weighted (legacy): {100 * (good - disaster) / total_land:.1f}% "
             f"(<=25ft {100 * good / total_land:.1f}% of land, "
             f">=200ft {100 * disaster / total_land:.1f}%, "
             f"total {total_land / 1e6:.2f} km2)"

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -302,7 +302,11 @@ def main() -> None:
         + f"  (total {total:.0f}s)"
     )
     manifest = json.loads((archived / "manifest.json").read_text())
-    score = manifest.get("metrics", {}).get("score")
+    # The #300 sheet-equal score lives under metrics.truth (truth_metrics
+    # computes it); the old top-level lookup never matched, so fit's own Score
+    # line silently never printed and compare's legacy land-weighted footer
+    # was the only "Score:" in the log -- the metric confusion behind #330.
+    score = manifest.get("metrics", {}).get("truth", {}).get("score")
     if score:
         print(
             f"\nScore: {score['net']:.1%} "

--- a/mapsnap/score.py
+++ b/mapsnap/score.py
@@ -430,6 +430,27 @@ def main() -> None:
     summaries: list[ScoreSummary] = []
     for path in args.generated:
         generated = Path(path)
+        # A truth set with split panels REQUIRES the volume's oim/ panels dir:
+        # without it every split panel goes unmatched and counts unplaced,
+        # silently cratering split-heavy volumes (champaign scored 70.0 instead
+        # of 97.1 when the 2026-08-14 archives were scored from a directory
+        # with no oim/ -- the #330 scare). Fail loudly instead.
+        volume_dir = generated.parent
+        truth_path = Path(args.truth) if args.truth else volume_dir / "main.iiif.json"
+        if truth_path.exists() and not (volume_dir / "oim").is_dir():
+            truth_doc = json.loads(truth_path.read_text())
+            has_splits = any(
+                "__" in str(item.get("label") or "")
+                or "[" in str(item.get("label") or "")
+                for item in truth_doc.get("items", [])
+            )
+            if has_splits:
+                sys.exit(
+                    f"{volume_dir} has no oim/ panels directory, but its truth "
+                    f"contains split panels -- scoring here would silently count "
+                    f"every split as unplaced. Score the volume-root IIIF (which "
+                    f"sits beside oim/), not an archive copy."
+                )
         pages = volume_page_scores(
             generated, street_near_m=args.street_near_m, truth=args.truth
         )


### PR DESCRIPTION
Closes #330. The root causes of the metric scare, each fixed:

1. **fit's own Score line never printed** — the manifest has recorded the correct #300 sheet-equal score all along (under `metrics.truth.score`), but fit.py looked it up at `metrics.score`. One-line path fix; every fit now ends with the authoritative number (verified: chicago's manifest holds net 0.7997 = the CLI's 80.0).
2. **compare's footer was the impostor** — its pre-#300 land-weighted line was the only unlabelled `Score:` in fit logs. Relabelled `Land-weighted (legacy):` rather than removed, since its RMSE context is still useful and the debugger displays the footer text.
3. **`mapsnap score` now fails loudly** when the target directory's truth has split panels but no `oim/` dir — the archive-copy mis-invocation that scored champaign at 70.0 instead of 97.1 and briefly read as a 2.6-point corpus regression. The error message names the correct invocation.

No metric changes (the soft-ramp idea is deliberately not included per discussion). 45 tests green; smoke-tested both the normal path and the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)