### PR TITLE
Fit starts with cold snap caches (#342): warm saves 3 min/corpus, costs ~2 points of variance

### DIFF
--- a/mapsnap/experiments.py
+++ b/mapsnap/experiments.py
@@ -402,18 +402,20 @@ def archive_run(
     # poses this run actually weighed (#270). Without these the baseline is
     # unrecoverable once any post-run experiment re-matches: the files live at
     # fixed paths and are overwritten in place.
+    # Globbed, not enumerated: clear_derived_sidecars deletes every
+    # candidates/selection file at the next fit's start, so anything the
+    # archive misses is destroyed rather than merely stale -- and the
+    # selection variants have grown before (selection_volume, selection_argmax
+    # were never in the old hardcoded list).
     for channel in ("osm_snap", "street_solve"):
         channel_dir = artifacts_dir / channel
-        for name in (
-            "candidates.jsonl",
-            "selection_arbitrate.jsonl",
-            "selection_union.jsonl",
+        for source in (
+            *sorted(channel_dir.glob("candidates.jsonl")),
+            *sorted(channel_dir.glob("selection_*.jsonl")),
         ):
-            source = channel_dir / name
-            if source.exists():
-                target_dir = run_dir / channel
-                target_dir.mkdir(exist_ok=True)
-                shutil.copy2(source, target_dir / name)
+            target_dir = run_dir / channel
+            target_dir.mkdir(exist_ok=True)
+            shutil.copy2(source, target_dir / source.name)
     if iiif_path is not None and iiif_path.exists():
         shutil.copy2(iiif_path, run_dir / iiif_path.name)
     if compare_txt is not None and compare_txt.exists():

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -110,6 +110,23 @@ def clear_derived_sidecars(dir_path: Path) -> int:
     for path in sorted(dir_path.glob(DERIVED_SIDECAR_GLOB)):
         path.unlink()
         removed += 1
+    # The snap candidate/selection caches are derived state too (#342). Inside
+    # a fit they can only ever hit for pages whose records carry no
+    # georef_mtime (demoted/failure classes) -- every fitted page's record is
+    # invalidated by the georef rewrite above -- and those hits are exactly
+    # the cache-temperature flips #342 measured (KC p566__1 at 7.4 vs 282 ft
+    # on cache state alone, ~2 net points). Measured across all 18 truth
+    # volumes, a fully cold snap stage costs 3 minutes per corpus run (4,958s
+    # warm vs 5,113s cold), so the cache buys nothing a fit can keep. The
+    # files remain useful within a run and for standalone `mapsnap snap`
+    # iteration; a fit just never inherits a previous run's records.
+    for cache in (
+        *sorted((dir_path / "artifacts" / "osm_snap").glob("candidates.jsonl")),
+        *sorted((dir_path / "artifacts" / "osm_snap").glob("selection_*.jsonl")),
+        *sorted((dir_path / "artifacts" / "street_solve").glob("candidates.jsonl")),
+    ):
+        cache.unlink()
+        removed += 1
     if removed:
         print(f"Cleared {removed} derived georef sidecar(s) from {dir_path}")
     return removed

--- a/mapsnap/fit_test.py
+++ b/mapsnap/fit_test.py
@@ -112,3 +112,21 @@ def test_channel_writers_and_arbiter_agree_on_names(tmp_path):
     assert channels == set(CHANNEL_ORDER), (
         f"channels written {channels} != channels arbitrated {set(CHANNEL_ORDER)}"
     )
+
+
+def test_clear_derived_sidecars_clears_snap_caches(tmp_path: Path):
+    # #342: a fit must never inherit a previous run's snap candidate or
+    # selection records -- cache temperature alone flipped KC pages 7.4 <-> 282 ft.
+    (tmp_path / "p1.georef.json").write_text("{}")
+    snap = tmp_path / "artifacts" / "osm_snap"
+    street = tmp_path / "artifacts" / "street_solve"
+    snap.mkdir(parents=True)
+    street.mkdir(parents=True)
+    (snap / "candidates.jsonl").write_text("{}\n")
+    (snap / "selection_volume.jsonl").write_text("{}\n")
+    (street / "candidates.jsonl").write_text("{}\n")
+    removed = clear_derived_sidecars(tmp_path)
+    assert removed == 4
+    assert not (snap / "candidates.jsonl").exists()
+    assert not (snap / "selection_volume.jsonl").exists()
+    assert not (street / "candidates.jsonl").exists()


### PR DESCRIPTION
Closes #342

is the incremental snap cache worth its invalidation hazards?

**Measurement** (per-stage wall-clock, all 18 truth volumes, like-for-like 2-up runs): snap stage totals **4,958 s warm vs 5,113 s cold** — the cache saves ~3 minutes per corpus run, within noise (cold is faster on LA, columbia, nashville).

**Why it can't save more inside a fit**: `clear_derived_sidecars` wipes every georef sidecar, georef rewrites them all, and `candidates_record_fresh` keys on `georef_mtime` — every fitted page's record is stale by construction, every run. The only records that survive across fits are the mtime-less demoted/failure classes, which are precisely the #342 cache-temperature flips (KC p566__1: 7.4 ↔ 282 ft on cache state alone, ~2 net points) and the #275/KC-p551 stale-record re-adoption class. The cache's entire cross-run surface inside fit is its bug surface.

**Change**: `clear_derived_sidecars` also removes `artifacts/osm_snap/candidates.jsonl`, `selection_*.jsonl`, and `artifacts/street_solve/candidates.jsonl` — the #240 idempotency principle extended to cache records. Every fit is cold by definition; the files remain useful within a run and for standalone `mapsnap snap` iteration. Side benefit: A/B protocols no longer need manual cache snapshotting/clearing, which every experiment this month has had to do by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)