### PR TITLE
Road UNet v4 swap with recalibrated verification bars

### DIFF
--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1816,11 +1816,18 @@ def cmd_sweep_refine(volumes: list[Path], recompute: bool = False) -> None:
 # The frozen production gates (dev-swept; `mapsnap snap` uses these): the
 # per-page rescue score/margin gates, the volume-energy conservative elbow,
 # and the arbitration score gate.
-PRODUCTION_GATE_SCORE = 1.25
+# Absolute verification bars are calibrated to the road UNet's score
+# distribution. v3 (30-volume retrain) lifts genuine poses' verification by
+# +0.10 median over v1 (164 identical incumbent poses, detroit+richmond:
+# median 1.055 -> 1.159, driven by inlier_frac and chamfer), so the absolute
+# bars move with it -- otherwise rescues that used to fail the bar clear it
+# on the lift alone (detroit p61/p8/p93 vacuum-fills at 358-591 ft). Gap
+# comparisons (challenge margins) are shift-invariant and stay unchanged.
+PRODUCTION_GATE_SCORE = 1.35
 PRODUCTION_GATE_MARGIN = 0.25
-PRODUCTION_ARBITRATE_GATE = 1.5
+PRODUCTION_ARBITRATE_GATE = 1.6
 
-STAMP_RESCUE_SCORE = 0.7
+STAMP_RESCUE_SCORE = 0.8
 """Relaxed rescue bar for stamp-corroborated candidates.
 
 A contradiction-demoted page's rescue candidate that lands its printed claim

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1817,12 +1817,14 @@ def cmd_sweep_refine(volumes: list[Path], recompute: bool = False) -> None:
 # per-page rescue score/margin gates, the volume-energy conservative elbow,
 # and the arbitration score gate.
 # Absolute verification bars are calibrated to the road UNet's score
-# distribution. v3 (30-volume retrain) lifts genuine poses' verification by
-# +0.10 median over v1 (164 identical incumbent poses, detroit+richmond:
-# median 1.055 -> 1.159, driven by inlier_frac and chamfer), so the absolute
-# bars move with it -- otherwise rescues that used to fail the bar clear it
-# on the lift alone (detroit p61/p8/p93 vacuum-fills at 358-591 ft). Gap
-# comparisons (challenge margins) are shift-invariant and stay unchanged.
+# distribution. v4 (30-volume retrain at v1's width; #173 uniform sampling)
+# lifts verification over v1 by +0.05 median on good poses and +0.13 on the
+# rest (164 identical incumbent poses, detroit+richmond: absolute median
+# 1.055 -> 1.199, driven by inlier_frac and chamfer), so the absolute bars
+# carry a +0.10 offset inside that band -- otherwise rescues that used to
+# fail the bar clear it on the lift alone (detroit p61/p8/p93 vacuum-fills
+# at 358-591 ft under uncalibrated v3). Gap comparisons (challenge margins)
+# are shift-invariant and stay unchanged.
 PRODUCTION_GATE_SCORE = 1.35
 PRODUCTION_GATE_MARGIN = 0.25
 PRODUCTION_ARBITRATE_GATE = 1.6

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -439,10 +439,12 @@ def test_stamp_corroborated_rescue_relaxes_the_gates():
             "candidates": candidates,
         }
 
-    # KC p551 shape: true pose at 0.77 within the stamp bound, rivals gated
+    # KC p551 shape: true pose within the stamp bound, rivals gated
     # implausible (select_score None) -> adopted under the relaxed bar.
+    # (0.77 was its v1-era score; the v3 recalibration shifted the bars and
+    # the scores together, so the fixture tracks: 0.87 vs the 0.8 bar.)
     (choice,) = select_argmax(
-        [rec([cand(0.77, sep=24.0), {"select_score": None}])],
+        [rec([cand(0.87, sep=24.0), {"select_score": None}])],
         PRODUCTION_GATE_SCORE,
         PRODUCTION_GATE_MARGIN,
     )
@@ -461,9 +463,9 @@ def test_stamp_corroborated_rescue_relaxes_the_gates():
     )
     assert choice["chosen"] is None and "margin" in choice["reason"]
 
-    # Without stamp corroboration the normal bar stands (0.77 < 1.25)...
+    # Without stamp corroboration the normal bar stands (0.87 < 1.35)...
     (choice,) = select_argmax(
-        [rec([cand(0.77)])], PRODUCTION_GATE_SCORE, PRODUCTION_GATE_MARGIN
+        [rec([cand(0.87)])], PRODUCTION_GATE_SCORE, PRODUCTION_GATE_MARGIN
     )
     assert choice["chosen"] is None
     # ...and a fitted page's record never takes the relaxed path.

--- a/mapsnap/train_road_unet.py
+++ b/mapsnap/train_road_unet.py
@@ -34,10 +34,11 @@ from mapsnap.utils import image_stem
 
 # Random patches sampled from each page per epoch.
 PATCHES_PER_PAGE = 6
-# Fraction of training patches constrained to the page-margin band, where the
-# seam strips the edge-join matcher depends on live.
-EDGE_FRACTION = 0.5
-# Width of that band in pixels (~75m at the 25%-scale ~0.24 m/px).
+# Width of the page-margin band in pixels (~75m at the 25%-scale ~0.24 m/px).
+# Only the VALIDATION edge-IoU metric reads this now: #173 dropped the edge
+# oversampling of training patches, which served the edge-join matcher's seam
+# strips -- since #152 the model's consumer is fit refinement, which reads it
+# wherever OSM features are, so training samples uniformly.
 EDGE_BAND_PX = 320
 
 
@@ -84,27 +85,14 @@ def sample_patch(
 
     The rotation augmentation matters here: adjacent Sanborn sheets are drawn grid-aligned
     rather than north-up, so at inference the model sees corridors at arbitrary angles.
-    EDGE_FRACTION of patches are pinned to the page-margin band: the edge-join matcher
-    reads the model exclusively in seam strips, where content is sketchier (duplicated
-    margin blocks, big sheet numbers) than in the page interior.
+    Sampling is uniform over the page (#173): the model's consumer is fit
+    refinement, which reads it wherever OSM features are, not the edge-join
+    seam strips the old edge oversampling served.
     """
     height, width = gray.shape
     y_max, x_max = max(1, height - PATCH), max(1, width - PATCH)
