### PR TITLE
Failed fits seed snap's rescue from candidate-GCP hints and neighbor stamps

### DIFF
--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -30,7 +30,7 @@ import json
 import math
 import statistics
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import cv2
@@ -108,6 +108,10 @@ class PageUnit:
     # snap's search, because a demoted pose is measurably a good init (refine
     # fixed richmond p353's 3.06x scale error from one).
     demoted_affine: np.ndarray | None = None
+    # Clustered candidate-GCP world positions from a FAILED fit (#335):
+    # location evidence snap's rescue uses as search centers, recorded in the
+    # nofit sidecar. Empty for fitted pages.
+    gcp_hints: list[tuple[float, float]] = field(default_factory=list)
     anchor_truth: bool = False
     anchor_free: bool = False
     rmse_ft: float | None = None  # generated-vs-truth RMSE
@@ -278,6 +282,9 @@ def load_page_units(volume: Path) -> list[PageUnit]:
             keymap_centers = [tuple(c) for c in keymap.get("centers", [])]
             keymap_radius = float(keymap.get("radius_m") or 0.0)
             keymap_regions = keymap.get("regions") or None
+            gcp_hints = [tuple(h) for h in georef.get("gcp_hints") or []]
+        else:
+            gcp_hints = []
 
         unit = PageUnit(
             stem=stem,
@@ -289,6 +296,7 @@ def load_page_units(volume: Path) -> list[PageUnit]:
             split_truth=stem in split_truth_parents,
             gen_affine=gen_affine,
             demoted_affine=demoted_affine,
+            gcp_hints=gcp_hints,
             inlier_intersections=inlier_int,
             inlier_streets=inlier_str,
             keymap_centers=keymap_centers,

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -99,6 +99,10 @@ class ProcessResult:
     rotation: float | None = None  # directed rotation in radians, set on success
     deferred: dict | None = None  # set when deferred (exactly 1 GCP, needs scale)
     nofit_written: bool = False  # process_image already wrote a --debug nofit sidecar
+    # Clustered world positions of the page's candidate GCPs when no fit was
+    # reached (#335): a failed RANSAC still located matched street crossings,
+    # and those clusters seed snap's rescue search like contradiction hints do.
+    gcp_hints: list[tuple[float, float]] | None = None
 
 
 def label_features(labels: list[dict]) -> list[LabelFeature]:
@@ -1121,6 +1125,41 @@ def straight_intersection_geo(
         lon0 + float(point[0]) / (cos0 * _FT_PER_DEG_LAT),
         lat0 + float(point[1]) / _FT_PER_DEG_LAT,
     )
+
+
+def cluster_gcp_hints(
+    gcps: list["IntersectionGCP"], tol_m: float = 100.0, max_hints: int = 3
+) -> list[tuple[float, float]]:
+    """Up to ``max_hints`` clustered world positions of candidate GCPs (#335).
+
+    A page that failed to fit still matched street pairs to OSM crossings;
+    their positions cluster near the page's true location when the matches are
+    right (measured corpus-wide: p25 124 m, median 206 m on unplaced truth
+    pages) and scatter on aliases. Single-linkage clusters within ``tol_m``,
+    largest first -- the biggest cluster is the mutually-consistent story.
+    """
+    import math as _math
+
+    clusters: list[list[tuple[float, float]]] = []
+    for gcp in gcps:
+        lon, lat = gcp.geo
+        ky = 110540.0
+        kx = 111320.0 * _math.cos(_math.radians(lat))
+        for cluster in clusters:
+            if any(
+                _math.hypot((lon - x) * kx, (lat - y) * ky) <= tol_m for x, y in cluster
+            ):
+                cluster.append((lon, lat))
+                break
+        else:
+            clusters.append([(lon, lat)])
+    clusters.sort(key=len, reverse=True)
+    hints = []
+    for cluster in clusters[:max_hints]:
+        xs = sorted(x for x, _ in cluster)
+        ys = sorted(y for _, y in cluster)
+        hints.append((xs[len(xs) // 2], ys[len(ys) // 2]))
+    return hints
 
 
 def find_intersection_gcps(
@@ -2485,17 +2524,26 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
     # the channel was asked and had no answer. Skip this when process_image already wrote a
     # richer --debug nofit sidecar (with seed-pair fits) to the same path.
     if (
-        keymap is not None
+        (keymap is not None or result.gcp_hints)
         and not result.success
         and result.deferred is None
         and not result.nofit_written
     ):
         nofit: dict = {
             "status": sidecar.NOFIT,
-            "keymap": keymap,
             "streets": [],
             "intersections": [],
         }
+        if keymap is not None:
+            nofit["keymap"] = keymap
+        # Candidate-GCP location hints (#335): a failed fit's matched street
+        # crossings, clustered. Snap's rescue reads these as search centers
+        # like contradiction hints; for a keymap-less page they are the only
+        # location evidence on disk.
+        if result.gcp_hints:
+            nofit["gcp_hints"] = [
+                [round(lon, 7), round(lat, 7)] for lon, lat in result.gcp_hints
+            ]
         from mapsnap.printed_scale import printed_scale_ft as _note_read
 
         _note = _note_read(Path(derive_paths(image_path)[0]))
@@ -2982,7 +3030,7 @@ def process_image(
                 f"Only 1 distinct intersection: {descr}; skipping (use --disable-one-gcp-fits to suppress).",
                 file=sys.stderr,
             )
-            return ProcessResult(success=False)
+            return ProcessResult(success=False, gcp_hints=cluster_gcp_hints(gcps))
         print(
             f"Only 1 distinct intersection: {descr}; deferring for median-scale processing.",
             file=sys.stderr,
@@ -3052,8 +3100,12 @@ def process_image(
                 truth_polygons=truth_polygons,
                 gcp_pair_records=pair_records,
             )
-            return ProcessResult(success=False, nofit_written=True)
-        return ProcessResult(success=False)
+            return ProcessResult(
+                success=False,
+                nofit_written=True,
+                gcp_hints=cluster_gcp_hints(gcps),
+            )
+        return ProcessResult(success=False, gcp_hints=cluster_gcp_hints(gcps))
     print(
         f"RANSAC: {len(inlier_feat_indices)} / {len(features)} inlier labels",
         file=sys.stderr,

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -1138,16 +1138,14 @@ def cluster_gcp_hints(
     pages) and scatter on aliases. Single-linkage clusters within ``tol_m``,
     largest first -- the biggest cluster is the mutually-consistent story.
     """
-    import math as _math
-
     clusters: list[list[tuple[float, float]]] = []
     for gcp in gcps:
         lon, lat = gcp.geo
         ky = 110540.0
-        kx = 111320.0 * _math.cos(_math.radians(lat))
+        kx = 111320.0 * math.cos(math.radians(lat))
         for cluster in clusters:
             if any(
-                _math.hypot((lon - x) * kx, (lat - y) * ky) <= tol_m for x, y in cluster
+                math.hypot((lon - x) * kx, (lat - y) * ky) <= tol_m for x, y in cluster
             ):
                 cluster.append((lon, lat))
                 break

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -3094,7 +3094,17 @@ def process_image(
                 labels_path,
                 centerlines_path,
                 initial_pair=None,
-                extra_fields={"nofit": True, "status": sidecar.NOFIT},
+                extra_fields={
+                    "nofit": True,
+                    "status": sidecar.NOFIT,
+                    # #335: the failed fit's clustered candidate-GCP positions
+                    # -- this path writes the sidecar itself, so the hints must
+                    # ride extra_fields (the wrapper skips nofit_written pages).
+                    "gcp_hints": [
+                        [round(lon, 7), round(lat, 7)]
+                        for lon, lat in cluster_gcp_hints(gcps)
+                    ],
+                },
                 parameters=parameters,
                 keymap=keymap,
                 truth_polygons=truth_polygons,

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1853,3 +1853,21 @@ def test_haversine_m_one_degree_latitude():
     # One degree of latitude is ~111 km anywhere on the globe.
     assert abs(haversine_m(0.0, 0.0, 1.0, 0.0) - 111_320) < 500
     assert haversine_m(38.9, -77.0, 38.9, -77.0) == 0.0
+
+
+def test_cluster_gcp_hints_ranks_consistent_cluster_first():
+    """The mutually-consistent cluster outranks a lone alias; tol merges near points."""
+    from types import SimpleNamespace
+
+    from mapsnap.georef_from_labels import cluster_gcp_hints
+
+    def gcp(lon, lat):
+        return SimpleNamespace(geo=(lon, lat))
+
+    near = [gcp(-96.0000, 46.0000), gcp(-96.0003, 46.0002), gcp(-96.0001, 46.0004)]
+    alias = [gcp(-96.1, 46.1)]
+    hints = cluster_gcp_hints(near + alias)
+    assert len(hints) == 2
+    # Largest cluster (the 3 near points) first, its median inside the group.
+    assert abs(hints[0][0] - -96.0001) < 1e-3 and abs(hints[0][1] - 46.0002) < 1e-3
+    assert cluster_gcp_hints([]) == []

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1857,12 +1857,10 @@ def test_haversine_m_one_degree_latitude():
 
 def test_cluster_gcp_hints_ranks_consistent_cluster_first():
     """The mutually-consistent cluster outranks a lone alias; tol merges near points."""
-    from types import SimpleNamespace
-
     from mapsnap.georef_from_labels import cluster_gcp_hints
 
-    def gcp(lon, lat):
-        return SimpleNamespace(geo=(lon, lat))
+    def gcp(lon: float, lat: float) -> IntersectionGCP:
+        return _make_gcp((0.0, 0.0), (lon, lat))
 
     near = [gcp(-96.0000, 46.0000), gcp(-96.0003, 46.0002), gcp(-96.0001, 46.0004)]
     alias = [gcp(-96.1, 46.1)]

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -2563,7 +2563,13 @@ def select_argmax(
                         continue
             top = record["candidates"][0]
             score = top.get("select_score")
-            margin = distinct_margin(record)
+            # Pose-aware twins only for RESCUE: a fitted page's challenger
+            # must beat the legacy (conservative) ambiguity test -- the
+            # unscoped fix flipped nashville p6 (11 ft -> 425 ft) through
+            # this very path's "energy" choice.
+            margin = distinct_margin(
+                record, pose_aware=record.get("fit_state") in RESCUE_STATES
+            )
             corroborated = (
                 record.get("fit_state") in RESCUE_STATES
                 and score is not None

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1366,8 +1366,20 @@ def distinct_margin(record: dict) -> float | None:
             cand_center[1],
             cand_center[0],
         )
+
+        def pose_theta(c):
+            # The REFINED pose's rotation, not the ladder rung it started
+            # from: richmond p353's two 6-10 ft twins carried rung thetas
+            # 14.65 deg apart while their refined poses coincided, so the
+            # rung-based gap called the winner's duplicate a distinct rival
+            # and the margin bar abstained on a correct placement.
+            a = c.get("world_affine")
+            if a is None:
+                return c["theta_deg"]
+            return math.degrees(math.atan2(-a[1][0], a[0][0]))
+
         theta_gap = abs(
-            (candidate["theta_deg"] - top["theta_deg"] + 180.0) % 360.0 - 180.0
+            (pose_theta(candidate) - pose_theta(top) + 180.0) % 360.0 - 180.0
         )
         if separation > DISTINCT_SEPARATION_M or theta_gap > DISTINCT_THETA_DEG:
             # Candidates are sorted by select_score, so the first distinct

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1374,7 +1374,7 @@ DISTINCT_SEPARATION_M = 100.0
 DISTINCT_THETA_DEG = 10.0
 
 
-def distinct_margin(record: dict) -> float | None:
+def distinct_margin(record: dict, pose_aware: bool = True) -> float | None:
     """Rank-1's select_score lead over the best *distinct* alternative lock.
 
     Near-identical twins (the same lock found from two search centers, within
@@ -1420,8 +1420,14 @@ def distinct_margin(record: dict) -> float | None:
             # 14.65 deg apart while their refined poses coincided, so the
             # rung-based gap called the winner's duplicate a distinct rival
             # and the margin bar abstained on a correct placement.
+            #
+            # pose_aware=False keeps the legacy rung-theta comparison for the
+            # CHALLENGE path: replacing a placed page is the risky direction,
+            # and the rung-collapse conservatism was functioning as a brake --
+            # scoping it away flipped nashville p6 (11 ft -> 425 ft) the first
+            # time the fix ran unscoped.
             a = c.get("world_affine")
-            if a is None:
+            if not pose_aware or a is None:
                 return c["theta_deg"]
             return math.degrees(math.atan2(-a[1][0], a[0][0]))
 
@@ -2039,7 +2045,7 @@ def arbitrate_challenge(record: dict, arbitrate_gate: float) -> dict | None:
     score = top.get("select_score")
     if score is None or score < arbitrate_gate:
         return None
-    margin = distinct_margin(record)
+    margin = distinct_margin(record, pose_aware=False)
     if margin is None or margin < PRODUCTION_GATE_MARGIN:
         return None
     disagreement = grid_rmse_ft_between(

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -729,13 +729,15 @@ def build_page_context(
     for lon, lat in unit.gcp_hints:
         if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in centers):
             centers = centers + [(lon, lat)]
-    # Neighbor-stamp priors (#335 phase 2): only for pages the pipeline did
-    # not place — fitted pages neither need them nor should have their
-    # local-challenge search widened by them.
-    if unit.fit_state != "fitted":
-        for lon, lat in neighbor_stamp_centers(vctx, unit.stem):
-            if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in centers):
-                centers = centers + [(lon, lat)]
+    # Neighbor-stamp priors (#335 phase 2): ONLY for unplaced pages with no
+    # other search centers — the keymap-less class (schenectady's 100-114
+    # block) where nothing else reaches. Widening an existing search proved
+    # harmful even with worse-ranked additions: the volume-energy arbitration
+    # is a joint optimization over the candidate pool, and adding stamp
+    # candidates to nashville p6 (which already had 4 centers) re-ranked its
+    # selection from the correct 11 ft pose to a 4x-scale 425 ft one.
+    if unit.fit_state != "fitted" and not centers:
+        centers = list(neighbor_stamp_centers(vctx, unit.stem))
     seed_affine = None
     if unit.fit_state == "fitted" and unit.gen_affine is not None:
         # For arbitration the incumbent pose itself is the natural search

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -96,6 +96,9 @@ class VolumeContext:
     radius_m: float
     radius_source: str
     median_theta_deg: float | None
+    # Lazily-built map of stem -> FittedPage for neighbor-stamp priors
+    # (#335 phase 2); None until the first unplaced page asks for it.
+    stamp_fitted: dict | None = None
 
 
 def ring_centroid(ring: list[list[float]]) -> tuple[float, float]:
@@ -664,6 +667,43 @@ def volume_note_calibration(vctx: VolumeContext) -> tuple[float, str]:
     return _note_calibration_cache[key]
 
 
+def neighbor_stamp_centers(
+    vctx, stem: str, limit: int = 4
+) -> list[tuple[float, float]]:
+    """Incoming-claim stamp positions from PLACED neighbors (#335 phase 2).
+
+    A neighbor's printed claim of this page, mapped through the neighbor's own
+    published pose, is a world point on the shared boundary — measured over
+    the corpus's unplaced truth pages: mutual-claim stamps sit at median 178 m
+    from truth (83 pages), one-sided at 416 m (24 more). This was previously
+    computed only for gate-DEMOTED pages (contradiction hints); every unplaced
+    page with placed claiming neighbors gets it now. Mutual-claim stamps rank
+    first (the ~100%-precision tier); the rescue bars absorb the junk tail of
+    one-sided claims.
+    """
+    adjacency = vctx.adjacency
+    if not adjacency:
+        return []
+    if vctx.stamp_fitted is None:
+        from mapsnap.adjacency_gate import load_fitted_pages
+
+        vctx.stamp_fitted = load_fitted_pages(vctx.volume, adjacency)
+    from mapsnap.adjacency_gate import stamp_worlds
+
+    mutual_pairs = {frozenset(edge) for edge in adjacency.get("adjacency", [])}
+    mutual_pts: list[tuple[float, float]] = []
+    oneside_pts: list[tuple[float, float]] = []
+    for nstem, neighbor in vctx.stamp_fitted.items():
+        if nstem == stem:
+            continue
+        for point in stamp_worlds(adjacency, neighbor, stem):
+            if frozenset((nstem, stem)) in mutual_pairs:
+                mutual_pts.append(point)
+            else:
+                oneside_pts.append(point)
+    return (mutual_pts + oneside_pts)[:limit]
+
+
 def build_page_context(
     vctx: VolumeContext, unit: PageUnit
 ) -> tuple[PageContext | None, str]:
@@ -689,6 +729,13 @@ def build_page_context(
     for lon, lat in unit.gcp_hints:
         if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in centers):
             centers = centers + [(lon, lat)]
+    # Neighbor-stamp priors (#335 phase 2): only for pages the pipeline did
+    # not place — fitted pages neither need them nor should have their
+    # local-challenge search widened by them.
+    if unit.fit_state != "fitted":
+        for lon, lat in neighbor_stamp_centers(vctx, unit.stem):
+            if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in centers):
+                centers = centers + [(lon, lat)]
     seed_affine = None
     if unit.fit_state == "fitted" and unit.gen_affine is not None:
         # For arbitration the incumbent pose itself is the natural search

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -365,6 +365,7 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
         keymap_radius = 0.0
         keymap_regions = None
         demoted_affine = None
+        gcp_hints: list[tuple[float, float]] = []
         if georef is not None:
             if state == "fitted":
                 gen_affine = page_world_affine(georef)
@@ -377,6 +378,7 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
             keymap = georef.get("keymap") or {}
             keymap_centers = [tuple(c) for c in keymap.get("centers", [])]
             keymap_radius = float(keymap.get("radius_m") or 0.0)
+            gcp_hints = [tuple(h) for h in georef.get("gcp_hints") or []]
             keymap_regions = keymap.get("regions") or None
 
         units.append(
@@ -390,6 +392,7 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
                 split_truth=False,
                 gen_affine=gen_affine,
                 demoted_affine=demoted_affine,
+                gcp_hints=gcp_hints,
                 inlier_intersections=effective_gcps,
                 inlier_streets=0,
                 keymap_centers=keymap_centers,
@@ -678,6 +681,12 @@ def build_page_context(
     for lon, lat in contradiction_centers(
         vctx.volume, panel_base(unit.stem) or unit.stem
     ):
+        if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in centers):
+            centers = centers + [(lon, lat)]
+    # Candidate-GCP hints (#335): a failed fit's matched crossings, weighed
+    # like contradiction hints -- for a keymap-less page they are the only
+    # centers, which is what makes rescue reachable at all there.
+    for lon, lat in unit.gcp_hints:
         if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in centers):
             centers = centers + [(lon, lat)]
     seed_affine = None

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -726,9 +726,16 @@ def build_page_context(
     # Candidate-GCP hints (#335): a failed fit's matched crossings, weighed
     # like contradiction hints -- for a keymap-less page they are the only
     # centers, which is what makes rescue reachable at all there.
-    for lon, lat in unit.gcp_hints:
-        if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in centers):
-            centers = centers + [(lon, lat)]
+    # Like the stamp centers below, hints only serve pages with NO other
+    # centers: the volume-energy arbitration is a joint optimization, and
+    # widening an existing pool re-ranked nashville p6's rescue from its
+    # correct 11 ft pose to a 4x-scale 425 ft one. Both richmond conversions
+    # (p353 6.1 ft, p348 12.7 ft) are no_keymap pages whose hints are their
+    # only centers, so the narrow scope keeps every measured win.
+    if not centers:
+        for lon, lat in unit.gcp_hints:
+            if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in centers):
+                centers = centers + [(lon, lat)]
     # Neighbor-stamp priors (#335 phase 2): ONLY for unplaced pages with no
     # other search centers — the keymap-less class (schenectady's 100-114
     # block) where nothing else reaches. Widening an existing search proved

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1339,14 +1339,32 @@ def distinct_margin(record: dict) -> float | None:
     if not candidates or candidates[0].get("select_score") is None:
         return None
     top = candidates[0]
+
+    def pose_center(c):
+        # The candidate's REFINED pose center, not its search center: two
+        # searches from different hint centers converge to the same lock
+        # (richmond p353's 6 ft and 10 ft twins came from hint clusters 250 m
+        # apart), and twin-ness is a property of where the pose LANDED.
+        a = c.get("world_affine")
+        if a is None:
+            return c["center"]
+        w = record.get("width") or 0
+        h = record.get("height") or 0
+        return (
+            a[0][0] * w / 2 + a[0][1] * h / 2 + a[0][2],
+            a[1][0] * w / 2 + a[1][1] * h / 2 + a[1][2],
+        )
+
+    top_center = pose_center(top)
     for candidate in candidates[1:]:
         if candidate.get("select_score") is None:
             continue
+        cand_center = pose_center(candidate)
         separation = haversine_m(
-            top["center"][1],
-            top["center"][0],
-            candidate["center"][1],
-            candidate["center"][0],
+            top_center[1],
+            top_center[0],
+            cand_center[1],
+            cand_center[0],
         )
         theta_gap = abs(
             (candidate["theta_deg"] - top["theta_deg"] + 180.0) % 360.0 - 180.0


### PR DESCRIPTION
Phases 1 and 2 of #335: a page that could not be fit now seeds snap's rescue from whatever location evidence it does have — its own candidate GCPs, and its neighbours' printed claims. Validated: **richmond p353 places at 6.1 ft** (unplaced since onboarding), richmond 78.5 → **79.6 (+1.1)**, disasters unchanged.

## The chain

1. **Phase 1 — candidate-GCP hints.** A failed fit clusters its candidate-GCP world positions (single-linkage 100 m, top 3, largest cluster first — the mutually-consistent story outranks lone aliases) and records them as `gcp_hints` in the failure sidecar. Written on all three failure paths, including the debug-nofit path that writes its own sidecar, and *even for keymap-less pages* — narrowing #334's no-sidecar gap.
2. **Phase 2 — neighbour-stamp centres.** A neighbour's printed claim of a page, through the neighbour's published pose, is a world point on their shared boundary: median 178 m from truth for mutual claims (83 unplaced corpus pages), 416 m one-sided. This geometry previously existed only for gate-demoted pages via contradiction hints; now any unplaced page with placed claiming neighbours gets them as rescue centres, mutual first.
3. **snap**: both PageUnit loaders (the #315 twin-loader lesson) carry hints and stamps; `build_page_context` appends them to rescue search centres. Candidates from these centres face the unchanged rescue bars and reconcile entry.

## Both centre sources are scoped to pages with NO other search centres

Widening an *existing* search proved harmful even when the added candidates ranked worse individually: volume-energy arbitration is a joint optimization over the whole pool, so extra centres on nashville p6 (which already had keymap centres) re-ranked its selection from the correct 11 ft rescue to a 4×-scale 425 ft one — first via stamps, then again via phase-1 hints. Both are now restricted to centre-less pages, which is exactly the target class (schenectady's keymap-less 100–114 block; both richmond conversions are `no_keymap` pages), and leaves every existing search pool untouched.

## The bug the validation exposed (pre-existing, now fixed)

p353's rescue found the correct lock TWICE (6.2/9.9 ft, select 1.60/1.59) from hint clusters 250 m apart — and `distinct_margin`'s twin test abstained on margin 0.015 against the winner's own duplicate. Root cause in two layers: the test compared the ladder-rung `theta_deg` (search entry) rather than the REFINED pose's rotation — the two entries were 14.65° apart while their refined poses coincided. With pose-derived theta (and pose-centre separation made explicit), the margin is measured against the genuinely distinct rival: 0.015 → 1.076.

**Scoped to rescue.** An unscoped first run flipped nashville p6 (11 ft → 425 ft): the rung-theta twin collapse had been acting as an accidental brake on fitted-page challenges, and the arbitrate path's docstring names why it should stay — replacing a placed page is the risky direction, ties keep the incumbent. `arbitrate_challenge` and the selection path (scoped by `fit_state`) keep the legacy margin; rescue keeps the fix, which richmond p353's placement depends on. Rescues of *unplaced* pages that converge to one lock from multiple rungs may still flip on the next corpus run — confident locks are the likeliest beneficiaries.

## Honest scoping from validation

- The corpus scan's 26-page crossing pool overcounts: OIM panel-numbering swaps created phantom targets (champaign's "unplaced" p13__1 is truth's p13__2 at 7.9 ft), sliver panels carry negligible weight, and admission gates drop some scan-level matches before GCPs form (richmond p348: 7 matched names in the scan, zero pipeline GCPs). Realistic pool: a handful of base pages.
- The narrow centre-less scope deliberately trades reach for safety. Widening to pages that already have centres needs the joint-arbitration interaction understood first (#270), not a bar tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
