### PR TITLE
Debugger: compare colors for uppercase lettered sheets (asheville p3C)

### DIFF
--- a/app/src/iiif/compare.test.ts
+++ b/app/src/iiif/compare.test.ts
@@ -51,3 +51,12 @@ describe('statsByItemIndex', () => {
     });
   });
 });
+
+describe('statsByItemIndex casing', () => {
+  it('pairs uppercase lettered stems with lowercase sidecar keys', () => {
+    // compareTxt normalizes keys to lowercase; disk stems keep their case
+    // (asheville p3C). The join must not lose those pages' colors.
+    const stats = statsByItemIndex([row('p3c', 12)], [page('p3C', 7)]);
+    expect(stats.get(7)?.rmseFt).toBe(12);
+  });
+});

--- a/app/src/iiif/compare.ts
+++ b/app/src/iiif/compare.ts
@@ -60,7 +60,11 @@ export function statsByItemIndex(
   const byKey = new Map(rows.map((row) => [row.genPageKey, row]));
   const stats = new Map<number, PageCompareStats>();
   for (const page of pages) {
-    const row = byKey.get(page.stem);
+    // Sidecar keys are normalized to lowercase (compareTxt.ts); page stems
+    // keep the disk file's case, and lettered sheets are uppercase on some
+    // volumes (asheville p3C). Match case-insensitively or those pages
+    // silently lose their compare colors.
+    const row = byKey.get(page.stem.toLowerCase());
     if (!row) continue;
     stats.set(page.itemIndex, {
       rmseFt: row.rmseFt,


### PR DESCRIPTION
The IIIF debugger showed no compare color for asheville's `p3C`: the compare sidecar's rows are keyed lowercase (`compareTxt.ts` normalizes deliberately), while `PageGeo.stem` keeps the disk file's case via the `stemsByLowercase` recovery — so `statsByItemIndex`'s `byKey.get(page.stem)` missed every uppercase lettered sheet. One-line fix: lowercase the stem at the join, with a regression test.

Verified separately that `mapsnap compare` / `mapsnap score` are unaffected — they derive keys from source ids on both sides, and asheville shows zero case mismatches between truth keys and generated keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)