-    if rng.random() < EDGE_FRACTION:
-        side = int(rng.integers(0, 4))
-        band_y = min(EDGE_BAND_PX, y_max)
-        band_x = min(EDGE_BAND_PX, x_max)
-        if side == 0:  # top
-            y, x = rng.integers(0, band_y), rng.integers(0, x_max)
-        elif side == 1:  # bottom
-            y, x = rng.integers(y_max - band_y, y_max), rng.integers(0, x_max)
-        elif side == 2:  # left
-            y, x = rng.integers(0, y_max), rng.integers(0, band_x)
-        else:  # right
-            y, x = rng.integers(0, y_max), rng.integers(x_max - band_x, x_max)
-    else:
-        y = rng.integers(0, y_max)
-        x = rng.integers(0, x_max)
+    y = rng.integers(0, y_max)
+    x = rng.integers(0, x_max)
     patch = gray[y : y + PATCH, x : x + PATCH]
     label = mask[y : y + PATCH, x : x + PATCH]
     k = int(rng.integers(0, 4))


### PR DESCRIPTION
Stacked on #348. Swaps `models/road_unet.pt` to **v4**: the 30-volume / 2,080-page corpus with #348's uniform sampling, at **v1's full width (base 32)** — the manual review of v3 found its across-the-board confidence loss traced to being trained at the CLI-default base 24 (56% of v1's parameters) while tripling style diversity. v4: hudson IoU **0.536 / edge 0.519** (best of v1/v3/v4); corridors refill to v1 saturation with v3's clean background; the 10-page review preferred v4 over v3 everywhere.

## Calibration

164 identical incumbent poses under both models: v4 lifts verification +0.05 median (good poses) / +0.13 (rest), absolute median 1.055 → 1.199. The absolute bars carry a +0.10 offset inside that band (`PRODUCTION_GATE_SCORE` 1.35, `PRODUCTION_ARBITRATE_GATE` 1.6, `STAMP_RESCUE_SCORE` 0.8); gap comparisons unchanged.

## Final ledger (single-variable: v4 vs v1-cold controls, cache effects separated per #342)

| volume | v4 model effect | note |
|---|---|---|
| **asheville** | **+11.8** (23.3 → 35.1) | disasters 10.1→5.8%; the coarse-sheet P(road)+keymap thesis |
| **miami** | +4.7 | held from v3 |
| **columbia** | +4.6 (69.7 → 74.3) | up from v3's +1.3 |
| fargo | +1.6 | v3's −2.4 healed; p9g intact at 10.8 ft |
| detroit | +0.7 | p8/p93 back to abstention |
| richmond | +0.1 | v3's +3.4 traded for p311's new 14,712 ft vacuum-fill |
| washington_dc | −0.8 | p210 (13.5→352) persists |
| brooklyn | −2.9 | p44/p14 persist |

Sum over measured movers: **≈ +20 points**; v3's ledger for comparison was ≈ +7.5 with fargo/detroit negative.

## Residuals, named for the reconciler (#270/#340)

brooklyn p44/p14, DC p210, detroit p61, richmond p311 — challenge re-rankings and confident vacuum-fills that neither model choice nor threshold offsets resolve; all need joint/neighbor evidence.

Validation archives: `unet3-corpus`, `unet3-recal`, `unet4-recal`, `v1cold`/`fargo-v1cold`, `asheville-unet3b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)