### PR TITLE
Fix snap panel crash on unscored candidates

### DIFF
--- a/app/src/components/SnapPanel.tsx
+++ b/app/src/components/SnapPanel.tsx
@@ -18,38 +18,6 @@ interface SnapPanelProps {
   onClose: () => void;
 }
 
-// A component bar: label, value in [0, 1]-ish range, red for penalties.
-function EvidenceBar({
-  label,
-  value,
-  max,
-  penalty,
-  detail,
-}: {
-  label: string;
-  value: number | undefined;
-  max: number;
-  penalty?: boolean;
-  detail?: string;
-}) {
-  if (value == null) return null;
-  const frac = Math.max(0, Math.min(1, Math.abs(value) / max));
-  return (
-    <div className="snap-bar-row" title={detail}>
-      <span className="snap-bar-label">{label}</span>
-      <span className="snap-bar-track">
-        <span
-          className={
-            penalty ? 'snap-bar-fill snap-bar-penalty' : 'snap-bar-fill'
-          }
-          style={{ width: `${Math.round(frac * 100)}%` }}
-        />
-      </span>
-      <span className="snap-bar-value">{value.toFixed(3)}</span>
-    </div>
-  );
-}
-
 function CandidateRow({
   label,
   candidate,
@@ -134,11 +102,19 @@ export function SnapPanel({
         <thead>
           <tr>
             <th>pose</th>
-            <th>select</th>
-            <th>verif</th>
-            <th>inlier</th>
-            <th>ncc</th>
-            <th>chamfer</th>
+            <th title="the ranking score gates compare against (rescue bar 1.25)">
+              select
+            </th>
+            <th title="inlier_frac + ncc_fine − chamfer penalty">verif</th>
+            <th title="share of P(road) pixels within the chamfer inlier distance of OSM">
+              inlier
+            </th>
+            <th title="fine-scale normalized cross-correlation, P(road) vs OSM raster">
+              ncc
+            </th>
+            <th title="mean P(road)→OSM distance in metres (penalty)">
+              chamfer
+            </th>
             <th>θ</th>
             <th>scale src</th>
             <th>truth</th>
@@ -173,45 +149,10 @@ export function SnapPanel({
         </p>
       )}
 
-      {activeCandidate && (
-        <div className="snap-evidence">
-          <EvidenceBar
-            label="inlier_frac"
-            value={activeCandidate.inlier_frac}
-            max={1}
-            detail="share of P(road) pixels within the chamfer inlier distance of OSM"
-          />
-          <EvidenceBar
-            label="ncc_fine"
-            value={activeCandidate.ncc_fine}
-            max={1}
-            detail="fine-scale normalized cross-correlation, P(road) vs OSM raster"
-          />
-          <EvidenceBar
-            label="chamfer"
-            value={activeCandidate.chamfer_mean_m}
-            max={30}
-            penalty
-            detail="mean P(road)→OSM distance in metres (penalty)"
-          />
-          <EvidenceBar
-            label="verification"
-            value={activeCandidate.verification}
-            max={1.5}
-            detail="inlier_frac + ncc_fine − chamfer penalty"
-          />
-          <EvidenceBar
-            label="select"
-            value={activeCandidate.select_score}
-            max={3}
-            detail="the ranking score gates compare against (rescue bar 1.25)"
-          />
-          {(activeCandidate.gate_reasons?.length ?? 0) > 0 && (
-            <p className="snap-note">
-              gates: {activeCandidate.gate_reasons!.join(' · ')}
-            </p>
-          )}
-        </div>
+      {activeCandidate && (activeCandidate.gate_reasons?.length ?? 0) > 0 && (
+        <p className="snap-note">
+          gates: {activeCandidate.gate_reasons!.join(' · ')}
+        </p>
       )}
     </div>
   );

--- a/app/src/components/SnapPanel.tsx
+++ b/app/src/components/SnapPanel.tsx
@@ -1,4 +1,4 @@
-import { rankedCandidates } from '../snap';
+import { groupRotationPriors, rankedCandidates } from '../snap';
 import type { SnapCandidate, SnapRecord } from '../snap';
 
 /**
@@ -71,6 +71,7 @@ export function SnapPanel({
         ? (record.incumbent ?? null)
         : (ranked[selected] ?? null);
   const activeCandidate = active as SnapCandidate | null;
+  const priorGroups = groupRotationPriors(record.priors?.rotation ?? []);
 
   return (
     <div className="snap-panel">
@@ -89,13 +90,16 @@ export function SnapPanel({
           {record.search.centers.length === 1 ? '' : 's'} · radius{' '}
           {Math.round(record.search.radius_m)} m ({record.search.radius_source})
           {record.search.demoted_seed && ' · demoted-pose seed'}
-          {' · priors: '}
-          {(record.priors?.rotation ?? [])
-            .map(
-              (p) => `${p.theta_deg.toFixed(0)}°±${p.sigma_deg} (${p.source})`,
-            )
-            .join(', ') || 'none'}
+          {' · priors:'}
+          {priorGroups.length === 0 && ' none'}
         </p>
+      )}
+      {record.search && priorGroups.length > 0 && (
+        <ul className="snap-priors">
+          {priorGroups.map((line) => (
+            <li key={line}>{line}</li>
+          ))}
+        </ul>
       )}
 
       <table className="snap-table">

--- a/app/src/components/SnapPanel.tsx
+++ b/app/src/components/SnapPanel.tsx
@@ -32,7 +32,7 @@ function EvidenceBar({
   penalty?: boolean;
   detail?: string;
 }) {
-  if (value === undefined) return null;
+  if (value == null) return null;
   const frac = Math.max(0, Math.min(1, Math.abs(value) / max));
   return (
     <div className="snap-bar-row" title={detail}>
@@ -76,16 +76,14 @@ function CandidateRow({
       <td className="num">{c.inlier_frac?.toFixed(2) ?? '—'}</td>
       <td className="num">{c.ncc_fine?.toFixed(2) ?? '—'}</td>
       <td className="num">
-        {c.chamfer_mean_m !== undefined
-          ? `${c.chamfer_mean_m.toFixed(1)}m`
-          : '—'}
+        {c.chamfer_mean_m != null ? `${c.chamfer_mean_m.toFixed(1)}m` : '—'}
       </td>
       <td className="num">
-        {c.theta_deg !== undefined ? `${c.theta_deg.toFixed(1)}°` : '—'}
+        {c.theta_deg != null ? `${c.theta_deg.toFixed(1)}°` : '—'}
       </td>
       <td>{c.scale_source ?? '—'}</td>
       <td className="num">
-        {c.rmse_ft !== undefined ? `${c.rmse_ft.toFixed(0)}ft` : ''}
+        {c.rmse_ft != null ? `${c.rmse_ft.toFixed(0)}ft` : ''}
       </td>
     </tr>
   );

--- a/app/src/snap.test.ts
+++ b/app/src/snap.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { parseSnapRecords, rankedCandidates } from './snap';
+import {
+  groupRotationPriors,
+  parseSnapRecords,
+  rankedCandidates,
+} from './snap';
 
 const affine = [
   [1, 0, 0],
@@ -46,5 +50,46 @@ describe('parseSnapRecords', () => {
     const ranked = rankedCandidates(record);
     expect(ranked[0]!.select_score).toBe(1.5);
     expect(ranked[1]!.select_score).toBeUndefined();
+  });
+});
+
+describe('groupRotationPriors', () => {
+  it('groups the fargo p17 ladder by rounded (θ, σ) with source counts', () => {
+    const prior = (theta_deg: number, source: string, sigma_deg = 4) => ({
+      theta_deg,
+      sigma_deg,
+      source,
+    });
+    const ladder = [
+      prior(0.1, 'label-pair-exact'),
+      prior(0.2, 'label-pair-exact'),
+      prior(-17.4, 'label-pair-exact'),
+      prior(-17.2, 'label-pair-exact'),
+      prior(0.1, 'label-osm-mod180'),
+      prior(-179.9, 'label-osm-mod180'),
+      prior(162.6, 'label-osm-mod180'),
+      prior(-17.4, 'label-osm-mod180'),
+      prior(162.8, 'label-osm-mod180'),
+      prior(-17.2, 'label-osm-mod180'),
+      prior(180.0, 'label-osm-mod180'),
+      prior(-0.2, 'label-osm-mod180'),
+      prior(-16.0, 'volume-median-theta', 15),
+    ];
+    expect(groupRotationPriors(ladder)).toEqual([
+      '0°±4 (label-pair-exact ×2, label-osm-mod180 ×2)',
+      '-17°±4 (label-pair-exact ×2, label-osm-mod180 ×2)',
+      '180°±4 (label-osm-mod180 ×2)',
+      '163°±4 (label-osm-mod180 ×2)',
+      '-16°±15 (volume-median-theta)',
+    ]);
+  });
+
+  it('separates identical angles with different sigmas', () => {
+    expect(
+      groupRotationPriors([
+        { theta_deg: 12, sigma_deg: 4, source: 'a' },
+        { theta_deg: 12, sigma_deg: 15, source: 'b' },
+      ]),
+    ).toEqual(['12°±4 (a)', '12°±15 (b)']);
   });
 });

--- a/app/src/snap.test.ts
+++ b/app/src/snap.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { parseSnapRecords, rankedCandidates } from './snap';
+
+const affine = [
+  [1, 0, 0],
+  [0, 1, 0],
+];
+
+// One candidates.jsonl row with a scored candidate and an unscored one whose
+// numeric fields the pipeline wrote as JSON null. Clicking the unscored
+// candidate used to crash EvidenceBar (null.toFixed) on fargo p17.
+const row = JSON.stringify({
+  target: 'p17',
+  status: 'ok',
+  fit_state: 'fit',
+  width: 100,
+  height: 80,
+  candidates: [
+    {
+      world_affine: affine,
+      center: [0, 0],
+      select_score: 1.5,
+      verification: 0.8,
+    },
+    {
+      world_affine: affine,
+      center: [0, 0],
+      select_score: null,
+      verification: null,
+    },
+  ],
+});
+
+describe('parseSnapRecords', () => {
+  it('strips JSON nulls so optional-number fields are absent, not null', () => {
+    const record = parseSnapRecords(row).get('p17')!;
+    const unscored = record.candidates![1]!;
+    expect('select_score' in unscored).toBe(false);
+    expect('verification' in unscored).toBe(false);
+    expect(unscored.world_affine).toEqual(affine);
+    expect(record.candidates![0]!.select_score).toBe(1.5);
+  });
+
+  it('ranks unscored candidates last', () => {
+    const record = parseSnapRecords(row).get('p17')!;
+    const ranked = rankedCandidates(record);
+    expect(ranked[0]!.select_score).toBe(1.5);
+    expect(ranked[1]!.select_score).toBeUndefined();
+  });
+});

--- a/app/src/snap.ts
+++ b/app/src/snap.ts
@@ -120,6 +120,42 @@ export function poseCorners(
   return [apply(0, 0), apply(width, 0), apply(width, height), apply(0, height)];
 }
 
+/**
+ * Rotation priors grouped for display: one line per distinct (θ, σ).
+ *
+ * The pipeline records one prior per vote (per label, per label pair), so the
+ * raw ladder is full of repeats — the multiplicity is the corroboration
+ * signal. Group by the rounded angle (−0 → 0, −180 → 180: same rotation) and
+ * sigma, keeping first-appearance order (rung priority), and aggregate the
+ * sources with ×N counts.
+ */
+export function groupRotationPriors(
+  priors: { theta_deg: number; sigma_deg: number; source: string }[],
+): string[] {
+  const groups = new Map<
+    string,
+    { label: string; counts: Map<string, number> }
+  >();
+  for (const prior of priors) {
+    let theta = Math.round(prior.theta_deg);
+    if (theta === 0) theta = 0; // normalize −0
+    if (theta === -180) theta = 180;
+    const label = `${theta}°±${prior.sigma_deg}`;
+    let group = groups.get(label);
+    if (!group) {
+      group = { label, counts: new Map() };
+      groups.set(label, group);
+    }
+    group.counts.set(prior.source, (group.counts.get(prior.source) ?? 0) + 1);
+  }
+  return [...groups.values()].map((group) => {
+    const sources = [...group.counts.entries()]
+      .map(([source, n]) => (n > 1 ? `${source} ×${n}` : source))
+      .join(', ');
+    return `${group.label} (${sources})`;
+  });
+}
+
 /** Candidates sorted by select_score descending (unscored last, order kept). */
 export function rankedCandidates(record: SnapRecord): SnapCandidate[] {
   return [...(record.candidates ?? [])].sort(

--- a/app/src/snap.ts
+++ b/app/src/snap.ts
@@ -73,6 +73,21 @@ export interface SnapRecord {
   candidates?: SnapCandidate[];
 }
 
+// Recursively drop null-valued keys: the pipeline writes JSON null for
+// unscored fields (e.g. an unverifiable candidate's select_score), but
+// consumers type these as optional numbers and guard with undefined checks.
+function stripNulls(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripNulls);
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (entry !== null) out[key] = stripNulls(entry);
+    }
+    return out;
+  }
+  return value;
+}
+
 /** Parse candidates.jsonl text into a stem-keyed map (later rows win). */
 export function parseSnapRecords(jsonl: string): Map<string, SnapRecord> {
   const records = new Map<string, SnapRecord>();
@@ -80,7 +95,7 @@ export function parseSnapRecords(jsonl: string): Map<string, SnapRecord> {
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
-      const record = JSON.parse(trimmed) as SnapRecord;
+      const record = stripNulls(JSON.parse(trimmed)) as SnapRecord;
       if (record.target) records.set(record.target, record);
     } catch {
       // A truncated final line (interrupted run) is not an error worth surfacing.

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -943,35 +943,3 @@ tr.relaxed {
 .snap-table tr.snap-best td:first-child {
   font-weight: 600;
 }
-.snap-bar-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 2px 0;
-}
-.snap-bar-label {
-  width: 90px;
-  color: #374151;
-  font-size: 12px;
-}
-.snap-bar-track {
-  flex: 1;
-  height: 8px;
-  background: #e5e7eb;
-  border-radius: 4px;
-  overflow: hidden;
-}
-.snap-bar-fill {
-  display: block;
-  height: 100%;
-  background: #059669;
-}
-.snap-bar-penalty {
-  background: #dc2626;
-}
-.snap-bar-value {
-  width: 52px;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-  font-size: 12px;
-}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -937,6 +937,10 @@ tr.relaxed {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
+.snap-priors {
+  margin: 2px 0;
+  padding-left: 22px;
+}
 .snap-table tr.selected {
   background: #dbeafe;
 }


### PR DESCRIPTION
Clicking an unscored snap candidate (e.g. fargo p17's C6 in the volume viewer) crashed the page with `Uncaught TypeError: Cannot read properties of null (reading 'toFixed') at EvidenceBar`.

### Root cause

The pipeline writes JSON `null` for an unverifiable candidate's `select_score`/`verification` (fargo p17 has two such rows, which `rankedCandidates` sorts last — C6/C7). The TypeScript types declare these fields as `number | undefined`, so the panel guards with `value === undefined` / `?.` — but a JSON `null` passes an `=== undefined` check and reaches `value.toFixed(3)`.

### Fix

- `parseSnapRecords` now recursively strips null-valued keys at the parse boundary, so the declared optional-number types are true for every consumer (one choke point; also keeps `null` out of sort comparators).
- Belt and braces: null-safe `!= null` guards in `CandidateRow` (`chamfer_mean_m`, `theta_deg`, `rmse_ft`), in case a null ever arrives through another path.
- Regression test in `snap.test.ts`: nulls are stripped to absent fields, and unscored candidates rank last.

### Second commit: remove the evidence bars

The green/red `EvidenceBar` rows duplicated the selected row's table numbers (at 3dp vs the table's 2dp) without adding information, while enlarging the panel and making it jump between row clicks. Removed the component and its CSS; the metric explanations that lived on the bars' hover tooltips moved to the table headers (`select`/`verif`/`inlier`/`ncc`/`chamfer`), and the `gates: …` note — the one piece of unique content — stays, rendered directly under the table.

### Third commit: group the rotation priors

The pipeline records one rotation prior per vote (per matched label, per label pair), so the raw ladder is full of repeats — the multiplicity is the corroboration signal `confident_theta_deg` keys on, but it made the header line unreadable. New `groupRotationPriors` in `snap.ts` groups by rounded (θ, σ) — normalizing −0→0 and −180→180 (same rotation) — in first-appearance (rung-priority) order, aggregating sources with ×N counts, rendered as a bulleted list. Fargo p17's 13 entries become:

- 0°±4 (label-pair-exact ×2, label-osm-mod180 ×2)
- -17°±4 (label-pair-exact ×2, label-osm-mod180 ×2)
- 180°±4 (label-osm-mod180 ×2)
- 163°±4 (label-osm-mod180 ×2)
- -16°±15 (volume-median-theta)

Unit-tested (the p17 ladder, and same-angle/different-sigma stays separate).

Verified on the exact repro (fargo p17 → snap → C6): the panel renders compactly with the `upside-down` gate note and no crash. `tsc` clean, 232 app tests pass.

<img width="861" height="1085" alt="image" src="https://github.com/user-attachments/assets/d84aec7a-8868-4eda-b808-e8befdf04aaf" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)