### PR TITLE
Embed sidecar keymap data below the megapixel floor (asheville/columbia regression)

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -2286,6 +2286,7 @@ def _init_worker(
     truth_by_page: dict[int, list[list[list[float]]]] | None = None,
     keep_labels_on_fill: bool = False,
     collinear_perp_tolerance_px: float = COLLINEAR_PERP_TOLERANCE_PX,
+    embed_locator: KeymapLocator | None = None,
 ) -> None:
     """Populate _worker_state once per worker process (or once in the main process)."""
     _worker_state.update(
@@ -2305,6 +2306,7 @@ def _init_worker(
         parameters=parameters,
         high_confidence_size_fraction=high_confidence_size_fraction,
         locator=locator,
+        embed_locator=embed_locator,
         geojson_features=geojson_features or [],
         rectangle_index=rectangle_index,
         truth_by_page=truth_by_page or None,
@@ -2345,7 +2347,10 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
         truth_by_page.get(number) if truth_by_page and number is not None else None
     )
     key = page_key(image_stem(image_path))
-    keymap = locator.page_keymap(key) if locator is not None else None
+    # Embed keymap data from the unfloored locator: the floor gates only the
+    # vocabulary restriction, not the sidecar transport to snap/street-solve.
+    embed = _worker_state.get("embed_locator") or locator
+    keymap = embed.page_keymap(key) if embed is not None else None
 
     def run(
         block_index: dict, cos_phi: float, size_fraction: float = 1.0
@@ -3659,7 +3664,19 @@ def main() -> None:
     # neighborhood and, if that starves the fit, against the whole key-map rectangle (a
     # volume-wide box every page sits in — far smaller than the full centerlines).
     keymap_files = resolve_keymaps(args.keymap, args.ignore_keymap, args.images)
+    # The sidecar keymap field (centers/radius/regions) is transport to
+    # osm-snap and street-solve and is embedded regardless of the megapixel
+    # floor -- the floor guards only the vocabulary restriction. Below the
+    # floor these differ: embed_locator exists while locator stays None.
+    embed_keymap_files = resolve_keymaps(
+        args.keymap, args.ignore_keymap, args.images, apply_floor=False
+    )
     locator = None
+    embed_locator = None
+    if embed_keymap_files:
+        embed_locator = KeymapLocator.from_keymaps(
+            embed_keymap_files, args.keymap_radius
+        )
     rectangle_index: tuple[dict[str, list[Block]], float] | None = None
     if keymap_files:
         print(
@@ -3667,6 +3684,8 @@ def main() -> None:
             file=sys.stderr,
         )
         locator = KeymapLocator.from_keymaps(keymap_files, args.keymap_radius)
+        if embed_keymap_files == keymap_files:
+            embed_locator = locator
         rectangle = locator.rectangle_features(geojson["features"])
         if rectangle:
             rectangle_bi = build_block_index(
@@ -3786,6 +3805,7 @@ def main() -> None:
         truth_by_page,
         args.keep_labels_on_fill,
         args.collinear_perp_tolerance,
+        embed_locator,
     )
     if args.num_workers > 1:
         with multiprocessing.Pool(

--- a/mapsnap/keymap/locate.py
+++ b/mapsnap/keymap/locate.py
@@ -238,13 +238,25 @@ def discover_keymaps(image_paths: list[str]) -> list[Path]:
 
 
 def resolve_keymaps(
-    explicit: list[str] | None, ignore: bool, image_paths: list[str]
+    explicit: list[str] | None,
+    ignore: bool,
+    image_paths: list[str],
+    *,
+    apply_floor: bool = True,
 ) -> list[Path]:
     """The key-map files ``ocr``/``georef`` should use, applying the shared flag precedence.
 
     ``--ignore-keymap`` (``ignore``) turns the feature off; otherwise an explicit ``--keymap``
     list wins, and with neither the key maps are auto-discovered next to the images (see
     :func:`discover_keymaps`). Centralized so both commands resolve key maps identically.
+
+    ``apply_floor=False`` skips the megapixel floor: the floor exists to stop
+    per-page-number VOCABULARY restriction on scans whose numbers truncate, but
+    the georef sidecar's keymap field (centers, radius, regions) is transport
+    to osm-snap and street-solve, which carry their own guards and are
+    documented to keep working below the floor. Dropping the locator entirely
+    severed that transport on asheville (23.8 MP): every sidecar's keymap was
+    null and snap lost its search centers and region priors.
     """
     if ignore:
         return []
@@ -254,7 +266,7 @@ def resolve_keymaps(
     return [
         keymap_json
         for keymap_json in discover_keymaps(image_paths)
-        if above_megapixel_floor(keymap_json)
+        if not apply_floor or above_megapixel_floor(keymap_json)
     ]
 
 

--- a/mapsnap/keymap/locate_test.py
+++ b/mapsnap/keymap/locate_test.py
@@ -497,3 +497,21 @@ def test_megapixel_floor_sits_in_the_corpus_gap():
     a future sheet landing near the floor means the assumption needs rechecking.
     """
     assert 25.0 < MIN_KEYMAP_MEGAPIXELS < 42.0
+
+
+def test_resolve_keymaps_apply_floor_false_keeps_sub_floor_sheets(tmp_path: Path):
+    """The sidecar-embed resolver must see sub-floor keymaps.
+
+    The floor guards only the vocabulary restriction; the georef sidecar's
+    keymap field is transport to osm-snap and street-solve. Dropping the
+    locator entirely nulled every asheville/columbia sidecar's keymap and
+    silently severed snap's search centers and region priors.
+    """
+    (tmp_path / "raw").mkdir(exist_ok=True)
+    write_keymap_pair(tmp_path / "raw", "p0", 4400, 5517)  # columbia-size: sub-floor
+    floored = resolve_keymaps(None, False, [str(tmp_path / "p5.jpg")])
+    unfloored = resolve_keymaps(
+        None, False, [str(tmp_path / "p5.jpg")], apply_floor=False
+    )
+    assert floored == []
+    assert [p.name for p in unfloored] == ["p0.keymap.json"]


### PR DESCRIPTION
The #249-era megapixel floor exists to stop per-page-number **vocabulary restriction** on scans whose numbers truncate — its own docstring promises osm-snap and street-solve keep working below it. But `resolve_keymaps` dropped sub-floor keymaps entirely, so `georef` built no locator and every sidecar's `keymap` field came out **null** on the sub-floor volumes (asheville 23.8 MP, columbia 24.3 MP). That field is the transport for keymap centers, radius, and **regions** into `PageUnit` — snap silently lost its keymap search centers and region priors on exactly the volumes whose pages need rescue most.

Fix: `resolve_keymaps` grows `apply_floor=False`; georef builds a second, unfloored locator whose only job is the sidecar embed. The floored locator still drives the vocabulary tiers, so the Columbia-measured protection (+17.3 net from not restricting on a bad decode) is unchanged.

Verified on asheville (tag `asheville-keymap3`, cold caches, PYTHONHASHSEED=0): sidecars again carry `{lat, lon, radius_m, centers, regions}`, and the volume moves 21.9% → **23.3%** vs the severed-transport run under identical OCR — with the best ≤25 ft share of any asheville arm (33.4%). Columbia's sidecars will heal on its next fit.

Unit test: `resolve_keymaps(apply_floor=False)` keeps a columbia-sized sub-floor sheet that the floored resolver drops. Full suite 1048 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)