### PR TITLE
RANSAC runner-up poses: emit near-ties, promote past misscale demotions, seed snap challenges

### DIFF
--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -321,9 +321,7 @@ def load_page_units(volume: Path) -> list[PageUnit]:
             keymap_centers=keymap_centers,
             keymap_radius_m=keymap_radius,
             keymap_regions=keymap_regions,
-            runner_up_affines=runner_up_affines_of(
-                georef if state == "fitted" else None, width, height
-            ),
+            runner_up_affines=runner_up_affines_of(georef, width, height),
         )
         if truth is not None and gen_affine is not None:
             unit.rmse_ft = grid_rmse_ft_between(

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -30,7 +30,7 @@ import json
 import math
 import statistics
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import cv2
@@ -86,6 +86,30 @@ class TruthFit:
     transform_type: str
 
 
+def runner_up_affines_of(georef: dict | None, width: int, height: int) -> list:
+    """Affines for a fitted sidecar's runner_up_poses entries (empty if none).
+
+    Shared by both PageUnit loaders (this module's and osm_snap_experiment's
+    panel loader) so the runner-up channel cannot fall out of sync between
+    base pages and split panels.
+    """
+    from mapsnap.road_model import page_world_affine
+
+    if not georef:
+        return []
+    affines = []
+    for pose in georef.get("runner_up_poses") or []:
+        try:
+            affines.append(
+                page_world_affine(
+                    {"corners": pose["corners"], "width": width, "height": height}
+                )
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+    return affines
+
+
 @dataclass
 class PageUnit:
     """One base (unsplit) page of a volume with everything the harness needs."""
@@ -108,6 +132,9 @@ class PageUnit:
     # snap's search, because a demoted pose is measurably a good init (refine
     # fixed richmond p353's 3.06x scale error from one).
     demoted_affine: np.ndarray | None = None
+    # Distinct near-tie poses RANSAC scored but did not pick (#342): consumed
+    # by snap as extra challenge seeds when the incumbent verifies poorly.
+    runner_up_affines: list[np.ndarray] = field(default_factory=list)
     anchor_truth: bool = False
     anchor_free: bool = False
     rmse_ft: float | None = None  # generated-vs-truth RMSE
@@ -294,6 +321,9 @@ def load_page_units(volume: Path) -> list[PageUnit]:
             keymap_centers=keymap_centers,
             keymap_radius_m=keymap_radius,
             keymap_regions=keymap_regions,
+            runner_up_affines=runner_up_affines_of(
+                georef if state == "fitted" else None, width, height
+            ),
         )
         if truth is not None and gen_affine is not None:
             unit.rmse_ft = grid_rmse_ft_between(

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -132,7 +132,7 @@ class PageUnit:
     # snap's search, because a demoted pose is measurably a good init (refine
     # fixed richmond p353's 3.06x scale error from one).
     demoted_affine: np.ndarray | None = None
-    # Distinct near-tie poses RANSAC scored but did not pick (#342): consumed
+    # Distinct near-tie poses RANSAC scored but did not pick (#340): consumed
     # by snap as extra challenge seeds when the incumbent verifies poorly.
     runner_up_affines: list[np.ndarray] = field(default_factory=list)
     anchor_truth: bool = False

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -1463,8 +1463,8 @@ def promotable_runner_up(georef: dict, ref_scale_px_per_ft: float) -> dict | Non
     for pose in georef.get("runner_up_poses") or []:
         if pose.get("score_ratio", 0.0) < RUNNER_UP_PROMOTE_MIN_RATIO:
             break  # records are score-ordered
-        pair = pose.get("pair")
-        if not pair or len(pair) != 2:
+        pair_px = pose.get("pair_px")
+        if not pair_px or len(pair_px) != 2:
             continue
         try:
             m_per_px = page_scale_m_per_px(
@@ -1486,7 +1486,7 @@ def promotable_runner_up(georef: dict, ref_scale_px_per_ft: float) -> dict | Non
 
 
 def select_runner_up_poses(
-    scored: list[tuple[float, np.ndarray, int, tuple[int, int]]],
+    scored: list,
     best_A: np.ndarray,
     size: tuple[int, int],
 ) -> list[dict]:
@@ -1502,7 +1502,7 @@ def select_runner_up_poses(
     if not scored:
         return []
     width, height = size
-    best_score = max(score for score, _, _, _ in scored)
+    best_score = max(entry[0] for entry in scored)
     if best_score <= 0:
         return []
 
@@ -1523,7 +1523,9 @@ def select_runner_up_poses(
 
     kept: list[tuple[tuple[float, float], float]] = []
     records: list[dict] = []
-    for score, A, n_streets, pair in sorted(scored, key=lambda entry: -entry[0]):
+    for score, A, n_streets, pair, pair_pixels in sorted(
+        scored, key=lambda entry: -entry[0]
+    ):
         if score < RUNNER_UP_MIN_SCORE_RATIO * best_score:
             break
         if pose_is_upside_down(A):
@@ -1546,8 +1548,13 @@ def select_runner_up_poses(
                 "inlier_streets": n_streets,
                 # The seed pair that produced this pose, so promotion (#340)
                 # can REFIT the page through the normal path via force_pair
-                # instead of swapping corners under stale GCP records.
+                # instead of swapping corners under stale GCP records. Indices
+                # are tier-relative; the crossing PIXELS are the durable
+                # address (see ransac_hybrid's force_pair_pixels).
                 "pair": [int(pair[0]), int(pair[1])],
+                "pair_px": [
+                    [round(float(px), 2), round(float(py), 2)] for px, py in pair_pixels
+                ],
             }
         )
         if len(records) >= MAX_RUNNER_UP_POSES:
@@ -1565,7 +1572,8 @@ def ransac_hybrid(
     force_pair: tuple[int, int] | None = None,
     debug: bool = False,
     pair_records: list[dict] | None = None,
-    scored_sink: list[tuple[float, np.ndarray, int, tuple[int, int]]] | None = None,
+    scored_sink: list | None = None,
+    force_pair_pixels: tuple | None = None,
 ) -> tuple[np.ndarray | None, list[int], tuple[int, int] | None]:
     """Find the best similarity affine using intersection GCPs as seeds, label-based inlier scoring.
 
@@ -1593,6 +1601,34 @@ def ransac_hybrid(
     n = len(gcps)
     if n < 2:
         return None, [], None
+
+    if force_pair_pixels is not None:
+        # Content-addressed forcing (#340 promotion): resolve the recorded
+        # crossing PIXELS to this call's gcps indices. Indices are only
+        # meaningful within one tier's gcps list -- the keymap-restricted
+        # tier and the full-index tier build different lists (forcing p74's
+        # tier-2 indices in tier 1 read past the end of a 2-gcp list) -- but
+        # a crossing's pixel position identifies it in whichever tier can see
+        # it. A tier that cannot resolve both pixels returns no fit, so the
+        # strict-first/relaxed-retry cascade falls through to the tier that
+        # can.
+        resolved = []
+        for want_x, want_y in force_pair_pixels:
+            match = next(
+                (
+                    i
+                    for i, gcp in enumerate(gcps)
+                    if abs(gcp.pixel[0] - want_x) <= 1.0
+                    and abs(gcp.pixel[1] - want_y) <= 1.0
+                ),
+                None,
+            )
+            if match is None:
+                return None, [], None
+            resolved.append(match)
+        if resolved[0] == resolved[1]:
+            return None, [], None
+        force_pair = (resolved[0], resolved[1])
 
     total_pairs = n * (n - 1) // 2
 
@@ -1654,7 +1690,13 @@ def ransac_hybrid(
             # pair_records): a vetoed near-tie can still be the true pose, and
             # the runner-up channel's consumer re-judges with its own evidence.
             scored_sink.append(
-                (float(len(inliers)) * pos_threshold - err, A, len(inliers), pair_idx)
+                (
+                    float(len(inliers)) * pos_threshold - err,
+                    A,
+                    len(inliers),
+                    pair_idx,
+                    (a.pixel, b.pixel),
+                )
             )
 
         # Record this pair's fit for the interactive debugger (only when --debug supplies a
@@ -2292,32 +2334,47 @@ def _promote_runner_up(
         return False
     if not _worker_state:
         _init_worker(*worker_initargs)
-    saved_force = _worker_state.get("force_intersection")
-    _worker_state["force_intersection"] = (int(pose["pair"][0]), int(pose["pair"][1]))
+    original_sidecar = Path(out_path).read_text()
+    saved_force = _worker_state.get("force_pair_pixels")
+    _worker_state["force_pair_pixels"] = (
+        tuple(pose["pair_px"][0]),
+        tuple(pose["pair_px"][1]),
+    )
     try:
         _, result = _process_one_image(img_path)
+    except Exception as error:  # noqa: BLE001 -- a failed refit must never eat the sidecar
+        print(f"Runner-up refit failed for {img_path}: {error}", file=sys.stderr)
+        result = None
     finally:
-        _worker_state["force_intersection"] = saved_force
-    if not result.success:
-        return False
-    try:
-        promoted = json.loads(Path(out_path).read_text())
-        promoted_px_per_ft = 1.0 / (page_scale_m_per_px(promoted) * FEET_PER_METER)
-    except (OSError, json.JSONDecodeError, KeyError, ZeroDivisionError):
-        return False
-    if is_scale_outlier(promoted_px_per_ft / ref_scale_px_per_ft):
-        # The forced pair reproduced an off-rung pose after all; restore no
-        # publication claim -- the caller demotes the (rewritten) sidecar.
+        _worker_state["force_pair_pixels"] = saved_force
+    promoted: dict | None = None
+    promoted_px_per_ft = None
+    if result is not None and result.success:
+        try:
+            loaded = json.loads(Path(out_path).read_text())
+            promoted_px_per_ft = 1.0 / (page_scale_m_per_px(loaded) * FEET_PER_METER)
+            promoted = loaded
+        except (OSError, json.JSONDecodeError, KeyError, ZeroDivisionError):
+            promoted = None
+            promoted_px_per_ft = None
+    if (
+        promoted is None
+        or promoted_px_per_ft is None
+        or is_scale_outlier(promoted_px_per_ft / ref_scale_px_per_ft)
+    ):
+        # Refit failed or reproduced an off-rung pose after all: put the
+        # original fit back so the caller demotes exactly what it measured.
+        Path(out_path).write_text(original_sidecar)
         return False
     promoted["promoted_from_runner_up"] = {
         "score_ratio": pose["score_ratio"],
-        "pair": pose["pair"],
+        "pair_px": pose["pair_px"],
         "demoted": demoted_detail,
     }
     Path(out_path).write_text(json.dumps(promoted, indent=2))
     SPECIAL_CASE_COUNTS["misscale_promoted_runner_up"] += 1
     print(
-        f"Promoted runner-up for {img_path}: seed pair {pose['pair']} at "
+        f"Promoted runner-up for {img_path}: crossing pixels {pose['pair_px']} at "
         f"{pose['score_ratio']:.1%} of the demoted winner's score, "
         f"{promoted_px_per_ft:.4f} px/ft (reference {ref_scale_px_per_ft:.4f})",
         file=sys.stderr,
@@ -2555,6 +2612,7 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
             min_aspect_ratio=_worker_state["min_aspect_ratio"],
             edge_margin=_worker_state["edge_margin"],
             force_intersection=_worker_state["force_intersection"],
+            force_pair_pixels=_worker_state.get("force_pair_pixels"),
             one_gcp_fits=_worker_state["one_gcp_fits"],
             debug=_worker_state["debug"],
             parameters=_worker_state["parameters"],
@@ -3099,6 +3157,7 @@ def process_image(
     min_aspect_ratio: float = 2.0,
     edge_margin: float = 0.0,
     force_intersection: tuple[int, int] | None = None,
+    force_pair_pixels: tuple | None = None,
     one_gcp_fits: bool = False,
     debug: bool = False,
     parameters: dict | None = None,
@@ -3201,7 +3260,7 @@ def process_image(
     pair_records: list[dict] | None = [] if debug else None
     # Always collect scored poses: distinct near-ties are published as
     # runner_up_poses for the snap channel to arbitrate (select_runner_up_poses).
-    scored_poses: list[tuple[float, np.ndarray, int, tuple[int, int]]] = []
+    scored_poses: list = []
     A, inlier_feat_indices, seed_pair = ransac_hybrid(
         gcps,
         features,
@@ -3211,6 +3270,7 @@ def process_image(
         debug=debug,
         pair_records=pair_records,
         scored_sink=scored_poses,
+        force_pair_pixels=force_pair_pixels,
     )
     if A is None:
         print("RANSAC failed: no valid affine found.", file=sys.stderr)

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -1431,6 +1431,82 @@ def _rank_pairs_by_consensus(
     return [(int(idx_i[k]), int(idx_j[k])) for k in order[:top_k] if counts[k] >= 0]
 
 
+# Runner-up emission (#342): near-ties kept for snap to arbitrate. Measured on
+# miami: 80/86 truth pages have a distinct pose at >=70% of the winner's score,
+# and on p13 the TRUE pose scored 99.9% of a 1,195 ft winner -- RANSAC's own
+# objective cannot break such ties, but snap's independent evidence can.
+RUNNER_UP_MIN_SCORE_RATIO = 0.7
+RUNNER_UP_DISTINCT_M = 30.0
+RUNNER_UP_DISTINCT_DEG = 1.5
+MAX_RUNNER_UP_POSES = 4
+
+
+def select_runner_up_poses(
+    scored: list[tuple[float, np.ndarray, int]],
+    best_A: np.ndarray,
+    size: tuple[int, int],
+) -> list[dict]:
+    """Distinct near-tie poses from the RANSAC scoring loop, as sidecar records.
+
+    RANSAC must publish one winner, but on gridded cities its objective is
+    nearly flat across block aliases. Each returned pose scored at least
+    RUNNER_UP_MIN_SCORE_RATIO of the best score, sits >RUNNER_UP_DISTINCT_M or
+    >RUNNER_UP_DISTINCT_DEG from the winner and from every other kept pose, and
+    is never upside-down (#324). Records carry the corner quad (the sidecar
+    pose convention), the score ratio, and the inlier street count.
+    """
+    if not scored:
+        return []
+    width, height = size
+    best_score = max(score for score, _, _ in scored)
+    if best_score <= 0:
+        return []
+
+    def centre(A: np.ndarray) -> tuple[float, float]:
+        return apply_affine(A, width / 2, height / 2)
+
+    def rotation_deg(A: np.ndarray) -> float:
+        return math.degrees(math.atan2(float(A[1][0]), float(A[0][0])))
+
+    best_centre, best_rot = centre(best_A), rotation_deg(best_A)
+    cos_lat = math.cos(math.radians(best_centre[1]))
+
+    def distinct(c1, r1, c2, r2) -> bool:
+        metres = math.hypot(
+            (c1[0] - c2[0]) * 111_320 * cos_lat, (c1[1] - c2[1]) * 110_540
+        )
+        return metres > RUNNER_UP_DISTINCT_M or abs(r1 - r2) > RUNNER_UP_DISTINCT_DEG
+
+    kept: list[tuple[tuple[float, float], float]] = []
+    records: list[dict] = []
+    for score, A, n_streets in sorted(scored, key=lambda entry: -entry[0]):
+        if score < RUNNER_UP_MIN_SCORE_RATIO * best_score:
+            break
+        if pose_is_upside_down(A):
+            continue
+        c, r = centre(A), rotation_deg(A)
+        if not distinct(c, r, best_centre, best_rot):
+            continue
+        if any(not distinct(c, r, c2, r2) for c2, r2 in kept):
+            continue
+        kept.append((c, r))
+        records.append(
+            {
+                "corners": [
+                    [round(v, 7) for v in apply_affine(A, 0, 0)],
+                    [round(v, 7) for v in apply_affine(A, width, 0)],
+                    [round(v, 7) for v in apply_affine(A, width, height)],
+                    [round(v, 7) for v in apply_affine(A, 0, height)],
+                ],
+                "score_ratio": round(score / best_score, 4),
+                "inlier_streets": n_streets,
+            }
+        )
+        if len(records) >= MAX_RUNNER_UP_POSES:
+            break
+    return records
+
+
 def ransac_hybrid(
     gcps: list[IntersectionGCP],
     features: list[LabelFeature],
@@ -1441,6 +1517,7 @@ def ransac_hybrid(
     force_pair: tuple[int, int] | None = None,
     debug: bool = False,
     pair_records: list[dict] | None = None,
+    scored_sink: list[tuple[float, np.ndarray, int]] | None = None,
 ) -> tuple[np.ndarray | None, list[int], tuple[int, int] | None]:
     """Find the best similarity affine using intersection GCPs as seeds, label-based inlier scoring.
 
@@ -1524,6 +1601,13 @@ def ransac_hybrid(
         inliers, err = label_inliers(
             features, block_index, A, pos_threshold, dir_threshold, debug=debug
         )
+        if scored_sink is not None:
+            # Every scored pose, recorded BEFORE the vetoes below (like
+            # pair_records): a vetoed near-tie can still be the true pose, and
+            # the runner-up channel's consumer re-judges with its own evidence.
+            scored_sink.append(
+                (float(len(inliers)) * pos_threshold - err, A, len(inliers))
+            )
 
         # Record this pair's fit for the interactive debugger (only when --debug supplies a
         # collector). Recorded before the rotation-outlier reject below so even pairs the
@@ -3007,6 +3091,9 @@ def process_image(
     # Under --debug, collect every scored seed pair's fit so the debugger can offer
     # interactive seed-pair exploration (see _finalize_georef's gcp_pairs output).
     pair_records: list[dict] | None = [] if debug else None
+    # Always collect scored poses: distinct near-ties are published as
+    # runner_up_poses for the snap channel to arbitrate (select_runner_up_poses).
+    scored_poses: list[tuple[float, np.ndarray, int]] = []
     A, inlier_feat_indices, seed_pair = ransac_hybrid(
         gcps,
         features,
@@ -3015,6 +3102,7 @@ def process_image(
         force_pair=force_intersection,
         debug=debug,
         pair_records=pair_records,
+        scored_sink=scored_poses,
     )
     if A is None:
         print("RANSAC failed: no valid affine found.", file=sys.stderr)
@@ -3083,6 +3171,7 @@ def process_image(
             A = affine
             residuals = _inlier_residuals(features, block_index, A, inlier_feat_indices)
 
+    runner_ups = select_runner_up_poses(scored_poses, A, (img_w, img_h))
     scale, center = _finalize_georef(
         A,
         features,
@@ -3098,6 +3187,7 @@ def process_image(
         parameters=parameters,
         keymap=keymap,
         truth_polygons=truth_polygons,
+        extra_fields={"runner_up_poses": runner_ups} if runner_ups else None,
     )
     rotation = math.atan2(float(A[1, 0]), float(-A[1, 1]))
     return ProcessResult(

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -1440,9 +1440,53 @@ RUNNER_UP_DISTINCT_M = 30.0
 RUNNER_UP_DISTINCT_DEG = 1.5
 MAX_RUNNER_UP_POSES = 4
 
+# Promotion (#340): a runner-up may replace a scale-outlier winner only when
+# it nearly tied it. Promotion publishes an incumbent -- a stronger claim than
+# seeding a search -- so the bar sits well above the 0.7 emission floor.
+RUNNER_UP_PROMOTE_MIN_RATIO = 0.9
+
+
+def promotable_runner_up(georef: dict, ref_scale_px_per_ft: float) -> dict | None:
+    """The best-scoring runner-up whose scale the volume's rungs accept.
+
+    #340: when the WINNER is a scale outlier but a near-tie is not, the
+    near-tie is a far better bet than anything a rescue search will find --
+    miami p13's 99.9%-score runner-up IS the true pose at 10 ft, while the
+    misscale winner's rescue searched the wrong block and reconcile left the
+    page unplaced. Only near-ties carrying their seed pair qualify, so the
+    caller can refit the page through the normal path (force_pair) rather
+    than swap corners under stale GCP records.
+    """
+    from mapsnap.road_model import page_scale_m_per_px
+    from mapsnap.utils import FEET_PER_METER
+
+    for pose in georef.get("runner_up_poses") or []:
+        if pose.get("score_ratio", 0.0) < RUNNER_UP_PROMOTE_MIN_RATIO:
+            break  # records are score-ordered
+        pair = pose.get("pair")
+        if not pair or len(pair) != 2:
+            continue
+        try:
+            m_per_px = page_scale_m_per_px(
+                {
+                    "corners": pose["corners"],
+                    "width": georef["width"],
+                    "height": georef["height"],
+                }
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+        if m_per_px <= 0:
+            continue
+        px_per_ft = 1.0 / (m_per_px * FEET_PER_METER)
+        if is_scale_outlier(px_per_ft / ref_scale_px_per_ft):
+            continue
+        return pose
+    return None
+
 
 def select_runner_up_poses(
-    scored: list[tuple[float, np.ndarray, int]],
+    scored: list[tuple[float, np.ndarray, int, tuple[int, int]]],
     best_A: np.ndarray,
     size: tuple[int, int],
 ) -> list[dict]:
@@ -1458,7 +1502,7 @@ def select_runner_up_poses(
     if not scored:
         return []
     width, height = size
-    best_score = max(score for score, _, _ in scored)
+    best_score = max(score for score, _, _, _ in scored)
     if best_score <= 0:
         return []
 
@@ -1479,7 +1523,7 @@ def select_runner_up_poses(
 
     kept: list[tuple[tuple[float, float], float]] = []
     records: list[dict] = []
-    for score, A, n_streets in sorted(scored, key=lambda entry: -entry[0]):
+    for score, A, n_streets, pair in sorted(scored, key=lambda entry: -entry[0]):
         if score < RUNNER_UP_MIN_SCORE_RATIO * best_score:
             break
         if pose_is_upside_down(A):
@@ -1500,6 +1544,10 @@ def select_runner_up_poses(
                 ],
                 "score_ratio": round(score / best_score, 4),
                 "inlier_streets": n_streets,
+                # The seed pair that produced this pose, so promotion (#340)
+                # can REFIT the page through the normal path via force_pair
+                # instead of swapping corners under stale GCP records.
+                "pair": [int(pair[0]), int(pair[1])],
             }
         )
         if len(records) >= MAX_RUNNER_UP_POSES:
@@ -1517,7 +1565,7 @@ def ransac_hybrid(
     force_pair: tuple[int, int] | None = None,
     debug: bool = False,
     pair_records: list[dict] | None = None,
-    scored_sink: list[tuple[float, np.ndarray, int]] | None = None,
+    scored_sink: list[tuple[float, np.ndarray, int, tuple[int, int]]] | None = None,
 ) -> tuple[np.ndarray | None, list[int], tuple[int, int] | None]:
     """Find the best similarity affine using intersection GCPs as seeds, label-based inlier scoring.
 
@@ -1606,7 +1654,7 @@ def ransac_hybrid(
             # pair_records): a vetoed near-tie can still be the true pose, and
             # the runner-up channel's consumer re-judges with its own evidence.
             scored_sink.append(
-                (float(len(inliers)) * pos_threshold - err, A, len(inliers))
+                (float(len(inliers)) * pos_threshold - err, A, len(inliers), pair_idx)
             )
 
         # Record this pair's fit for the interactive debugger (only when --debug supplies a
@@ -2215,6 +2263,66 @@ def correct_square_feature_dirs(
 
         if best_dir is not None:
             feat.dir_pix = round(best_dir % math.pi, 4)
+
+
+def _promote_runner_up(
+    img_path: str,
+    out_path: str,
+    ref_scale_px_per_ft: float,
+    worker_initargs: tuple,
+    demoted_detail: dict,
+) -> bool:
+    """Refit a scale-outlier page from its best rung-plausible runner-up (#340).
+
+    Returns True when the page was refit and stays published. The refit runs
+    the ordinary per-page pipeline with the runner-up's seed pair forced, so
+    the promoted sidecar carries its own coherent inliers/GCPs. The promoted
+    fit's scale is re-verified afterwards; a refit that lands back outside the
+    rungs (or fails) leaves the original sidecar for the caller to demote.
+    """
+    from mapsnap.road_model import page_scale_m_per_px
+    from mapsnap.utils import FEET_PER_METER
+
+    try:
+        georef = json.loads(Path(out_path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    pose = promotable_runner_up(georef, ref_scale_px_per_ft)
+    if pose is None:
+        return False
+    if not _worker_state:
+        _init_worker(*worker_initargs)
+    saved_force = _worker_state.get("force_intersection")
+    _worker_state["force_intersection"] = (int(pose["pair"][0]), int(pose["pair"][1]))
+    try:
+        _, result = _process_one_image(img_path)
+    finally:
+        _worker_state["force_intersection"] = saved_force
+    if not result.success:
+        return False
+    try:
+        promoted = json.loads(Path(out_path).read_text())
+        promoted_px_per_ft = 1.0 / (page_scale_m_per_px(promoted) * FEET_PER_METER)
+    except (OSError, json.JSONDecodeError, KeyError, ZeroDivisionError):
+        return False
+    if is_scale_outlier(promoted_px_per_ft / ref_scale_px_per_ft):
+        # The forced pair reproduced an off-rung pose after all; restore no
+        # publication claim -- the caller demotes the (rewritten) sidecar.
+        return False
+    promoted["promoted_from_runner_up"] = {
+        "score_ratio": pose["score_ratio"],
+        "pair": pose["pair"],
+        "demoted": demoted_detail,
+    }
+    Path(out_path).write_text(json.dumps(promoted, indent=2))
+    SPECIAL_CASE_COUNTS["misscale_promoted_runner_up"] += 1
+    print(
+        f"Promoted runner-up for {img_path}: seed pair {pose['pair']} at "
+        f"{pose['score_ratio']:.1%} of the demoted winner's score, "
+        f"{promoted_px_per_ft:.4f} px/ft (reference {ref_scale_px_per_ft:.4f})",
+        file=sys.stderr,
+    )
+    return True
 
 
 def derive_paths(image_path: str) -> tuple[str, str, str]:
@@ -3093,7 +3201,7 @@ def process_image(
     pair_records: list[dict] | None = [] if debug else None
     # Always collect scored poses: distinct near-ties are published as
     # runner_up_poses for the snap channel to arbitrate (select_runner_up_poses).
-    scored_poses: list[tuple[float, np.ndarray, int]] = []
+    scored_poses: list[tuple[float, np.ndarray, int, tuple[int, int]]] = []
     A, inlier_feat_indices, seed_pair = ransac_hybrid(
         gcps,
         features,
@@ -4128,6 +4236,26 @@ def main() -> None:
                         continue
                 _, out_path, _ = derive_paths(img_path)
                 if os.path.exists(out_path):
+                    # #340: before demoting, check whether a near-tie runner-up
+                    # carries a rung-plausible scale. If so, REFIT the page with
+                    # that pose's seed pair forced -- the promoted fit goes
+                    # through the normal path (its own inliers, GCPs, and
+                    # runner-ups), becomes the incumbent, and snap REFINES it
+                    # instead of rescuing a page whose search anchors on the
+                    # wrong pose (miami p13: misscale winner 1,195 ft; its
+                    # 99.9%-score runner-up is the true pose at 10 ft).
+                    if _promote_runner_up(
+                        img_path,
+                        out_path,
+                        ref_scale_px_per_ft,
+                        worker_initargs,
+                        demoted_detail={
+                            "px_per_ft": round(px_per_ft, 4),
+                            "reference_px_per_ft": round(ref_scale_px_per_ft, 4),
+                            "ratio": round(ratio, 3),
+                        },
+                    ):
+                        continue
                     sidecar.demote(
                         out_path,
                         sidecar.MISSCALE,

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -1431,7 +1431,7 @@ def _rank_pairs_by_consensus(
     return [(int(idx_i[k]), int(idx_j[k])) for k in order[:top_k] if counts[k] >= 0]
 
 
-# Runner-up emission (#342): near-ties kept for snap to arbitrate. Measured on
+# Runner-up emission (#340): near-ties kept for snap to arbitrate. Measured on
 # miami: 80/86 truth pages have a distinct pose at >=70% of the winner's score,
 # and on p13 the TRUE pose scored 99.9% of a 1,195 ft winner -- RANSAC's own
 # objective cannot break such ties, but snap's independent evidence can.

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -1463,8 +1463,8 @@ def promotable_runner_up(georef: dict, ref_scale_px_per_ft: float) -> dict | Non
     for pose in georef.get("runner_up_poses") or []:
         if pose.get("score_ratio", 0.0) < RUNNER_UP_PROMOTE_MIN_RATIO:
             break  # records are score-ordered
-        pair_px = pose.get("pair_px")
-        if not pair_px or len(pair_px) != 2:
+        pair_px, pair_geo = pose.get("pair_px"), pose.get("pair_geo")
+        if not pair_px or len(pair_px) != 2 or not pair_geo or len(pair_geo) != 2:
             continue
         try:
             m_per_px = page_scale_m_per_px(
@@ -1553,7 +1553,15 @@ def select_runner_up_poses(
                 # address (see ransac_hybrid's force_pair_pixels).
                 "pair": [int(pair[0]), int(pair[1])],
                 "pair_px": [
-                    [round(float(px), 2), round(float(py), 2)] for px, py in pair_pixels
+                    [round(float(px), 2), round(float(py), 2)]
+                    for (px, py), _geo in pair_pixels
+                ],
+                # A crossing PIXEL can carry several world candidates (a
+                # jogging street's two crossings share one pixel), so the geo
+                # side disambiguates which candidate this pose used.
+                "pair_geo": [
+                    [round(float(lon), 7), round(float(lat), 7)]
+                    for _px, (lon, lat) in pair_pixels
                 ],
             }
         )
@@ -1613,13 +1621,15 @@ def ransac_hybrid(
         # strict-first/relaxed-retry cascade falls through to the tier that
         # can.
         resolved = []
-        for want_x, want_y in force_pair_pixels:
+        for (want_x, want_y), (want_lon, want_lat) in force_pair_pixels:
             match = next(
                 (
                     i
                     for i, gcp in enumerate(gcps)
                     if abs(gcp.pixel[0] - want_x) <= 1.0
                     and abs(gcp.pixel[1] - want_y) <= 1.0
+                    and abs(gcp.geo[0] - want_lon) <= 1e-5
+                    and abs(gcp.geo[1] - want_lat) <= 1e-5
                 ),
                 None,
             )
@@ -1695,7 +1705,7 @@ def ransac_hybrid(
                     A,
                     len(inliers),
                     pair_idx,
-                    (a.pixel, b.pixel),
+                    ((a.pixel, a.geo), (b.pixel, b.geo)),
                 )
             )
 
@@ -2337,8 +2347,8 @@ def _promote_runner_up(
     original_sidecar = Path(out_path).read_text()
     saved_force = _worker_state.get("force_pair_pixels")
     _worker_state["force_pair_pixels"] = (
-        tuple(pose["pair_px"][0]),
-        tuple(pose["pair_px"][1]),
+        (tuple(pose["pair_px"][0]), tuple(pose["pair_geo"][0])),
+        (tuple(pose["pair_px"][1]), tuple(pose["pair_geo"][1])),
     )
     try:
         _, result = _process_one_image(img_path)

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1868,7 +1868,7 @@ def test_select_runner_up_poses_keeps_distinct_near_ties():
         return np.array([[c * scale, -s * scale, dlon], [s * scale, c * scale, 40.0]])
 
     best = pose(0.0)
-    px = ((10.0, 20.0), (30.0, 40.0))
+    px = (((10.0, 20.0), (-80.0, 25.0)), ((30.0, 40.0), (-80.1, 25.1)))
     scored = [
         (1.00, best, 9, (0, 1), px),
         (0.999, pose(0.001), 8, (0, 2), px),  # ~85 m away: distinct, kept
@@ -1882,6 +1882,7 @@ def test_select_runner_up_poses_keeps_distinct_near_ties():
     assert records[0]["inlier_streets"] == 8
     assert records[0]["pair"] == [0, 2]
     assert records[0]["pair_px"] == [[10.0, 20.0], [30.0, 40.0]]
+    assert records[0]["pair_geo"] == [[-80.0, 25.0], [-80.1, 25.1]]
     assert len(records[0]["corners"]) == 4
 
 
@@ -1899,7 +1900,7 @@ def test_select_runner_up_poses_drops_upside_down_and_caps():
         return np.array([[c * scale, -s * scale, dlon], [s * scale, c * scale, 40.0]])
 
     best = pose(0.0)
-    px = ((10.0, 20.0), (30.0, 40.0))
+    px = (((10.0, 20.0), (-80.0, 25.0)), ((30.0, 40.0), (-80.1, 25.1)))
     scored = [
         (1.0, best, 9, (0, 1), px),
         (0.99, pose(0.001, rot_deg=180.0), 9, (0, 2), px),
@@ -1937,11 +1938,13 @@ def test_promotable_runner_up_requires_plausible_scale_and_near_tie():
                 "score_ratio": 0.99,
                 "corners": corners(outlier),
                 "pair_px": [[1.0, 2.0], [3.0, 4.0]],
+                "pair_geo": [[-80.0, 25.0], [-80.1, 25.1]],
             },
             {
                 "score_ratio": 0.95,
                 "corners": corners(good),
                 "pair_px": [[5.0, 6.0], [7.0, 8.0]],
+                "pair_geo": [[-80.0, 25.0], [-80.1, 25.1]],
             },
             {"score_ratio": 0.92, "corners": corners(good)},  # no pair_px: skip
         ],
@@ -1950,7 +1953,12 @@ def test_promotable_runner_up_requires_plausible_scale_and_near_tie():
     assert pose is not None and pose["pair_px"] == [[5.0, 6.0], [7.0, 8.0]]
     # Below the 0.9 promotion bar nothing qualifies, however plausible.
     doc["runner_up_poses"] = [
-        {"score_ratio": 0.85, "corners": corners(good), "pair_px": [[5, 6], [7, 8]]}
+        {
+            "score_ratio": 0.85,
+            "corners": corners(good),
+            "pair_px": [[5, 6], [7, 8]],
+            "pair_geo": [[-80.0, 25.0], [-80.1, 25.1]],
+        }
     ]
     assert promotable_runner_up(doc, ref_scale_px_per_ft=1.0) is None
     assert promotable_runner_up({}, ref_scale_px_per_ft=1.0) is None

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1853,3 +1853,52 @@ def test_haversine_m_one_degree_latitude():
     # One degree of latitude is ~111 km anywhere on the globe.
     assert abs(haversine_m(0.0, 0.0, 1.0, 0.0) - 111_320) < 500
     assert haversine_m(38.9, -77.0, 38.9, -77.0) == 0.0
+
+
+def test_select_runner_up_poses_keeps_distinct_near_ties():
+    import numpy as np
+
+    from mapsnap.georef_from_labels import select_runner_up_poses
+
+    # Winner at the origin; poses expressed as tiny lon/lat affines around 0N.
+    # 1e-5 deg lon ~ 1.1 m, so 200 px * 5e-6 ~ 111 m offsets are "distinct".
+    def pose(dlon: float, rot_deg: float = 0.0):
+        c, s = np.cos(np.radians(rot_deg)), np.sin(np.radians(rot_deg))
+        scale = 5e-6
+        return np.array([[c * scale, -s * scale, dlon], [s * scale, c * scale, 40.0]])
+
+    best = pose(0.0)
+    scored = [
+        (1.00, best, 9),
+        (0.999, pose(0.001), 8),  # ~85 m away: distinct, kept
+        (0.995, pose(0.0011), 8),  # ~9 m from the previous tie: merged away
+        (0.95, pose(1e-7), 9),  # co-located with the winner: dropped
+        (0.5, pose(0.005), 7),  # below the 70% score floor: dropped
+    ]
+    records = select_runner_up_poses(scored, best, (1000, 1000))
+    assert len(records) == 1
+    assert records[0]["score_ratio"] == 0.999
+    assert records[0]["inlier_streets"] == 8
+    assert len(records[0]["corners"]) == 4
+
+
+def test_select_runner_up_poses_drops_upside_down_and_caps():
+    import numpy as np
+
+    from mapsnap.georef_from_labels import (
+        MAX_RUNNER_UP_POSES,
+        select_runner_up_poses,
+    )
+
+    def pose(dlon: float, rot_deg: float = 0.0):
+        c, s = np.cos(np.radians(rot_deg)), np.sin(np.radians(rot_deg))
+        scale = 5e-6
+        return np.array([[c * scale, -s * scale, dlon], [s * scale, c * scale, 40.0]])
+
+    best = pose(0.0)
+    scored = [(1.0, best, 9), (0.99, pose(0.001, rot_deg=180.0), 9)]
+    scored += [(0.98 - 0.01 * i, pose(0.002 * (i + 2)), 8) for i in range(8)]
+    records = select_runner_up_poses(scored, best, (1000, 1000))
+    # The 180-degree alias is corpus-impossible (#324) and never emitted.
+    assert all(r["score_ratio"] != 0.99 for r in records)
+    assert len(records) == MAX_RUNNER_UP_POSES

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1869,16 +1869,17 @@ def test_select_runner_up_poses_keeps_distinct_near_ties():
 
     best = pose(0.0)
     scored = [
-        (1.00, best, 9),
-        (0.999, pose(0.001), 8),  # ~85 m away: distinct, kept
-        (0.995, pose(0.0011), 8),  # ~9 m from the previous tie: merged away
-        (0.95, pose(1e-7), 9),  # co-located with the winner: dropped
-        (0.5, pose(0.005), 7),  # below the 70% score floor: dropped
+        (1.00, best, 9, (0, 1)),
+        (0.999, pose(0.001), 8, (0, 2)),  # ~85 m away: distinct, kept
+        (0.995, pose(0.0011), 8, (0, 3)),  # ~9 m from the previous tie: merged
+        (0.95, pose(1e-7), 9, (0, 4)),  # co-located with the winner: dropped
+        (0.5, pose(0.005), 7, (0, 5)),  # below the 70% score floor: dropped
     ]
     records = select_runner_up_poses(scored, best, (1000, 1000))
     assert len(records) == 1
     assert records[0]["score_ratio"] == 0.999
     assert records[0]["inlier_streets"] == 8
+    assert records[0]["pair"] == [0, 2]
     assert len(records[0]["corners"]) == 4
 
 
@@ -1896,9 +1897,46 @@ def test_select_runner_up_poses_drops_upside_down_and_caps():
         return np.array([[c * scale, -s * scale, dlon], [s * scale, c * scale, 40.0]])
 
     best = pose(0.0)
-    scored = [(1.0, best, 9), (0.99, pose(0.001, rot_deg=180.0), 9)]
-    scored += [(0.98 - 0.01 * i, pose(0.002 * (i + 2)), 8) for i in range(8)]
+    scored = [(1.0, best, 9, (0, 1)), (0.99, pose(0.001, rot_deg=180.0), 9, (0, 2))]
+    scored += [
+        (0.98 - 0.01 * i, pose(0.002 * (i + 2)), 8, (1, i + 2)) for i in range(8)
+    ]
     records = select_runner_up_poses(scored, best, (1000, 1000))
     # The 180-degree alias is corpus-impossible (#324) and never emitted.
     assert all(r["score_ratio"] != 0.99 for r in records)
     assert len(records) == MAX_RUNNER_UP_POSES
+
+
+def test_promotable_runner_up_requires_plausible_scale_and_near_tie():
+    from mapsnap.georef_from_labels import promotable_runner_up
+
+    def corners(scale: float):
+        # A 1000x1000 page at ~scale deg per px around (0 lon, 0 lat).
+        return [
+            [0.0, 0.0],
+            [1000 * scale, 0.0],
+            [1000 * scale, -1000 * scale],
+            [0.0, -1000 * scale],
+        ]
+
+    # ~1 px/ft at 2.74e-6 deg/px: within the reference band. 0.65x of it is
+    # the p13 class -- BETWEEN the legitimate 0.5x/1x family rungs, an outlier.
+    # (Exactly 0.5x would be a real rung and correctly NOT an outlier.)
+    good, outlier = 2.74e-6, 2.74e-6 / 0.65
+    doc = {
+        "width": 1000,
+        "height": 1000,
+        "runner_up_poses": [
+            {"score_ratio": 0.99, "corners": corners(outlier), "pair": [0, 1]},
+            {"score_ratio": 0.95, "corners": corners(good), "pair": [2, 3]},
+            {"score_ratio": 0.92, "corners": corners(good)},  # no pair: skipped
+        ],
+    }
+    pose = promotable_runner_up(doc, ref_scale_px_per_ft=1.0)
+    assert pose is not None and pose["pair"] == [2, 3]
+    # Below the 0.9 promotion bar nothing qualifies, however plausible.
+    doc["runner_up_poses"] = [
+        {"score_ratio": 0.85, "corners": corners(good), "pair": [2, 3]}
+    ]
+    assert promotable_runner_up(doc, ref_scale_px_per_ft=1.0) is None
+    assert promotable_runner_up({}, ref_scale_px_per_ft=1.0) is None

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1868,18 +1868,20 @@ def test_select_runner_up_poses_keeps_distinct_near_ties():
         return np.array([[c * scale, -s * scale, dlon], [s * scale, c * scale, 40.0]])
 
     best = pose(0.0)
+    px = ((10.0, 20.0), (30.0, 40.0))
     scored = [
-        (1.00, best, 9, (0, 1)),
-        (0.999, pose(0.001), 8, (0, 2)),  # ~85 m away: distinct, kept
-        (0.995, pose(0.0011), 8, (0, 3)),  # ~9 m from the previous tie: merged
-        (0.95, pose(1e-7), 9, (0, 4)),  # co-located with the winner: dropped
-        (0.5, pose(0.005), 7, (0, 5)),  # below the 70% score floor: dropped
+        (1.00, best, 9, (0, 1), px),
+        (0.999, pose(0.001), 8, (0, 2), px),  # ~85 m away: distinct, kept
+        (0.995, pose(0.0011), 8, (0, 3), px),  # ~9 m from previous tie: merged
+        (0.95, pose(1e-7), 9, (0, 4), px),  # co-located with winner: dropped
+        (0.5, pose(0.005), 7, (0, 5), px),  # below the 70% floor: dropped
     ]
     records = select_runner_up_poses(scored, best, (1000, 1000))
     assert len(records) == 1
     assert records[0]["score_ratio"] == 0.999
     assert records[0]["inlier_streets"] == 8
     assert records[0]["pair"] == [0, 2]
+    assert records[0]["pair_px"] == [[10.0, 20.0], [30.0, 40.0]]
     assert len(records[0]["corners"]) == 4
 
 
@@ -1897,9 +1899,13 @@ def test_select_runner_up_poses_drops_upside_down_and_caps():
         return np.array([[c * scale, -s * scale, dlon], [s * scale, c * scale, 40.0]])
 
     best = pose(0.0)
-    scored = [(1.0, best, 9, (0, 1)), (0.99, pose(0.001, rot_deg=180.0), 9, (0, 2))]
+    px = ((10.0, 20.0), (30.0, 40.0))
+    scored = [
+        (1.0, best, 9, (0, 1), px),
+        (0.99, pose(0.001, rot_deg=180.0), 9, (0, 2), px),
+    ]
     scored += [
-        (0.98 - 0.01 * i, pose(0.002 * (i + 2)), 8, (1, i + 2)) for i in range(8)
+        (0.98 - 0.01 * i, pose(0.002 * (i + 2)), 8, (1, i + 2), px) for i in range(8)
     ]
     records = select_runner_up_poses(scored, best, (1000, 1000))
     # The 180-degree alias is corpus-impossible (#324) and never emitted.
@@ -1927,16 +1933,24 @@ def test_promotable_runner_up_requires_plausible_scale_and_near_tie():
         "width": 1000,
         "height": 1000,
         "runner_up_poses": [
-            {"score_ratio": 0.99, "corners": corners(outlier), "pair": [0, 1]},
-            {"score_ratio": 0.95, "corners": corners(good), "pair": [2, 3]},
-            {"score_ratio": 0.92, "corners": corners(good)},  # no pair: skipped
+            {
+                "score_ratio": 0.99,
+                "corners": corners(outlier),
+                "pair_px": [[1.0, 2.0], [3.0, 4.0]],
+            },
+            {
+                "score_ratio": 0.95,
+                "corners": corners(good),
+                "pair_px": [[5.0, 6.0], [7.0, 8.0]],
+            },
+            {"score_ratio": 0.92, "corners": corners(good)},  # no pair_px: skip
         ],
     }
     pose = promotable_runner_up(doc, ref_scale_px_per_ft=1.0)
-    assert pose is not None and pose["pair"] == [2, 3]
+    assert pose is not None and pose["pair_px"] == [[5.0, 6.0], [7.0, 8.0]]
     # Below the 0.9 promotion bar nothing qualifies, however plausible.
     doc["runner_up_poses"] = [
-        {"score_ratio": 0.85, "corners": corners(good), "pair": [2, 3]}
+        {"score_ratio": 0.85, "corners": corners(good), "pair_px": [[5, 6], [7, 8]]}
     ]
     assert promotable_runner_up(doc, ref_scale_px_per_ft=1.0) is None
     assert promotable_runner_up({}, ref_scale_px_per_ft=1.0) is None

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -403,9 +403,7 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
                 keymap_centers=keymap_centers,
                 keymap_radius_m=keymap_radius,
                 keymap_regions=keymap_regions,
-                runner_up_affines=runner_up_affines_of(
-                    georef if state == "fitted" else None, width, height
-                ),
+                runner_up_affines=runner_up_affines_of(georef, width, height),
             )
         )
     return units
@@ -716,6 +714,26 @@ def build_page_context(
         )
         if all(haversine_m(lat_c, lon_c, b, a) > 50.0 for a, b in centers):
             centers = centers + [(lon_c, lat_c)]
+    if unit.fit_state in RESCUE_STATES and unit.runner_up_affines:
+        # #342: a demoted fit's RANSAC runner-ups join the rescue search. The
+        # demotion itself is the distrust signal (no verification gate needed,
+        # unlike the fitted-incumbent path), and the demoted pose's own center
+        # is often exactly the alias that earned the demotion -- miami p13's
+        # misscale seed searched 8 candidates around the wrong block while the
+        # true pose sat in runner_up_poses at 99.9% of the winner's score.
+        for affine in unit.runner_up_affines:
+            lon_r = float(
+                affine[0, 0] * unit.width / 2
+                + affine[0, 1] * unit.height / 2
+                + affine[0, 2]
+            )
+            lat_r = float(
+                affine[1, 0] * unit.width / 2
+                + affine[1, 1] * unit.height / 2
+                + affine[1, 2]
+            )
+            if all(haversine_m(lat_r, lon_r, b, a) > 50.0 for a, b in centers):
+                centers = centers + [(lon_r, lat_r)]
     if not centers:
         return None, "no_keymap"
     labels = page_label_features(vctx, unit)
@@ -1010,6 +1028,27 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
                 "source": "demoted-pose",
             }
         )
+    if unit.fit_state in RESCUE_STATES and unit.runner_up_affines:
+        # #342: the runner-ups' bearings enter as priors exactly like the
+        # demoted pose's (their centers joined in build_page_context).
+        for affine in unit.runner_up_affines:
+            theta = math.degrees(math.atan2(-affine[1, 0], affine[0, 0]))
+            ctx.rotation_priors = [
+                *ctx.rotation_priors,
+                RotationPrior(
+                    theta_deg=theta,
+                    sigma_deg=DEMOTED_SEED_SIGMA_DEG,
+                    source="ransac-runner-up",
+                ),
+            ]
+            record["priors"]["rotation"].append(
+                {
+                    "theta_deg": round(theta, 2),
+                    "sigma_deg": DEMOTED_SEED_SIGMA_DEG,
+                    "source": "ransac-runner-up",
+                }
+            )
+        record["search"]["runner_up_seeds"] = len(unit.runner_up_affines)
     candidates = snap_page(ctx, vctx.feature_index)
     # #324: a candidate whose pose reads the page upside-down is
     # corpus-impossible (0/1,332 truth pages in the zone); snap's rotation

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -75,13 +75,6 @@ RESCUE_STATES = {"nofit", "misscale", "1gcp", "outlier", "none"}
 # orientation -- its most trustworthy component -- ranks first.
 DEMOTED_SEED_SIGMA_DEG = 10.0
 
-# #340: a fitted page's RANSAC runner-ups may join the challenge search only
-# when the incumbent verifies below this. Ceiling measured on the 2026-08-14
-# corpus: no cross-channel adoption ever displaced an incumbent above 0.73
-# verification (18 street-solve adoptions), while the healthy fits whose pools
-# must not be perturbed verify 1.2-1.8.
-RUNNER_UP_MAX_INCUMBENT_VER = 1.0
-
 
 def artifacts_dir(volume: Path) -> Path:
     return volume / "artifacts" / "osm_snap"
@@ -714,26 +707,6 @@ def build_page_context(
         )
         if all(haversine_m(lat_c, lon_c, b, a) > 50.0 for a, b in centers):
             centers = centers + [(lon_c, lat_c)]
-    if unit.fit_state in RESCUE_STATES and unit.runner_up_affines:
-        # #340: a demoted fit's RANSAC runner-ups join the rescue search. The
-        # demotion itself is the distrust signal (no verification gate needed,
-        # unlike the fitted-incumbent path), and the demoted pose's own center
-        # is often exactly the alias that earned the demotion -- miami p13's
-        # misscale seed searched 8 candidates around the wrong block while the
-        # true pose sat in runner_up_poses at 99.9% of the winner's score.
-        for affine in unit.runner_up_affines:
-            lon_r = float(
-                affine[0, 0] * unit.width / 2
-                + affine[0, 1] * unit.height / 2
-                + affine[0, 2]
-            )
-            lat_r = float(
-                affine[1, 0] * unit.width / 2
-                + affine[1, 1] * unit.height / 2
-                + affine[1, 2]
-            )
-            if all(haversine_m(lat_r, lon_r, b, a) > 50.0 for a, b in centers):
-                centers = centers + [(lon_r, lat_r)]
     if not centers:
         return None, "no_keymap"
     labels = page_label_features(vctx, unit)
@@ -852,46 +825,6 @@ def candidate_record(candidate: SnapCandidate, unit: PageUnit) -> dict:
     return record
 
 
-def runner_up_search_extras(
-    unit: PageUnit,
-    incumbent_verification: float | None,
-    search_centers: list[tuple[float, float]],
-) -> tuple[list[tuple[float, float]], list[float]]:
-    """(extra centers, rotation thetas) RANSAC's runner-ups add to a challenge.
-
-    Empty unless the incumbent verifies below RUNNER_UP_MAX_INCUMBENT_VER --
-    above it no cross-channel adoption has ever displaced an incumbent, and
-    extra candidates in a healthy page's pool are pure perturbation risk
-    (nashville p6). Centers within 50 m of an existing search center are not
-    duplicated; every runner-up's rotation is offered regardless, since a
-    co-located near-tie can still disagree in bearing.
-    """
-    if not unit.runner_up_affines or incumbent_verification is None:
-        return [], []
-    if incumbent_verification >= RUNNER_UP_MAX_INCUMBENT_VER:
-        return [], []
-    centers: list[tuple[float, float]] = []
-    thetas: list[float] = []
-    for affine in unit.runner_up_affines:
-        lon_r = float(
-            affine[0, 0] * unit.width / 2
-            + affine[0, 1] * unit.height / 2
-            + affine[0, 2]
-        )
-        lat_r = float(
-            affine[1, 0] * unit.width / 2
-            + affine[1, 1] * unit.height / 2
-            + affine[1, 2]
-        )
-        if all(
-            haversine_m(lat_r, lon_r, b, a) > 50.0
-            for a, b in [*search_centers, *centers]
-        ):
-            centers.append((lon_r, lat_r))
-        thetas.append(math.degrees(math.atan2(-affine[1, 0], affine[0, 0])))
-    return centers, thetas
-
-
 def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
     """Generate the full candidates.jsonl record for one page."""
     ctx, status = build_page_context(vctx, unit)
@@ -971,41 +904,6 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
                     "radius_m": round(ctx.radius_m, 1),
                     "radius_source": "local-challenge",
                 }
-            # #340: RANSAC's near-tie runner-ups join the challenge as extra
-            # search centers + rotation priors -- but only under an incumbent
-            # the referee distrusts. No street-solve adoption has ever
-            # displaced an incumbent verifying above 0.73 (18 adoptions,
-            # 2026-08-14 corpus), so above RUNNER_UP_MAX_INCUMBENT_VER the
-            # ties are unbeatable noise and the pool stays untouched (the
-            # nashville p6 lesson: extra candidates can flip a healthy page).
-            # Runs after the local-challenge collapse, so each runner-up gets
-            # the same small-radius hunt an incumbent center does.
-            new_centers, thetas = runner_up_search_extras(
-                unit, incumbent.get("verification"), ctx.search_centers
-            )
-            if new_centers or thetas:
-                ctx.search_centers = [*ctx.search_centers, *new_centers]
-                for theta in thetas:
-                    ctx.rotation_priors = [
-                        *ctx.rotation_priors,
-                        RotationPrior(
-                            theta_deg=theta,
-                            sigma_deg=DEMOTED_SEED_SIGMA_DEG,
-                            source="ransac-runner-up",
-                        ),
-                    ]
-                    record["priors"]["rotation"].append(
-                        {
-                            "theta_deg": round(theta, 2),
-                            "sigma_deg": DEMOTED_SEED_SIGMA_DEG,
-                            "source": "ransac-runner-up",
-                        }
-                    )
-                if new_centers:
-                    record["search"]["runner_up_seeds"] = len(new_centers)
-                    record["search"]["centers"] = [
-                        [round(a, 7), round(b, 7)] for a, b in ctx.search_centers
-                    ]
     if unit.fit_state in RESCUE_STATES and unit.demoted_affine is not None:
         # #315: the demoted pose's center joined the search in
         # build_page_context; here its rotation — the pose's most trustworthy
@@ -1028,27 +926,6 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
                 "source": "demoted-pose",
             }
         )
-    if unit.fit_state in RESCUE_STATES and unit.runner_up_affines:
-        # #340: the runner-ups' bearings enter as priors exactly like the
-        # demoted pose's (their centers joined in build_page_context).
-        for affine in unit.runner_up_affines:
-            theta = math.degrees(math.atan2(-affine[1, 0], affine[0, 0]))
-            ctx.rotation_priors = [
-                *ctx.rotation_priors,
-                RotationPrior(
-                    theta_deg=theta,
-                    sigma_deg=DEMOTED_SEED_SIGMA_DEG,
-                    source="ransac-runner-up",
-                ),
-            ]
-            record["priors"]["rotation"].append(
-                {
-                    "theta_deg": round(theta, 2),
-                    "sigma_deg": DEMOTED_SEED_SIGMA_DEG,
-                    "source": "ransac-runner-up",
-                }
-            )
-        record["search"]["runner_up_seeds"] = len(unit.runner_up_affines)
     candidates = snap_page(ctx, vctx.feature_index)
     # #324: a candidate whose pose reads the page upside-down is
     # corpus-impossible (0/1,332 truth pages in the zone); snap's rotation

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -953,6 +953,41 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
                     "radius_m": round(ctx.radius_m, 1),
                     "radius_source": "local-challenge",
                 }
+            # #342: RANSAC's near-tie runner-ups join the challenge as extra
+            # search centers + rotation priors -- but only under an incumbent
+            # the referee distrusts. No street-solve adoption has ever
+            # displaced an incumbent verifying above 0.73 (18 adoptions,
+            # 2026-08-14 corpus), so above RUNNER_UP_MAX_INCUMBENT_VER the
+            # ties are unbeatable noise and the pool stays untouched (the
+            # nashville p6 lesson: extra candidates can flip a healthy page).
+            # Runs after the local-challenge collapse, so each runner-up gets
+            # the same small-radius hunt an incumbent center does.
+            new_centers, thetas = runner_up_search_extras(
+                unit, incumbent.get("verification"), ctx.search_centers
+            )
+            if new_centers or thetas:
+                ctx.search_centers = [*ctx.search_centers, *new_centers]
+                for theta in thetas:
+                    ctx.rotation_priors = [
+                        *ctx.rotation_priors,
+                        RotationPrior(
+                            theta_deg=theta,
+                            sigma_deg=DEMOTED_SEED_SIGMA_DEG,
+                            source="ransac-runner-up",
+                        ),
+                    ]
+                    record["priors"]["rotation"].append(
+                        {
+                            "theta_deg": round(theta, 2),
+                            "sigma_deg": DEMOTED_SEED_SIGMA_DEG,
+                            "source": "ransac-runner-up",
+                        }
+                    )
+                if new_centers:
+                    record["search"]["runner_up_seeds"] = len(new_centers)
+                    record["search"]["centers"] = [
+                        [round(a, 7), round(b, 7)] for a, b in ctx.search_centers
+                    ]
     if unit.fit_state in RESCUE_STATES and unit.demoted_affine is not None:
         # #315: the demoted pose's center joined the search in
         # build_page_context; here its rotation — the pose's most trustworthy

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -34,6 +34,7 @@ from mapsnap.edge_join_experiment import (
     keymap_region_adjacency,
     load_page_units,
     load_prob,
+    runner_up_affines_of,
     volume_median_scale,
 )
 from mapsnap.feature_index import FeatureIndex
@@ -73,6 +74,13 @@ RESCUE_STATES = {"nofit", "misscale", "1gcp", "outlier", "none"}
 # enough that the ladder still explores, tight enough that the demoted fit's
 # orientation -- its most trustworthy component -- ranks first.
 DEMOTED_SEED_SIGMA_DEG = 10.0
+
+# #342: a fitted page's RANSAC runner-ups may join the challenge search only
+# when the incumbent verifies below this. Ceiling measured on the 2026-08-14
+# corpus: no cross-channel adoption ever displaced an incumbent above 0.73
+# verification (18 street-solve adoptions), while the healthy fits whose pools
+# must not be perturbed verify 1.2-1.8.
+RUNNER_UP_MAX_INCUMBENT_VER = 1.0
 
 
 def artifacts_dir(volume: Path) -> Path:
@@ -395,6 +403,9 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
                 keymap_centers=keymap_centers,
                 keymap_radius_m=keymap_radius,
                 keymap_regions=keymap_regions,
+                runner_up_affines=runner_up_affines_of(
+                    georef if state == "fitted" else None, width, height
+                ),
             )
         )
     return units
@@ -821,6 +832,46 @@ def candidate_record(candidate: SnapCandidate, unit: PageUnit) -> dict:
             1,
         )
     return record
+
+
+def runner_up_search_extras(
+    unit: PageUnit,
+    incumbent_verification: float | None,
+    search_centers: list[tuple[float, float]],
+) -> tuple[list[tuple[float, float]], list[float]]:
+    """(extra centers, rotation thetas) RANSAC's runner-ups add to a challenge.
+
+    Empty unless the incumbent verifies below RUNNER_UP_MAX_INCUMBENT_VER --
+    above it no cross-channel adoption has ever displaced an incumbent, and
+    extra candidates in a healthy page's pool are pure perturbation risk
+    (nashville p6). Centers within 50 m of an existing search center are not
+    duplicated; every runner-up's rotation is offered regardless, since a
+    co-located near-tie can still disagree in bearing.
+    """
+    if not unit.runner_up_affines or incumbent_verification is None:
+        return [], []
+    if incumbent_verification >= RUNNER_UP_MAX_INCUMBENT_VER:
+        return [], []
+    centers: list[tuple[float, float]] = []
+    thetas: list[float] = []
+    for affine in unit.runner_up_affines:
+        lon_r = float(
+            affine[0, 0] * unit.width / 2
+            + affine[0, 1] * unit.height / 2
+            + affine[0, 2]
+        )
+        lat_r = float(
+            affine[1, 0] * unit.width / 2
+            + affine[1, 1] * unit.height / 2
+            + affine[1, 2]
+        )
+        if all(
+            haversine_m(lat_r, lon_r, b, a) > 50.0
+            for a, b in [*search_centers, *centers]
+        ):
+            centers.append((lon_r, lat_r))
+        thetas.append(math.degrees(math.atan2(-affine[1, 0], affine[0, 0])))
+    return centers, thetas
 
 
 def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -75,7 +75,7 @@ RESCUE_STATES = {"nofit", "misscale", "1gcp", "outlier", "none"}
 # orientation -- its most trustworthy component -- ranks first.
 DEMOTED_SEED_SIGMA_DEG = 10.0
 
-# #342: a fitted page's RANSAC runner-ups may join the challenge search only
+# #340: a fitted page's RANSAC runner-ups may join the challenge search only
 # when the incumbent verifies below this. Ceiling measured on the 2026-08-14
 # corpus: no cross-channel adoption ever displaced an incumbent above 0.73
 # verification (18 street-solve adoptions), while the healthy fits whose pools
@@ -715,7 +715,7 @@ def build_page_context(
         if all(haversine_m(lat_c, lon_c, b, a) > 50.0 for a, b in centers):
             centers = centers + [(lon_c, lat_c)]
     if unit.fit_state in RESCUE_STATES and unit.runner_up_affines:
-        # #342: a demoted fit's RANSAC runner-ups join the rescue search. The
+        # #340: a demoted fit's RANSAC runner-ups join the rescue search. The
         # demotion itself is the distrust signal (no verification gate needed,
         # unlike the fitted-incumbent path), and the demoted pose's own center
         # is often exactly the alias that earned the demotion -- miami p13's
@@ -971,7 +971,7 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
                     "radius_m": round(ctx.radius_m, 1),
                     "radius_source": "local-challenge",
                 }
-            # #342: RANSAC's near-tie runner-ups join the challenge as extra
+            # #340: RANSAC's near-tie runner-ups join the challenge as extra
             # search centers + rotation priors -- but only under an incumbent
             # the referee distrusts. No street-solve adoption has ever
             # displaced an incumbent verifying above 0.73 (18 adoptions,
@@ -1029,7 +1029,7 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
             }
         )
     if unit.fit_state in RESCUE_STATES and unit.runner_up_affines:
-        # #342: the runner-ups' bearings enter as priors exactly like the
+        # #340: the runner-ups' bearings enter as priors exactly like the
         # demoted pose's (their centers joined in build_page_context).
         for affine in unit.runner_up_affines:
             theta = math.degrees(math.atan2(-affine[1, 0], affine[0, 0]))

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -546,32 +546,6 @@ def test_load_page_units_populates_demoted_affine(tmp_path):
     assert units["p3"].demoted_affine is None
 
 
-def test_runner_up_search_extras_gates_on_incumbent_verification():
-    from mapsnap.osm_snap_experiment import runner_up_search_extras
-
-    unit = make_unit("fitted")
-    runner_up = np.array(affine(lon_shift_m=500.0))
-    unit.runner_up_affines = [runner_up]
-    incumbent_center = (
-        float(np.array(affine())[0] @ [500.0, 500.0, 1.0]),
-        float(np.array(affine())[1] @ [500.0, 500.0, 1.0]),
-    )
-    # A well-verifying incumbent keeps its pool untouched.
-    centers, thetas = runner_up_search_extras(unit, 1.4, [incumbent_center])
-    assert centers == [] and thetas == []
-    # A distrusted incumbent admits the runner-up center and its rotation.
-    centers, thetas = runner_up_search_extras(unit, 0.3, [incumbent_center])
-    assert len(centers) == 1 and len(thetas) == 1
-    # A runner-up on top of an existing center adds no duplicate center but
-    # still offers its bearing.
-    unit.runner_up_affines = [np.array(affine())]
-    centers, thetas = runner_up_search_extras(unit, 0.3, [incumbent_center])
-    assert centers == [] and len(thetas) == 1
-    # No verification score at all: stay out of the pool.
-    unit.runner_up_affines = [runner_up]
-    assert runner_up_search_extras(unit, None, [incumbent_center]) == ([], [])
-
-
 def test_runner_up_affines_load_for_fitted_pages_only(tmp_path):
 
     from mapsnap.edge_join_experiment import runner_up_affines_of

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -544,3 +544,42 @@ def test_load_page_units_populates_demoted_affine(tmp_path):
     assert units["p2"].gen_affine is not None
     assert units["p2"].demoted_affine is None
     assert units["p3"].demoted_affine is None
+
+
+def test_runner_up_search_extras_gates_on_incumbent_verification():
+    from mapsnap.osm_snap_experiment import runner_up_search_extras
+
+    unit = make_unit("fitted")
+    runner_up = np.array(affine(lon_shift_m=500.0))
+    unit.runner_up_affines = [runner_up]
+    incumbent_center = (
+        float(np.array(affine())[0] @ [500.0, 500.0, 1.0]),
+        float(np.array(affine())[1] @ [500.0, 500.0, 1.0]),
+    )
+    # A well-verifying incumbent keeps its pool untouched.
+    centers, thetas = runner_up_search_extras(unit, 1.4, [incumbent_center])
+    assert centers == [] and thetas == []
+    # A distrusted incumbent admits the runner-up center and its rotation.
+    centers, thetas = runner_up_search_extras(unit, 0.3, [incumbent_center])
+    assert len(centers) == 1 and len(thetas) == 1
+    # A runner-up on top of an existing center adds no duplicate center but
+    # still offers its bearing.
+    unit.runner_up_affines = [np.array(affine())]
+    centers, thetas = runner_up_search_extras(unit, 0.3, [incumbent_center])
+    assert centers == [] and len(thetas) == 1
+    # No verification score at all: stay out of the pool.
+    unit.runner_up_affines = [runner_up]
+    assert runner_up_search_extras(unit, None, [incumbent_center]) == ([], [])
+
+
+def test_runner_up_affines_load_for_fitted_pages_only(tmp_path):
+
+    from mapsnap.edge_join_experiment import runner_up_affines_of
+
+    corners = [[-80.0, 25.0], [-79.99, 25.0], [-79.99, 24.99], [-80.0, 24.99]]
+    georef = {"runner_up_poses": [{"corners": corners, "score_ratio": 0.98}]}
+    affines = runner_up_affines_of(georef, 1000, 1000)
+    assert len(affines) == 1
+    assert affines[0].shape == (2, 3)
+    assert runner_up_affines_of(None, 1000, 1000) == []
+    assert runner_up_affines_of({"runner_up_poses": [{"bad": 1}]}, 1000, 1000) == []


### PR DESCRIPTION
RANSAC keeps one argmax winner and discards every runner-up — but on gridded cities its objective is nearly flat across aliases (miami p13: the TRUE pose scored 99.9% of a 1,195 ft winner). This PR emits the near-ties and puts them to work through two consumers, gated so healthy pages' candidate pools are never touched. Tracking: #340.

## The mechanism, in three parts

1. **Emission** — `ransac_hybrid` sinks every scored pose; `select_runner_up_poses` keeps ≤4 distinct near-ties (≥70% of winner score, >30 m or >1.5° apart, never upside-down per #324) in the sidecar as `runner_up_poses`, each carrying its corner quad, score ratio, and its seed pair addressed by **crossing pixels + geo candidates** (indices are tier-relative and a pixel can carry several world candidates — both discovered the hard way, see commits).
2. **Promotion (the headline)** — when the scale-outlier pass would demote a fitted page as misscale, it first checks for a near-tie (≥90% score) whose scale the volume's rungs accept, and **refits the page with that pose's seed pair forced** through the ordinary pipeline. The promoted fit carries its own coherent inliers/GCPs, becomes the incumbent, and snap *refines* it instead of rescuing around the wrong pose's center. A refit that fails or lands off-rung restores the original sidecar and falls back to the demotion.
3. **Gated challenge/rescue seeding** — fitted pages whose incumbent verifies below 1.0 (measured ceiling: no adoption has ever displaced an incumbent above 0.73) get runner-up centers + bearings as extra local-challenge seeds; rescue-state pages get them alongside the #315 demoted seed.

## A/B (miami + nashville, cold caches, PYTHONHASHSEED=0; `runnerup-ctl` vs `runnerup-ab5`)

| | control | full treatment |
|---|---|---|
| **miami** | 78.5%, 82/93 placed | **82.0%, 84/93 placed (+3.6 net)** |
| **nashville** | 71.2% (= 2026-08-14 baseline) | 71.2%, zero page moves — five arms, never perturbed |

miami's moves: **p13 unplaced → 10.2 ft** (promoted at 99.9% score ratio — the page that motivated the channel, previously stuck as a misscale rescue searching the wrong block), **p76 352 → 4.5 ft** (a disaster converted: promoted neighbor p74 flips p76's snap arbitration; stable across two arms), p74 unplaced → 118.8 ft (band-neutral coverage), p1 32.4 → 26.1, plus sub-ft jitter. Worst regression anywhere: p24 +0.7 ft.

## Why seeding alone wasn't enough (the intermediate result)

Runner-up centers seeded into the rescue search could not save p13: `cluster_search_centers` merges centers within 0.75×radius, and the NCC ladder's top-K over the merged disc is dominated by grid aliases even though it covers truth — the pose needed *judging*, not re-deriving. Promotion sidesteps the ladder by refitting the exact pose; full candidate-injection into arbitration remains #340's reconcile-phase item.

Tests: emission selection (distinctness, upside-down, cap, pair addressing), promotion selector (rung check, near-tie bar, missing-pair skip), consumption gate (ver ≥1.0 untouched, dedupe, no-score abstention), loader round-trip. Full suite 1045 passing; ruff/pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)