### PR TITLE
Street-solve: batch consensus scoring (9x on heavy pages, no semantic changes)

### DIFF
--- a/mapsnap/street_solve.py
+++ b/mapsnap/street_solve.py
@@ -386,41 +386,56 @@ def dedupe_scales(
     return kept
 
 
-def propose_translation(
-    first: StreetSegments,
-    second: StreetSegments,
-    line_a: tuple[np.ndarray, np.ndarray],
-    line_b: tuple[np.ndarray, np.ndarray],
-    psi_deg: float,
-    log_scale: float,
-    size: tuple[int, int],
-) -> StreetPose | None:
-    """The pose placing two labels exactly on two given (non-parallel) street lines.
+def batch_point_to_segments(
+    points: np.ndarray, starts: np.ndarray, ends: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """(min distance, bearing of the nearest segment) for MANY points at once.
 
-    With bearing and scale fixed, a label lying on a known line is one linear equation
-    in the translation; two independent lines determine it outright.
+    The vectorized twin of ``align_page_region.point_to_segments`` — the same
+    clipped projection and nearest-segment bearing, evaluated for an (N, 2)
+    array of points in one broadcast instead of N interpreted calls. Returns
+    (distances (N,), bearings (N,) in degrees mod 180).
     """
-    point_a, direction_a = line_a
-    point_b, direction_b = line_b
-    normal_a = np.array([direction_a[1], -direction_a[0]])
-    normal_b = np.array([direction_b[1], -direction_b[0]])
-    matrix = np.array([normal_a, normal_b])
-    if abs(float(np.linalg.det(matrix))) < 1e-6:
-        return None
-    base = (0.0, 0.0, psi_deg, log_scale)
-    offset_a = pose_world_of(base, first[0], size)
-    offset_b = pose_world_of(base, second[0], size)
-    rhs = np.array(
-        [
-            float(normal_a @ (point_a - offset_a)),
-            float(normal_b @ (point_b - offset_b)),
-        ]
-    )
-    try:
-        translation = np.linalg.solve(matrix, rhs)
-    except np.linalg.LinAlgError:
-        return None
-    return (float(translation[0]), float(translation[1]), psi_deg, log_scale)
+    delta = ends - starts  # (S, 2)
+    length_sq = (delta * delta).sum(axis=1)  # (S,)
+    diff = points[:, None, :] - starts[None]  # (N, S, 2)
+    t = np.clip((diff * delta).sum(axis=2) / np.maximum(length_sq, 1e-9), 0, 1)
+    projected = starts[None] + t[:, :, None] * delta[None]  # (N, S, 2)
+    distances = np.linalg.norm(points[:, None, :] - projected, axis=2)  # (N, S)
+    nearest = distances.argmin(axis=1)
+    segment_bearings = np.degrees(np.arctan2(delta[:, 0], delta[:, 1])) % 180.0
+    rows = np.arange(len(points))
+    return distances[rows, nearest], segment_bearings[nearest]
+
+
+LineEquation = tuple[
+    float, float, float, float
+]  # (normal_x, normal_y, n·point, bearing)
+
+
+def line_equations(
+    lines: list[tuple[np.ndarray, np.ndarray]],
+) -> list[LineEquation]:
+    """Each line as (normal, normal·point, bearing) scalars, precomputed once.
+
+    A label lying on a known line is one linear equation in the translation
+    (normal · (t + label_world) = normal · point); two independent lines
+    determine t outright. Extracting the coefficients here lets the consensus
+    search solve each pair in closed form instead of building numpy matrices
+    a million times per page.
+    """
+    equations: list[LineEquation] = []
+    for point, direction in lines:
+        normal_x, normal_y = float(direction[1]), float(-direction[0])
+        equations.append(
+            (
+                normal_x,
+                normal_y,
+                normal_x * float(point[0]) + normal_y * float(point[1]),
+                math.degrees(math.atan2(*direction)) % 180.0,
+            )
+        )
+    return equations
 
 
 def consensus_poses(
@@ -441,48 +456,97 @@ def consensus_poses(
     scored: list[tuple[tuple[int, float], StreetPose, list[StreetSegments], str]] = []
     if lines is None:
         lines = [distinct_lines(c[3], c[4]) for c in constraints]
+    families = [street_name_family(c[2]) for c in constraints]
+    # constraint_bearing depends only on psi, which is fixed for this call, so
+    # every constraint's claimed bearing is one number for the whole search.
+    claimed = [constraint_bearing((0.0, 0.0, psi_deg, 0.0), c[1]) for c in constraints]
+    equations = [line_equations(choices) for choices in lines]
     for log_scale, scale_source in log_scales:
-        for i, first in enumerate(constraints):
+        # Propose: two labels pinned exactly onto two non-parallel street lines
+        # — each line is one linear equation in the translation, solved in
+        # closed form. The same placement reached from different pairs is
+        # merged HERE, on a 1 m grid, rather than scored repeatedly and
+        # deduplicated at 20 m afterwards.
+        bases = [
+            pose_world_of((0.0, 0.0, psi_deg, log_scale), c[0], size)
+            for c in constraints
+        ]
+        proposals: dict[tuple[float, float], StreetPose] = {}
+        for i in range(len(constraints)):
+            base_i = (float(bases[i][0]), float(bases[i][1]))
             for j in range(i + 1, len(constraints)):
-                second = constraints[j]
-                for line_a in lines[i]:
-                    for line_b in lines[j]:
-                        bearing_a = math.degrees(math.atan2(*line_a[1])) % 180.0
-                        bearing_b = math.degrees(math.atan2(*line_b[1])) % 180.0
+                base_j = (float(bases[j][0]), float(bases[j][1]))
+                for nax, nay, ndpa, bearing_a in equations[i]:
+                    rhs_a = ndpa - nax * base_i[0] - nay * base_i[1]
+                    for nbx, nby, ndpb, bearing_b in equations[j]:
                         if (
                             abs(angle_difference_mod180(bearing_a, bearing_b))
                             < gates.bearing_diversity_deg
                         ):
                             continue
-                        pose = propose_translation(
-                            first, second, line_a, line_b, psi_deg, log_scale, size
+                        det = nax * nby - nay * nbx
+                        if abs(det) < 1e-6:
+                            continue
+                        rhs_b = ndpb - nbx * base_j[0] - nby * base_j[1]
+                        tx = (rhs_a * nby - nay * rhs_b) / det
+                        ty = (nax * rhs_b - rhs_a * nbx) / det
+                        proposals.setdefault(
+                            (round(tx), round(ty)), (tx, ty, psi_deg, log_scale)
                         )
-                        if pose is None:
-                            continue
-                        inliers = [
-                            c for c in constraints if is_inlier(pose, c, size, gates)
-                        ]
-                        if len(inliers) < gates.min_inliers:
-                            continue
-                        if len(inliers) < gates.min_inlier_fraction * len(constraints):
-                            # Kansas City p576 slid a block on two streets while four
-                            # others disagreed; a correct pose explains most of them.
-                            continue
-                        if distinct_streets(inliers) < gates.min_distinct_streets:
-                            continue
-                        if bearing_spread(pose, inliers) < gates.bearing_diversity_deg:
-                            continue
-                        mean_position = float(
-                            np.mean([residuals_at(pose, c, size)[0] for c in inliers])
-                        )
-                        scored.append(
-                            (
-                                (len(inliers), -mean_position),
-                                pose,
-                                inliers,
-                                scale_source,
-                            )
-                        )
+        if not proposals:
+            continue
+        # Score every proposal against every constraint in one broadcast per
+        # constraint: with bearing and scale fixed, a proposal only TRANSLATES
+        # each label's world point (pose_world_of is base + t), so the per-pose
+        # residual loop collapses to array arithmetic. This was 97% of the
+        # channel's runtime as 14M scalar residuals_at calls (43 s on a
+        # constraint-heavy Kansas City page; ~2 s batched).
+        poses = list(proposals.values())
+        translations = np.array([(p[0], p[1]) for p in poses])
+        position = np.empty((len(poses), len(constraints)))
+        angle = np.empty_like(position)
+        for k, c in enumerate(constraints):
+            distances, bearings = batch_point_to_segments(
+                translations + bases[k], c[3], c[4]
+            )
+            position[:, k] = distances
+            angle[:, k] = (claimed[k] - bearings + 90.0) % 180.0 - 90.0
+        inlier_mask = (position <= gates.position_gate_m) & (
+            np.abs(angle) <= gates.angle_gate_deg
+        )
+        counts = inlier_mask.sum(axis=1)
+        for p, pose in enumerate(poses):
+            if counts[p] < gates.min_inliers:
+                continue
+            if counts[p] < gates.min_inlier_fraction * len(constraints):
+                # Kansas City p576 slid a block on two streets while four
+                # others disagreed; a correct pose explains most of them.
+                continue
+            indices = np.flatnonzero(inlier_mask[p])
+            inliers = [constraints[q] for q in indices]
+            if len({families[q] for q in indices}) < gates.min_distinct_streets:
+                continue
+            spread = max(
+                (
+                    abs(angle_difference_mod180(claimed[a], claimed[b]))
+                    for x, a in enumerate(indices)
+                    for b in indices[x + 1 :]
+                ),
+                default=0.0,
+            )
+            if spread < gates.bearing_diversity_deg:
+                continue
+            # The batch already holds every inlier's position residual; the
+            # mean falls out for free instead of a second residuals_at pass.
+            mean_position = float(position[p, indices].mean())
+            scored.append(
+                (
+                    (int(counts[p]), -mean_position),
+                    pose,
+                    inliers,
+                    scale_source,
+                )
+            )
     scored.sort(key=lambda entry: entry[0], reverse=True)
     kept: list[tuple[StreetPose, list[StreetSegments], str]] = []
     for _score, pose, inliers, scale_source in scored:

--- a/mapsnap/street_solve_test.py
+++ b/mapsnap/street_solve_test.py
@@ -338,3 +338,39 @@ def test_street_ending_short_still_constrains_the_page():
     after, _ = residuals_at(TRUE_POSE, extended, SIZE)
     assert before > 35.0  # measured to the polyline's end
     assert after < 1.0  # measured across to its line, where the label actually sits
+
+
+def test_batch_point_to_segments_matches_scalar():
+    import pytest
+
+    from mapsnap.keymap.align_page_region import point_to_segments
+    from mapsnap.street_solve import batch_point_to_segments
+
+    rng = np.random.default_rng(0)
+    starts = rng.uniform(-200.0, 200.0, (15, 2))
+    ends = starts + rng.uniform(-80.0, 80.0, (15, 2))
+    points = rng.uniform(-250.0, 250.0, (50, 2))
+    distances, bearings = batch_point_to_segments(points, starts, ends)
+    for k, point in enumerate(points):
+        distance, bearing = point_to_segments(point, starts, ends)
+        assert distances[k] == pytest.approx(distance, abs=1e-9)
+        assert bearings[k] == pytest.approx(bearing, abs=1e-9)
+
+
+def test_consensus_batch_scoring_matches_scalar_gates():
+    # Every kept proposal's inlier set, count, and mean residual must agree
+    # with the scalar is_inlier/residuals_at path the batch replaced.
+    from mapsnap.street_solve import DEFAULT_GATES, is_inlier
+
+    constraints = scene() + [
+        constraint_for(TRUE_POSE, "LIAR", (500.0, 200.0), 70.0, offset_m=(400.0, 0.0))
+    ]
+    proposals = consensus_poses(
+        constraints, TRUE_POSE[2], [(LOG_SCALE, "prior")], SIZE, DEFAULT_GATES
+    )
+    assert proposals, "the true pose must survive"
+    for pose, inliers, _source in proposals:
+        scalar = [c for c in constraints if is_inlier(pose, c, SIZE, DEFAULT_GATES)]
+        assert [c[2] for c in inliers] == [c[2] for c in scalar]
+        assert len(inliers) >= DEFAULT_GATES.min_inliers
+        assert bearing_spread(pose, inliers) >= DEFAULT_GATES.bearing_diversity_deg


### PR DESCRIPTION
Street-solve recomputed 97% of its runtime as 14M scalar `residuals_at` calls — profiled on Kansas City's 8 constraint-heaviest pages: 343s, with `consensus_poses` at 334s of it. The psi × scale × pair × line search proposes ~19k poses per page and scored each against every constraint one interpreted numpy call at a time.

Three changes (#333 discussion items 2–4; explicitly **no caching**), none touching gates, guards, or the objective:

1. **Batch scoring.** With bearing and scale fixed, a proposal only *translates* each label's world point (`pose_world_of` is base + t), so all proposals in a scale group score as one broadcast per constraint — `batch_point_to_segments` is the vectorized twin of `point_to_segments`. Proposal generation itself now uses a closed-form 2×2 solve over precomputed line equations (`line_equations`) instead of building numpy matrices per pair (1.2M `np.linalg.solve` calls gone).
2. **Dedupe before scoring.** Identical placements reached from different pair/line combinations merge on a 1 m grid before scoring, instead of being scored repeatedly and deduplicated at 20 m afterwards.
3. **No residual recompute.** `mean_position` reads the batch's position residuals instead of a second `residuals_at` pass over the inliers.

## Timing

| workload | before | after |
|---|---|---|
| KC's 8 heaviest pages (profiled) | 343 s | **38 s** |
| Kansas City full candidates (128 pages) | 779 s stage in 2026-08-14 run | **124 s** |
| Miami full candidates (91 pages) | 658 s | **126 s** |

## Equivalence

Verified full-volume against the archived 2026-08-14 candidates (street-solve code unchanged since, so they're an exact before-baseline):

- **miami: 91/91 statuses identical**; max candidate rmse delta 10.9 ft on one page.
- **KC: 127/128 statuses identical** — p483 abstains in both runs, just via `polish-runaway` instead of `unstable-leave-one-out`. Remaining deltas are tie-breaks between equivalent-cost attempts (5 `scale_source`/`psi_source` label flips, max pose move 1.3 m — inside the solver's own 20 m/0.01 dedupe tolerance; KC p523 improved 18.6 → 15.0 ft). Root cause of the ULP-level shifts: `base + t` addition order and Cramer-vs-LAPACK 2×2 solves.

New tests: `batch_point_to_segments` equals the scalar `point_to_segments` on random soups; every kept consensus proposal's inlier set matches the scalar `is_inlier` path. Full suite 1042 passing; live `candidates.jsonl` files restored to their archived state after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)