### PR TITLE
compare prints the #300 score with 25-50/50-200ft bands; truth self-compare scores 100%

### DIFF
--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -606,6 +606,46 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
             )
 
 
+def print_sheet_equal_score(truth_path: Path, generated_path: Path) -> None:
+    """Print the #300 sheet-equal score footer, or one line saying why not.
+
+    The number matches ``mapsnap score`` and the Score line of ``mapsnap fit``
+    exactly: the volume is the GENERATED file's directory, whose oim/ panels
+    and centerlines.geojson supply the split weights and land fractions. The
+    "Land-weighted (legacy)" footer above it predates #300.
+    """
+    # Imported here because score.py imports compare_pages from this module.
+    from mapsnap.score import summarize, volume_page_scores
+
+    volume = generated_path.parent
+    if default_centerlines(volume) is None:
+        print(
+            f"\nScore: unavailable -- {volume} has no centerlines.geojson "
+            "(needed for land weights)"
+        )
+        return
+    if not (volume / "oim").is_dir():
+        # The #330 trap: scoring a directory with no oim/ silently counts
+        # every split panel as unplaced. Refuse rather than mislead.
+        truth_doc = json.loads(truth_path.read_text())
+        has_splits = any(
+            "__" in str(item.get("label") or "") or "[" in str(item.get("label") or "")
+            for item in truth_doc.get("items", [])
+        )
+        if has_splits:
+            print(
+                f"\nScore: unavailable -- truth has split panels but {volume} "
+                "has no oim/ panels directory; score the volume-root IIIF"
+            )
+            return
+    summary = summarize(volume_page_scores(generated_path, truth=truth_path))
+    print(
+        f"\nScore: {summary.net_score:.1%} "
+        f"(<=25ft {summary.good_share:.1%}, >=200ft {summary.disaster_share:.1%}, "
+        f"{summary.n_placed}/{summary.n_pages} pages placed)"
+    )
+
+
 def print_tsv(rows: list[dict], missing: list[dict]) -> None:
     """Print all results as TSV for copy/paste into a spreadsheet.
 
@@ -672,6 +712,22 @@ def annotation_split_index(item: dict) -> int | None:
     """Return split number N from a generated annotation id like '...__N/georef'."""
     m = re.search(r"__(\d+)/", item.get("id", ""))
     return int(m.group(1)) if m else None
+
+
+def annotation_is_own_output(item: dict) -> bool:
+    """True when the annotation came from make_iiif_georef rather than OIM.
+
+    Our writer always emits "streets"/"intersections" metadata entries (99/99
+    across the archived generated files); OIM annotations never do (0/150 on
+    an OIM truth set). The distinction decides how a '[N]'-labeled item with
+    no '__N' id suffix is graded: ours are whole-page placements whose label
+    marker leaked from the truth-side label source, while OIM's are genuine
+    panel fits displayed over one panel only.
+    """
+    return any(
+        entry.get("label") in ("streets", "intersections")
+        for entry in item.get("metadata") or []
+    )
 
 
 def ring_to_polygon(ring: list[list[float]]) -> ShapelyPolygon:
@@ -855,6 +911,7 @@ def compare_pages(
         def generated_region(
             gen: dict,
             gen_polygons: dict[int, ShapelyPolygon] = gen_polygons,
+            truth_polygons: dict[int, ShapelyPolygon] = truth_polygons,
             canvas_polygon: ShapelyPolygon = canvas_polygon,
         ) -> ShapelyPolygon | None:
             # The polygons are bound as defaults rather than captured: this page's
@@ -862,6 +919,23 @@ def compare_pages(
             gen_index = annotation_split_index(gen)
             if gen_index is not None:
                 return gen_polygons.get(gen_index)
+            label_index = label_split_index(gen)
+            if label_index is not None and not annotation_is_own_output(gen):
+                # An OIM-shaped item labeled '[N]' is a PANEL fit, not a
+                # whole-page placement: grading it over the whole canvas hands
+                # its siblings' regions to the wrong transform (an OIM truth
+                # file scored against itself lost 28 net points this way). Its
+                # region resolves exactly as the truth side resolves it —
+                # panels.json first, GCP-verified selector as the fallback
+                # (selectors can sit in the crop's frame, OIM#402).
+                region = truth_polygons.get(label_index)
+                if region is not None:
+                    return region
+                return selector_split_polygons([gen]).get(label_index)
+            # Our own annotations without a '__N' id suffix are whole-page
+            # placements even when their label says '[N]' — the marker leaks
+            # from the truth-side label source on sheets our pipeline never
+            # split — so the whole-canvas grading rule applies.
             return canvas_polygon
 
         # Grade every truth panel over ITS OWN region, against whatever
@@ -955,6 +1029,7 @@ def main() -> None:
         print_tsv(rows, missing)
     else:
         print_table(rows, missing)
+        print_sheet_equal_score(Path(args.truth), Path(args.generated))
 
     if args.csv:
         fields = [

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -641,7 +641,8 @@ def print_sheet_equal_score(truth_path: Path, generated_path: Path) -> None:
     summary = summarize(volume_page_scores(generated_path, truth=truth_path))
     print(
         f"\nScore: {summary.net_score:.1%} "
-        f"(<=25ft {summary.good_share:.1%}, >=200ft {summary.disaster_share:.1%}, "
+        f"(<=25ft {summary.good_share:.1%}, 25-50ft {summary.fair_share:.1%}, "
+        f"50-200ft {summary.poor_share:.1%}, >=200ft {summary.disaster_share:.1%}, "
         f"{summary.n_placed}/{summary.n_pages} pages placed)"
     )
 

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -545,3 +545,105 @@ def test_attach_land_annotates_rows_and_strips_rings(tmp_path):
     rows2 = [{"page_key": "p1", "truth_ring": ring}]
     attach_land(rows2, [], tmp_path / "absent.geojson")
     assert rows2[0]["area_m2"] is None and "truth_ring" not in rows2[0]
+
+
+def _write_centerlines_near_split_volume(tmp_path):
+    # One street through both p7 panel footprints (lon -74.0.. and -73.99..).
+    (tmp_path / "centerlines.geojson").write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {"name": "MAIN ST"},
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [[-74.001, 40.0001], [-73.989, 40.0001]],
+                        },
+                    }
+                ],
+            }
+        )
+    )
+
+
+def test_sheet_equal_score_footer_matches_mapsnap_score(tmp_path, capsys):
+    from mapsnap.compare_iiif_georef import print_sheet_equal_score
+
+    truth_path, gen_path = _split_volume(
+        tmp_path,
+        [
+            ("x p7 [1]", -74.0, "https://x/p7__1/georef"),
+            ("x p7 [2]", -73.99, "https://x/p7__2/georef"),
+        ],
+        gen_panels=[
+            [[0, 0], [200, 0], [200, 200], [0, 200]],
+            [[200, 0], [400, 0], [400, 200], [200, 200]],
+        ],
+    )
+    _write_centerlines_near_split_volume(tmp_path)
+    print_sheet_equal_score(truth_path, gen_path)
+    out = capsys.readouterr().out
+    # Generated matches truth panel-for-panel, so the score is perfect.
+    assert "Score: 100.0%" in out
+    assert "2/2 pages placed" in out
+
+
+def test_sheet_equal_score_footer_notes_missing_centerlines(tmp_path, capsys):
+    from mapsnap.compare_iiif_georef import print_sheet_equal_score
+
+    truth_path, gen_path = _split_volume(
+        tmp_path, [("x p7 [1]", -74.0), ("x p7 [2]", -73.99)]
+    )
+    print_sheet_equal_score(truth_path, gen_path)
+    out = capsys.readouterr().out
+    assert "Score: unavailable" in out
+    assert "centerlines.geojson" in out
+
+
+def test_sheet_equal_score_footer_refuses_splits_without_oim(tmp_path, capsys):
+    import shutil
+
+    from mapsnap.compare_iiif_georef import print_sheet_equal_score
+
+    truth_path, gen_path = _split_volume(
+        tmp_path, [("x p7 [1]", -74.0), ("x p7 [2]", -73.99)]
+    )
+    _write_centerlines_near_split_volume(tmp_path)
+    shutil.rmtree(tmp_path / "oim")
+    print_sheet_equal_score(truth_path, gen_path)
+    out = capsys.readouterr().out
+    assert "Score: unavailable" in out
+    assert "oim/" in out
+
+
+def test_truth_scores_perfectly_against_itself(tmp_path):
+    # An OIM truth file in the generated seat: each '[N]' item is a panel
+    # fit, so every truth panel must pair with its own annotation instead of
+    # all grading under whichever item comes first in the file.
+    from mapsnap.compare_iiif_georef import compare_pages
+
+    truth_path, _ = _split_volume(tmp_path, [("x p7 [1]", -74.0), ("x p7 [2]", -73.99)])
+    rows, missing = compare_pages(truth_path, truth_path)
+    assert missing == []
+    assert sorted(r["page_key"] for r in rows) == ["p7__1", "p7__2"]
+    assert all(r["rmse_ft"] < 1.0 for r in rows)
+
+
+def test_own_leaked_label_marker_still_grades_whole_canvas(tmp_path):
+    # Our writer leaks a '[N]' label marker onto whole-page placements of
+    # sheets it never split (the annotation has no '__N' id and displays the
+    # whole canvas). The whole-canvas grading rule must still apply: sibling
+    # panels grade under the same transform rather than going unplaced.
+    from mapsnap.compare_iiif_georef import compare_pages
+
+    truth_path, gen_path = _split_volume(tmp_path, [("x p7 [1]", -74.0)])
+    gen = json.loads(gen_path.read_text())
+    gen["items"][0]["metadata"] = [{"label": "streets", "value": "3"}]
+    gen_path.write_text(json.dumps(gen))
+    rows, missing = compare_pages(truth_path, gen_path)
+    assert missing == []
+    by_key = {r["page_key"]: r for r in rows}
+    assert by_key["p7__1"]["rmse_ft"] < 25.0
+    assert by_key["p7__2"]["rmse_ft"] > 1000.0

--- a/mapsnap/experiments.py
+++ b/mapsnap/experiments.py
@@ -246,6 +246,8 @@ def truth_metrics(truth_path: Path, iiif_path: Path) -> dict:
         metrics["score"] = {
             "net": round(score.net_score, 4),
             "good_share": round(score.good_share, 4),
+            "fair_share": round(score.fair_share, 4),
+            "poor_share": round(score.poor_share, 4),
             "disaster_share": round(score.disaster_share, 4),
             "n_pages": score.n_pages,
             "n_placed": score.n_placed,

--- a/mapsnap/experiments_test.py
+++ b/mapsnap/experiments_test.py
@@ -345,6 +345,8 @@ def test_truth_metrics_includes_score(tmp_path):
     assert score == {
         "net": 1.0,
         "good_share": 1.0,
+        "fair_share": 0.0,
+        "poor_share": 0.0,
         "disaster_share": 0.0,
         "n_pages": 1,
         "n_placed": 1,

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -308,9 +308,17 @@ def main() -> None:
     # was the only "Score:" in the log -- the metric confusion behind #330.
     score = manifest.get("metrics", {}).get("truth", {}).get("score")
     if score:
+        # fair/poor bands are absent from manifests archived before they existed.
+        bands = ""
+        if "fair_share" in score:
+            bands = (
+                f"25-50ft {score['fair_share']:.1%}, "
+                f"50-200ft {score['poor_share']:.1%}, "
+            )
         print(
             f"\nScore: {score['net']:.1%} "
-            f"(<=25ft {score['good_share']:.1%}, >=200ft {score['disaster_share']:.1%}, "
+            f"(<=25ft {score['good_share']:.1%}, {bands}"
+            f">=200ft {score['disaster_share']:.1%}, "
             f"{score['n_placed']}/{score['n_pages']} pages placed)"
         )
     print(f"\nArchived run {run_id} to {archived}")

--- a/mapsnap/score.py
+++ b/mapsnap/score.py
@@ -67,6 +67,7 @@ from mapsnap.compare_iiif_georef import (
 from mapsnap.utils import default_centerlines, source_id_to_page_key
 
 GOOD_FT = 25.0
+FAIR_FT = 50.0  # reporting band only (25-50ft / 50-200ft); no score effect
 DISASTER_FT = 200.0
 STREET_NEAR_M = 120.0
 GRID_N = 15  # land sampling grid per footprint (GRID_N x GRID_N candidate points)
@@ -117,6 +118,8 @@ class ScoreSummary:
     weight: float
     good_weight: float  # rmse <= good threshold
     disaster_weight: float  # placed at rmse >= disaster threshold
+    fair_weight: float = 0.0  # good threshold < rmse <= FAIR_FT
+    poor_weight: float = 0.0  # FAIR_FT < rmse < disaster threshold
 
     @property
     def good_share(self) -> float:
@@ -125,6 +128,14 @@ class ScoreSummary:
     @property
     def disaster_share(self) -> float:
         return self.disaster_weight / self.weight if self.weight else 0.0
+
+    @property
+    def fair_share(self) -> float:
+        return self.fair_weight / self.weight if self.weight else 0.0
+
+    @property
+    def poor_share(self) -> float:
+        return self.poor_weight / self.weight if self.weight else 0.0
 
     @property
     def net_score(self) -> float:
@@ -355,6 +366,16 @@ def summarize(
             p.weight
             for p in pages
             if p.rmse_ft is not None and p.rmse_ft >= disaster_ft
+        ),
+        fair_weight=sum(
+            p.weight
+            for p in pages
+            if p.rmse_ft is not None and good_ft < p.rmse_ft <= FAIR_FT
+        ),
+        poor_weight=sum(
+            p.weight
+            for p in pages
+            if p.rmse_ft is not None and FAIR_FT < p.rmse_ft < disaster_ft
         ),
     )
 

--- a/mapsnap/score_test.py
+++ b/mapsnap/score_test.py
@@ -114,6 +114,9 @@ def test_summarize_net_score_subtracts_disasters():
     assert s.good_share == 0.25
     assert s.disaster_share == 0.25
     assert s.net_score == 0.0  # the disaster cancels the success
+    # Reporting bands: p2's 100ft lands in 50-200ft; nothing in 25-50ft.
+    assert s.fair_share == 0.0
+    assert s.poor_share == 0.25
 
 
 def test_summarize_ignores_sheet_size():


### PR DESCRIPTION
Three related changes to how the project metric is reported.

## 1. `compare` prints the authoritative score

`mapsnap compare truth gen` only printed the legacy land-weighted footer. It now ends with the same `Score:` line that `mapsnap fit` prints, computed through the same `volume_page_scores`/`summarize` path as `mapsnap score`, so all three commands agree to the decimal. When the volume lacks the inputs, it prints a one-line reason instead of exiting (missing `centerlines.geojson`, or the #330 trap: split truth with no `oim/` beside the generated file).

## 2. The Score parenthetical reports all four bands

The line previously named only the two bands the metric acts on (`<=25ft` credit, `>=200ft` penalty). The mid-tier pages between them are exactly the snap-refinement audience, so compare and fit now print:

```
Score: 77.0% (<=25ft 77.9%, 25-50ft 7.6%, 50-200ft 2.6%, >=200ft 0.9%, 117/150 pages placed)
```

`ScoreSummary` grows `fair_share`/`poor_share` (reporting only — `net_score` unchanged), the manifest score dict records them, and `fit` guards the new keys for manifests archived before they existed.

## 3. Truth data now scores 100% against itself

`mapsnap score data/<vol>/main.iiif.json` (truth vs itself) scored schenectady **71.6%** — below the generated file's 77.0%. Root cause: the generated seat of a comparison derived panel identity only from `__N` in the annotation id. OIM items carry opaque ids (`.../resource/17461/`) with the panel index in the `[N]` label, so every truth item degraded to a whole-canvas region and each truth panel graded under whichever item came **first in file order** (p52's items are ordered `[3],[2],[1]` — all three panels graded under `[3]`'s transform).

OIM-shaped `[N]` items now resolve their region the way the truth seat always has: `oim/pN.panels.json` first, GCP-gated selector as fallback (OIM#402 crop-frame selectors — schenectady p11/p63/p72/p96 pass the 0.5 gate while geometrically disagreeing with the panels, which is why selector-first only reached 97.9%). Schenectady truth-vs-truth: **71.6% → 100.0%**.

One subtlety kept production scores untouched: our own writer leaks the `[N]` label marker onto **whole-page** placements of sheets our pipeline never split (99 such items across the archives, e.g. fargo p10 — no `p10.panels.json` exists, the annotation displays the whole canvas). These keep whole-canvas grading, distinguished by the writer's `streets`/`intersections` metadata signature (99/99 of ours carry it, 0/150 OIM items do). Verified: fargo / grand_rapids / LA / columbia / richmond / nashville 2026-08-14 scores are byte-identical before and after.

Follow-up worth its own issue: `make_iiif_georef` writing a `[N]` label on a whole-page annotation is the underlying wart — the label should drop the marker when the pipeline didn't split the sheet.

Tests: score-footer (exact match, missing-centerlines note, splits-without-oim refusal), truth-vs-itself perfection, leaked-label whole-canvas rule, band math in summarize and the manifest dict. Full suite 1045 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)