### PR TITLE
Volume viewer greys the selected panel's own off-panel area, not siblings

### DIFF
--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -133,6 +133,7 @@ function selectionFeatures(
 export function VolumeMap(props: VolumeMapProps) {
   const {
     annotation,
+    fitVolumeKey,
     pages,
     missingPages,
     truthPages,
@@ -149,6 +150,19 @@ export function VolumeMap(props: VolumeMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const layerRef = useRef<WarpedMapLayer | null>(null);
+
+  // Panel polygons per parent stem, from the volume's pN.panels.json (25%-jpg
+  // frame). null = fetched and absent. The SvgSelector is split INTERSECT
+  // mask, so it under-covers the panel wherever the content mask bites; the
+  // panels.json ring is the split itself, which is what the off-panel grey
+  // must hole out (#303) — pixels inside the split but outside the mask stay
+  // at full brightness, exactly like an unsplit page's out-of-mask area.
+  const panelDocsRef = useRef<
+    Map<
+      string,
+      { width: number; height: number; panels: [number, number][][] } | null
+    >
+  >(new Map());
   const [mapReady, setMapReady] = useState(false);
   // Whether the map has been fit to a loaded annotation.
   const [positioned, setPositioned] = useState(false);
@@ -582,29 +596,102 @@ export function VolumeMap(props: VolumeMapProps) {
         : [];
     source?.setData(selectionFeatures(page, truthRings));
 
-    // Grey the parts of THIS page's uncut sheet outside its own clip polygon,
-    // so the cut is visible on the image being looked at. Outer ring = the
-    // full image rectangle, hole = the panel's clip; siblings' fits are left
-    // alone (they may legitimately be placed elsewhere). Only for a page that
-    // is itself a panel — a whole page has no off-panel area.
+    // Grey the parts of THIS page's uncut sheet outside its own SPLIT, so the
+    // cut is visible on the image being looked at. Outer ring = the full
+    // image rectangle; hole = the panel polygon from pN.panels.json (the
+    // split itself — the SvgSelector is split∩mask and would wrongly dim
+    // in-split pixels the mask clipped). While the panels file loads, or when
+    // it is missing, the selector ring stands in. Siblings' fits are left
+    // alone. Only for a page that is itself a panel.
     const offpanel = map.getSource<maplibregl.GeoJSONSource>('offpanel-mask');
-    offpanel?.setData(
-      page.splitIndex === null
-        ? EMPTY_FEATURES
-        : {
-            type: 'FeatureCollection',
-            features: [
-              {
-                type: 'Feature',
-                properties: {},
-                geometry: {
-                  type: 'Polygon',
-                  coordinates: [page.rectRing, page.clipRing],
-                },
-              },
-            ],
+    // panels.json describes the parent sheet at 25% scale, and the served
+    // annotation is rescaled into that same frame (see rewriteAnnotationPage),
+    // so plain fractional coordinates line up with the page corners. Gray the
+    // OTHER panels' polygons directly rather than cutting this panel out of
+    // the sheet rect as a hole: panel rings share edges with the sheet
+    // boundary, and a hole touching its outer ring degenerates triangulation.
+    const maskFromPanels = (doc: {
+      width: number;
+      height: number;
+      panels: [number, number][][];
+    }): FeatureCollection | null => {
+      const panelIndex = page.splitIndex === null ? -1 : page.splitIndex - 1;
+      const selectedRing = doc.panels[panelIndex];
+      if (!selectedRing || doc.width <= 0 || doc.height <= 0) return null;
+      const [nw, ne, , sw] = page.corners;
+      const toGeo = (x: number, y: number): [number, number] => {
+        const fx = x / doc.width;
+        const fy = y / doc.height;
+        return [
+          (nw[0] ?? 0) +
+            ((ne[0] ?? 0) - (nw[0] ?? 0)) * fx +
+            ((sw[0] ?? 0) - (nw[0] ?? 0)) * fy,
+          (nw[1] ?? 0) +
+            ((ne[1] ?? 0) - (nw[1] ?? 0)) * fx +
+            ((sw[1] ?? 0) - (nw[1] ?? 0)) * fy,
+        ];
+      };
+      return {
+        type: 'FeatureCollection',
+        features: doc.panels
+          .filter((ring, i) => i !== panelIndex && ring.length >= 4)
+          .map((ring) => ({
+            type: 'Feature',
+            properties: {},
+            geometry: {
+              type: 'Polygon',
+              coordinates: [ring.map(([x, y]) => toGeo(x, y))],
+            },
+          })),
+      };
+    };
+    // Fallback while panels.json loads (or is absent): hole out the selector,
+    // which is split∩mask — close, but dims mask-clipped pixels in the split.
+    const selectorFallback = (): FeatureCollection => ({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Polygon',
+            coordinates: [page.rectRing, page.clipRing],
           },
-    );
+        },
+      ],
+    });
+    if (page.splitIndex === null) {
+      offpanel?.setData(EMPTY_FEATURES);
+    } else {
+      const parent = page.stem.split('__')[0];
+      const cacheKey = `${fitVolumeKey}/${parent}`;
+      const cached = panelDocsRef.current.get(cacheKey);
+      offpanel?.setData(
+        (cached ? maskFromPanels(cached) : null) ?? selectorFallback(),
+      );
+      if (!panelDocsRef.current.has(cacheKey) && fitVolumeKey) {
+        const selectedAtFetch = selectedItemIndex;
+        fetch(`/data/${fitVolumeKey}/${parent}.panels.json`)
+          .then((r) => (r.ok ? r.json() : null))
+          .then(
+            (
+              doc: {
+                width: number;
+                height: number;
+                panels: [number, number][][];
+              } | null,
+            ) => {
+              panelDocsRef.current.set(cacheKey, doc);
+              // Re-apply only if this page is still the selection.
+              if (doc && selectedAtFetch === selectedItemIndex) {
+                const mask = maskFromPanels(doc);
+                if (mask) offpanel?.setData(mask);
+              }
+            },
+          )
+          .catch(() => panelDocsRef.current.set(cacheKey, null));
+      }
+    }
     const mapId = mapIdsRef.current[page.itemIndex];
     if (mapId) {
       layer.bringMapsToFront([mapId]);

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -338,24 +338,26 @@ export function VolumeMap(props: VolumeMapProps) {
           'line-dasharray': [2, 2],
         },
       });
-      // The OTHER panels of a selected split sheet, greyed out. Added before
-      // the selection layers so it draws beneath them: selecting one panel of a
-      // sheet otherwise gives no clue where the cut runs, since the neighbouring
-      // panel looks like more of the same map (#303).
-      map.addSource('sibling-panels', {
+      // The selected panel's own sheet, greyed OUTSIDE its clip polygon: a
+      // ring-with-hole over the page's full image rectangle whose hole is the
+      // panel's clip, so everything on the uncut sheet that is not this panel
+      // dims. Selecting one panel otherwise gives no clue where the cut runs
+      // (#303) — and greying the SIBLING's fit instead (the first fix) marked
+      // the wrong thing entirely when the sibling was placed elsewhere.
+      map.addSource('offpanel-mask', {
         type: 'geojson',
         data: EMPTY_FEATURES,
       });
       map.addLayer({
-        id: 'sibling-panels-fill',
+        id: 'offpanel-mask-fill',
         type: 'fill',
-        source: 'sibling-panels',
+        source: 'offpanel-mask',
         paint: { 'fill-color': '#111827', 'fill-opacity': 0.45 },
       });
       map.addLayer({
-        id: 'sibling-panels-outline',
+        id: 'offpanel-mask-outline',
         type: 'line',
-        source: 'sibling-panels',
+        source: 'offpanel-mask',
         paint: {
           'line-color': '#111827',
           'line-width': 1,
@@ -566,7 +568,7 @@ export function VolumeMap(props: VolumeMapProps) {
       source?.setData(EMPTY_FEATURES);
       // Deselecting must clear the grey too, or it stays over the sheet.
       map
-        .getSource<maplibregl.GeoJSONSource>('sibling-panels')
+        .getSource<maplibregl.GeoJSONSource>('offpanel-mask')
         ?.setData(EMPTY_FEATURES);
       return;
     }
@@ -580,25 +582,27 @@ export function VolumeMap(props: VolumeMapProps) {
         : [];
     source?.setData(selectionFeatures(page, truthRings));
 
-    // Grey the sheet's other panels so the cut is visible. Keyed on pageKey,
-    // which splits share, and only for a page that is itself a panel.
-    const siblings = map.getSource<maplibregl.GeoJSONSource>('sibling-panels');
-    siblings?.setData(
+    // Grey the parts of THIS page's uncut sheet outside its own clip polygon,
+    // so the cut is visible on the image being looked at. Outer ring = the
+    // full image rectangle, hole = the panel's clip; siblings' fits are left
+    // alone (they may legitimately be placed elsewhere). Only for a page that
+    // is itself a panel — a whole page has no off-panel area.
+    const offpanel = map.getSource<maplibregl.GeoJSONSource>('offpanel-mask');
+    offpanel?.setData(
       page.splitIndex === null
         ? EMPTY_FEATURES
         : {
             type: 'FeatureCollection',
-            features: pages
-              .filter(
-                (other) =>
-                  other.pageKey === page.pageKey &&
-                  other.itemIndex !== page.itemIndex,
-              )
-              .map((other): FeatureCollection['features'][0] => ({
+            features: [
+              {
                 type: 'Feature',
                 properties: {},
-                geometry: { type: 'Polygon', coordinates: [other.clipRing] },
-              })),
+                geometry: {
+                  type: 'Polygon',
+                  coordinates: [page.rectRing, page.clipRing],
+                },
+              },
+            ],
           },
     );
     const mapId = mapIdsRef.current[page.itemIndex];


### PR DESCRIPTION
Fixes #303's remaining issue with split panels (follow-up to #312).

Selecting a split panel (e.g. nashville p41__1) used to gray a polygon over the sibling's fit elsewhere on the map. After this change:

- **Unsplit pages**: unchanged — no gray overlay; pixels outside the mask render at full brightness.
- **Split panels**: all pixels belonging to the selected split render at full brightness (including mask-clipped ones, matching the unsplit behavior), and only the parts of the parent sheet belonging to *other* panels are grayed. Nothing is drawn over the sibling's own fit.

<img width="797" height="848" alt="image" src="https://github.com/user-attachments/assets/6178b968-68d0-4944-9b19-bfa203f0b45a" />

### How

The IIIF annotation doesn't carry the split polygon (its SvgSelector is split∩mask), so the viewer now fetches the `p<N>.panels.json` sidecar for the split's parent and grays the **other** panels' rings directly. Frame mapping: the served annotation is rescaled into the local 25% frame (`rewriteAnnotationPage`), which is exactly the panels.json frame, so panel coordinates map through plain fractions of the sheet rect, bilinear over the page corners (exact for order-1 fits).

Two subtleties found along the way:

- A split annotation's corner GCPs span only the panel bbox, but `pagesFromAnnotation` projects the full source rect through the fitted affine, so `page.corners` span the whole parent sheet — panel coords must be divided by the sheet dims, not the panel bbox.
- Rendering the selected panel as a *hole* in the sheet rect fails: panel rings share edges with the sheet boundary, and a hole touching its outer ring degenerates MapLibre's triangulation (the whole sheet filled gray). Graying the complement (sibling panels as plain polygons) avoids holes entirely.

While panels.json is loading (or absent for volumes without splits run through the splitter), the viewer falls back to holing out the selector — close, but it dims mask-clipped pixels; the fetched version replaces it as soon as it arrives (cached per parent).

Verified visually on nashville p41__1 and p41__2 (gray inverts correctly between the two panels, each under its own pose). `tsc` clean, 228 app tests pass.