### PR TITLE
Split annotations fall back to their panel rectangle, not the page

### DIFF
--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -30,7 +30,7 @@ import numpy as np
 from PIL import Image, ImageDraw
 from shapely import make_valid
 from shapely.errors import GEOSException
-from shapely.geometry import LineString, MultiPolygon, Polygon
+from shapely.geometry import GeometryCollection, LineString, MultiPolygon, Polygon
 from shapely.geometry import mapping as geom_mapping
 from shapely.geometry import shape as geom_shape
 from shapely.geometry.base import BaseGeometry, BaseMultipartGeometry
@@ -1005,12 +1005,14 @@ def geo_polygon_to_svg(
         # ring itself if the mask misses the panel entirely (degenerate pose).
         mask_polygon = Polygon(canvas_points).buffer(0)
         clipped = mask_polygon.intersection(ring_polygon)
-        pieces = (
-            [g for g in clipped.geoms if isinstance(g, Polygon)]
-            if hasattr(clipped, "geoms")
-            else ([clipped] if isinstance(clipped, Polygon) else [])
+        parts = (
+            list(clipped.geoms)
+            if isinstance(clipped, (MultiPolygon, GeometryCollection))
+            else [clipped]
         )
-        pieces = [g for g in pieces if not g.is_empty and g.area > 0]
+        pieces = [
+            g for g in parts if isinstance(g, Polygon) and not g.is_empty and g.area > 0
+        ]
         if not pieces:
             return ring_svg(ring_polygon)
         return ring_svg(max(pieces, key=lambda g: g.area))

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -915,6 +915,7 @@ def geo_polygon_to_svg(
     source_width: int,
     source_height: int,
     split_canvas: tuple[float, float, float, float] | None = None,
+    panel_ring_canvas: list[tuple[float, float]] | None = None,
 ) -> str:
     """Convert a geo-space Shapely Polygon to an IIIF SvgSelector string.
 
@@ -926,17 +927,38 @@ def geo_polygon_to_svg(
         canvas_x = cx + pixel_x * (cw / georef_width)
         canvas_y = cy + pixel_y * (ch / georef_height)
 
-    Falls back to the standard full-page rectangle when geo_polygon is
-    None or empty. Raises ValueError for MultiPolygon input.
+    ``panel_ring_canvas`` is the split panel's polygon in canvas coordinates.
+    A split annotation's selector must NEVER include content outside its own
+    panel, whatever the mask says: block-based masks are built from the pose's
+    street structure and routinely extend past the panel seam (90 of 184 split
+    selectors in the 2026-08-28 corpus leaked, fargo p12__1's L-shaped panel by
+    32% of its area), and the maskless fallback used to emit the whole page
+    (fargo p72__1). Masks are intersected with the ring; the maskless fallback
+    IS the ring. Falls back to the full-page rectangle only for unsplit pages.
+    Raises ValueError for MultiPolygon input.
     """
     georef_width = float(georef["width"])
     georef_height = float(georef["height"])
 
+    ring_polygon = (
+        Polygon(panel_ring_canvas).buffer(0)
+        if panel_ring_canvas and len(panel_ring_canvas) >= 3
+        else None
+    )
+
+    def ring_svg(polygon: Polygon) -> str:
+        points = " ".join(
+            f"{round(x, 1)},{round(y, 1)}" for x, y in polygon.exterior.coords
+        )
+        return f'<svg><polygon points="{points}" /></svg>'
+
     def fallback_rect() -> str:
-        # A split annotation's fallback is its PANEL rectangle, not the page:
+        # A split annotation's fallback is its PANEL POLYGON, not the page:
         # maskless split pages (isolated poses have no street blocks to build
         # a mask from) were emitting whole-canvas selectors, so the viewer
         # drew the full sheet for a panel (fargo p72__1, 2026-08-28 baseline).
+        if ring_polygon is not None and not ring_polygon.is_empty:
+            return ring_svg(ring_polygon)
         if split_canvas is not None:
             cx0, cy0, cw0, ch0 = split_canvas
             x1, y1 = round(cx0 + cw0, 1), round(cy0 + ch0, 1)
@@ -976,7 +998,20 @@ def geo_polygon_to_svg(
         return round(cx + px * scale_x, 1), round(cy + py * scale_y, 1)
 
     coords = list(geo_polygon.exterior.coords)
-    points = " ".join(
-        f"{x},{y}" for x, y in (geo_to_canvas(lon, lat) for lon, lat in coords)
-    )
+    canvas_points = [geo_to_canvas(lon, lat) for lon, lat in coords]
+    if ring_polygon is not None and not ring_polygon.is_empty:
+        # Clip the mask to the panel: keep the largest surviving piece, or the
+        # ring itself if the mask misses the panel entirely (degenerate pose).
+        mask_polygon = Polygon(canvas_points).buffer(0)
+        clipped = mask_polygon.intersection(ring_polygon)
+        pieces = (
+            [g for g in clipped.geoms if isinstance(g, Polygon)]
+            if hasattr(clipped, "geoms")
+            else ([clipped] if isinstance(clipped, Polygon) else [])
+        )
+        pieces = [g for g in pieces if not g.is_empty and g.area > 0]
+        if not pieces:
+            return ring_svg(ring_polygon)
+        return ring_svg(max(pieces, key=lambda g: g.area))
+    points = " ".join(f"{x},{y}" for x, y in canvas_points)
     return f'<svg><polygon points="{points}" /></svg>'

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -933,6 +933,17 @@ def geo_polygon_to_svg(
     georef_height = float(georef["height"])
 
     def fallback_rect() -> str:
+        # A split annotation's fallback is its PANEL rectangle, not the page:
+        # maskless split pages (isolated poses have no street blocks to build
+        # a mask from) were emitting whole-canvas selectors, so the viewer
+        # drew the full sheet for a panel (fargo p72__1, 2026-08-28 baseline).
+        if split_canvas is not None:
+            cx0, cy0, cw0, ch0 = split_canvas
+            x1, y1 = round(cx0 + cw0, 1), round(cy0 + ch0, 1)
+            return (
+                f'<svg><polygon points="{cx0},{y1} {cx0},{cy0} '
+                f'{x1},{cy0} {x1},{y1} {cx0},{y1}" /></svg>'
+            )
         return (
             f'<svg><polygon points="0,{source_height} 0,0 '
             f'{source_width},0 {source_width},{source_height} 0,{source_height}" /></svg>'

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -828,3 +828,16 @@ def test_safe_overlay_passes_through_non_polygon_result():
     touching = safe_overlay(a, b, "intersection")
     assert touching is not None
     assert _collect_polygons(touching) == []
+
+
+def test_svg_fallback_uses_panel_rect_for_split_pages():
+    # A maskless SPLIT page must fall back to its panel rectangle, not the
+    # whole canvas -- the whole-canvas fallback drew the full sheet for
+    # fargo p72__1 (top panel, 2026-08-28 baseline).
+    georef = {"width": 1665, "height": 917}
+    svg = geo_polygon_to_svg(None, georef, 6660, 8070, (0.0, 0.0, 6660.0, 3666.7))
+    assert "8070" not in svg
+    assert 'points="0.0,3666.7 0.0,0.0 6660.0,0.0 6660.0,3666.7 0.0,3666.7"' in svg
+    # Unsplit pages keep the full-page fallback.
+    svg = geo_polygon_to_svg(None, {"width": 1665, "height": 2018}, 6660, 8070, None)
+    assert 'points="0,8070 0,0 6660,0 6660,8070 0,8070"' in svg

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -841,3 +841,31 @@ def test_svg_fallback_uses_panel_rect_for_split_pages():
     # Unsplit pages keep the full-page fallback.
     svg = geo_polygon_to_svg(None, {"width": 1665, "height": 2018}, 6660, 8070, None)
     assert 'points="0,8070 0,0 6660,0 6660,8070 0,8070"' in svg
+
+
+def test_split_selector_never_escapes_the_panel_ring():
+    from shapely.geometry import Polygon as ShapelyPolygon
+
+    # L-shaped panel (fargo p12__1's class): bbox spans the whole canvas, so
+    # only the RING can express the boundary. Maskless fallback = the ring.
+    ring = [(0.0, 0.0), (400.0, 0.0), (400.0, 2000.0), (1000.0, 2000.0),
+            (1000.0, 4000.0), (0.0, 4000.0)]
+    georef = {"width": 250, "height": 1000}
+    svg = geo_polygon_to_svg(None, georef, 1000, 4000, (0.0, 0.0, 1000.0, 4000.0), ring)
+    assert "400.0,2000.0" in svg and "1000.0,2000.0" in svg  # the L's notch survives
+
+    # A mask that leaks past the ring gets clipped to it: build a georef whose
+    # pixel frame maps 1:1 onto the canvas so the geo mask is easy to reason
+    # about, then hand in a full-canvas mask.
+    import numpy as np
+    georef = {
+        "width": 1000, "height": 4000,
+        "corners": [[0.0, 0.0], [0.001, 0.0], [0.001, -0.004], [0.0, -0.004]],
+    }
+    full = ShapelyPolygon([(0.0, 0.0), (0.001, 0.0), (0.001, -0.004), (0.0, -0.004)])
+    svg = geo_polygon_to_svg(full, georef, 1000, 4000, (0.0, 0.0, 1000.0, 4000.0), ring)
+    pts = [tuple(map(float, p.split(","))) for p in
+           svg.split('points="')[1].split('"')[0].split()]
+    clipped = ShapelyPolygon(pts)
+    ring_poly = ShapelyPolygon(ring)
+    assert clipped.difference(ring_poly.buffer(1.0)).area < 1.0  # nothing outside

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -848,8 +848,14 @@ def test_split_selector_never_escapes_the_panel_ring():
 
     # L-shaped panel (fargo p12__1's class): bbox spans the whole canvas, so
     # only the RING can express the boundary. Maskless fallback = the ring.
-    ring = [(0.0, 0.0), (400.0, 0.0), (400.0, 2000.0), (1000.0, 2000.0),
-            (1000.0, 4000.0), (0.0, 4000.0)]
+    ring = [
+        (0.0, 0.0),
+        (400.0, 0.0),
+        (400.0, 2000.0),
+        (1000.0, 2000.0),
+        (1000.0, 4000.0),
+        (0.0, 4000.0),
+    ]
     georef = {"width": 250, "height": 1000}
     svg = geo_polygon_to_svg(None, georef, 1000, 4000, (0.0, 0.0, 1000.0, 4000.0), ring)
     assert "400.0,2000.0" in svg and "1000.0,2000.0" in svg  # the L's notch survives
@@ -858,14 +864,18 @@ def test_split_selector_never_escapes_the_panel_ring():
     # pixel frame maps 1:1 onto the canvas so the geo mask is easy to reason
     # about, then hand in a full-canvas mask.
     import numpy as np
+
     georef = {
-        "width": 1000, "height": 4000,
+        "width": 1000,
+        "height": 4000,
         "corners": [[0.0, 0.0], [0.001, 0.0], [0.001, -0.004], [0.0, -0.004]],
     }
     full = ShapelyPolygon([(0.0, 0.0), (0.001, 0.0), (0.001, -0.004), (0.0, -0.004)])
     svg = geo_polygon_to_svg(full, georef, 1000, 4000, (0.0, 0.0, 1000.0, 4000.0), ring)
-    pts = [tuple(map(float, p.split(","))) for p in
-           svg.split('points="')[1].split('"')[0].split()]
+    pts = [
+        tuple(map(float, p.split(",")))
+        for p in svg.split('points="')[1].split('"')[0].split()
+    ]
     clipped = ShapelyPolygon(pts)
     ring_poly = ShapelyPolygon(ring)
     assert clipped.difference(ring_poly.buffer(1.0)).area < 1.0  # nothing outside

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -863,7 +863,6 @@ def test_split_selector_never_escapes_the_panel_ring():
     # A mask that leaks past the ring gets clipped to it: build a georef whose
     # pixel frame maps 1:1 onto the canvas so the geo mask is easy to reason
     # about, then hand in a full-canvas mask.
-    import numpy as np
 
     georef = {
         "width": 1000,

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -454,6 +454,7 @@ def make_annotation(
 
     gcp_pts = georef_gcp_points(georef)
     split_canvas: tuple[float, float, float, float] | None = None
+    panel_ring_canvas: list[tuple[float, float]] | None = None
 
     if split_index is None:
         # Full page: scale 25%-page coordinates up to the full canvas.
@@ -494,6 +495,11 @@ def make_annotation(
             round(split_cw, 1),
             round(split_ch, 1),
         )
+        # The panel's own polygon in canvas coordinates: the hard boundary a
+        # split selector may never escape, whatever the mask computed.
+        panel_ring_canvas = [
+            (pt[0] * page_scale_x, pt[1] * page_scale_y) for pt in ring
+        ]
 
         resource_coords_list = [
             [
@@ -544,7 +550,12 @@ def make_annotation(
             "selector": {
                 "type": "SvgSelector",
                 "value": geo_polygon_to_svg(
-                    geo_mask, georef, source_width, source_height, split_canvas
+                    geo_mask,
+                    georef,
+                    source_width,
+                    source_height,
+                    split_canvas,
+                    panel_ring_canvas,
                 ),
             },
         },


### PR DESCRIPTION
Diagnoses the viewer report of fargo p72__1 rendering the full sheet: **an IIIF encoding bug, not a viewer bug.**

## Mechanism

`geo_polygon_to_svg`'s maskless fallback emitted the **full-page rectangle regardless of `split_canvas`**. Clip masks are built from street-block structure, so the pages that end up maskless are precisely the isolated poses — a split panel placed far from any street gets a whole-canvas selector, and the viewer faithfully draws the entire sheet for it. The `split_canvas` bbox was already computed and even present in the annotation's *metadata* (p72__1's says y 0–3666.7); only the selector ignored it.

**Corpus scope — wider than first diagnosed.** The maskless fallback (5 annotations, all isolated poses) was only the visible tip. Holding every split selector to the invariant *"never include content outside the panel"* found **90 of 184 leaking**: block-based masks are built from the pose's street structure with no knowledge of the seam (champaign p21__1 leaked 74% of its ring's area), and L-shaped panels (fargo p12__1, reported second) have bounding boxes spanning the whole canvas, so even a panel-*rect* fallback cannot express their boundary.

**Fix, in two commits**: (1) maskless split fallback uses the panel rectangle; (2) `make_annotation` passes the panel **ring** in canvas coordinates and `geo_polygon_to_svg` enforces the invariant — masks are intersected with the ring (largest surviving piece kept), the maskless fallback *is* the ring, and only unsplit pages keep the full-page fallback. Tests pin the L-notch surviving in the fallback and a leaking mask being clipped.

**Regeneration**: all 16 affected volumes rebuilt from unchanged georef-final sidecars; ring-violation scan now reports **0 corpus-wide**; labels/GCPs/metadata byte-identical and every volume score unchanged. Originals stashed as `2026-08-28-bug.iiif.json`; gallery copies updated on the baseline branch.

## Also found while diagnosing (not fixed here)

The generated labels' `[N]` suffixes are **LoC's own canvas-title markers, taken verbatim** — e.g. unsplit `p10 [1]`, and both p72 panels labeled `p72 [2]` (LoC's title for the sheet). They collide with our `[N]`-means-split-index convention: `label_to_page_key("… p72 [2]")` parses a phantom `p72__2`, and anything that falls back to label parsing (the no-service-URL path, compare's OIM-label resolution) can mis-key such pages. The canvas *ids* are correct (`…0072__1/georef`), so id-based consumers are fine. Worth a separate look — it may explain occasional phantom-panel confusion in scoring (champaign's p13__1-vs-p13__2 class).

Note: this branch is off `main`, which currently fails CI on the pre-existing pyright break; green once the CI-fix PR merges. The existing 2026-08-28 IIIF files retain the 5 wrong selectors until a regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
