### PR TITLE
Fix CI pyright break; adopt the no-direct-push workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,12 @@
 # Claude Code Instructions
 
+## Pull Requests
+
+- Don't commit directly to `main`. Always go through a pull request.
+- Don't merge PRs unless explicitly told to.
+- Don't include issue numbers in PR titles. Put them in the body instead.
+- Use GitHub keyword phrases like "Fixes #123" or "Resolves #234" to make PRs automatically close issues.
+
 ## Coding guidelines
 
 - Avoid abbrevs: `const startDate = r.tags['start_date']`, not `const sd = ...`.

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -114,6 +114,13 @@ resuming would produce a corpus that silently mixes two recognizers.
 That makes the OCR lane much slower than a normal re-run (which reuses reads
 and only re-recognizes new panels), so budget for it.
 
+## Fixing bugs found along the way
+
+You can fix small issues that arise while running the pipeline. Commit these
+changes on the same branch as the baseline update and include them in the PR.
+Do not commit directly to `main` or push commits directly onto `origin/main`.
+This avoids breaking CI (see #360).
+
 ## Reading the results
 
 ```sh

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -21,6 +21,7 @@ number of color pixels and improves convexity.
 
 import math
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -257,7 +258,7 @@ def _assign_blocks_to_pages(
     return assignment
 
 
-def safe_unary_union(geoms: list[BaseGeometry]) -> BaseGeometry:
+def safe_unary_union(geoms: Sequence[BaseGeometry]) -> BaseGeometry:
     """unary_union with a make_valid retry (see safe_overlay).
 
     Masks arrive from earlier overlay chains and can carry self-intersections


### PR DESCRIPTION
Fixes the CI break on `main` (and inherited by every PR branch) introduced by the two clip-masks commits pushed directly to `main` during the 2026-08-28 baseline run.

**The break**: `safe_unary_union(geoms: list[BaseGeometry])` — CI's pyright correctly rejects passing `list[Polygon]` because `list` is invariant. My local pyright was stale (it warned "Please install the new version" and I missed it) and passed. Fix: `Sequence[BaseGeometry]`, covariant and read-only in this function. Verified against `PYRIGHT_PYTHON_FORCE_VERSION=latest` (0 errors) plus the full suite (1,066 passing).

**The process fix, included per instructions**: CLAUDE.md gains the pull-request rules (no direct commits to `main`, no merging without instruction, issue numbers in bodies not titles, GitHub closing keywords), and docs/baseline.md gains a "Fixing bugs found along the way" section — mid-run fixes ride the baseline update branch and its PR, which is exactly what these two commits should have done.

For the record, the two offending commits (`5845f2b`, `04427eb`) are functionally sound — write-path GEOS robustness that richmond's fit needed — and remain on `main`; this PR only repairs the type signature and encodes the workflow rule that would have kept them off `main` in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
