### PR TITLE
Snap debugger phase 2: truth_pose and decision records

### DIFF
--- a/app/src/components/SnapPanel.test.tsx
+++ b/app/src/components/SnapPanel.test.tsx
@@ -103,6 +103,10 @@ describe('SnapPanel phase-2 records', () => {
     const html = render(record);
     expect(html).toContain('<td>truth</td>');
     expect(html).toContain('0.68'); // the truth row's select score
+    // θ and px/ft are derived from every row's affine, the incumbent included.
+    expect(html).toContain('rotation in snap');
+    expect((html.match(/0\.0°/g) ?? []).length).toBeGreaterThanOrEqual(4);
+    expect((html.match(/0\.35<\/td>/g) ?? []).length).toBeGreaterThanOrEqual(4);
     expect(html).toContain(
       'a pose 14713 ft from truth outscores the truth pose',
     );

--- a/app/src/components/SnapPanel.test.tsx
+++ b/app/src/components/SnapPanel.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { SnapPanel } from './SnapPanel';
+import type { SnapRecord } from '../snap';
+
+const affine: [number, number, number][] = [
+  [1e-5, 0, -77.43],
+  [0, -1e-5, 37.55],
+];
+
+// Shaped like richmond p311 in the 2026-08-28 baseline: a fitted page whose
+// alias outscores the true-location candidate and the truth pose (#325).
+const record: SnapRecord = {
+  target: 'p311',
+  status: 'ok',
+  fit_state: 'fitted',
+  width: 1412,
+  height: 2037,
+  has_truth: true,
+  margin: 0.0464,
+  incumbent: {
+    world_affine: affine,
+    verification: -0.708,
+    name: { score: 0.1728, n_labels: 9, n_hits: 4 },
+    effective_gcps: 2,
+    rmse_ft: 210.3,
+  },
+  truth_pose: {
+    world_affine: affine,
+    verification: 0.1163,
+    inlier_frac: 0.3365,
+    ncc_fine: 0.3551,
+    chamfer_mean_m: 17.26,
+    name: { score: 0.4279, n_labels: 9, n_hits: 5 },
+    select_score: 0.6776,
+  },
+  candidates: [
+    {
+      world_affine: affine,
+      center: [-77.47, 37.57],
+      select_score: 1.0207,
+      verification: 0.8249,
+      rmse_ft: 14713.1,
+      theta_deg: -43.96,
+      scale_source: 'volume-median',
+    },
+    {
+      world_affine: affine,
+      center: [-77.43, 37.55],
+      select_score: 0.9743,
+      verification: 0.2288,
+      rmse_ft: 18.8,
+      theta_deg: 52.34,
+      scale_source: 'volume-median',
+    },
+  ],
+  decision: {
+    path: 'challenge',
+    page_verdict: 'keep',
+    bars: [
+      {
+        rule: 'challenge/select',
+        need: '>= 1.6',
+        got: 1.0207,
+        verdict: 'fail',
+      },
+      {
+        rule: 'challenge/name-parity',
+        need: "candidate name score >= incumbent's",
+        got: 0,
+        verdict: 'fail',
+        note: 'incumbent 0.1728',
+      },
+      {
+        rule: 'rung-flip',
+        need: 'double-scale candidate over a half-scale incumbent',
+        got: 'no flip',
+        verdict: 'n/a',
+      },
+    ],
+    skipped: [
+      {
+        rule: 'volume-energy',
+        reason: 'volume-level committee may still accept an abstained page',
+      },
+    ],
+  },
+};
+
+function render(rec: SnapRecord, selected: number | null = null): string {
+  return renderToStaticMarkup(
+    <SnapPanel
+      record={rec}
+      selected={selected}
+      onSelect={() => {}}
+      onClose={() => {}}
+    />,
+  );
+}
+
+describe('SnapPanel phase-2 records', () => {
+  it('renders the truth pose as a row and classifies the outcome', () => {
+    const html = render(record);
+    expect(html).toContain('<td>truth</td>');
+    expect(html).toContain('0.68'); // the truth row's select score
+    expect(html).toContain(
+      'a pose 14713 ft from truth outscores the truth pose',
+    );
+  });
+
+  it('renders the decision trace with need/got/verdict lines', () => {
+    const html = render(record);
+    expect(html).toContain('decision · challenge → keep');
+    expect(html).toContain('✗ challenge/select: need &gt;= 1.6, got 1.021');
+    expect(html).toContain('got 0 (incumbent 0.1728)');
+    expect(html).toContain('– rung-flip: need');
+    expect(html).toContain('volume-energy: volume-level committee');
+  });
+
+  it('highlights the truth row when it is selected (index -2)', () => {
+    expect(render(record, -2)).toMatch(
+      /<tr class="selected[^"]*"[^>]*><td>truth<\/td>/,
+    );
+  });
+
+  it('says when truth exists but was never scored', () => {
+    const { truth_pose: _omit, ...unscored } = record;
+    const html = render(unscored);
+    expect(html).not.toContain('<td>truth</td>');
+    expect(html).toContain('truth pose not scored in this record');
+  });
+});

--- a/app/src/components/SnapPanel.tsx
+++ b/app/src/components/SnapPanel.tsx
@@ -1,4 +1,10 @@
-import { groupRotationPriors, rankedCandidates, truthVerdict } from '../snap';
+import {
+  groupRotationPriors,
+  posePxPerFoot,
+  poseRotationDeg,
+  rankedCandidates,
+  truthVerdict,
+} from '../snap';
 import type {
   SnapCandidate,
   SnapDecisionBar,
@@ -51,8 +57,22 @@ function CandidateRow({
       <td className="num">
         {c.chamfer_mean_m != null ? `${c.chamfer_mean_m.toFixed(1)}m` : '—'}
       </td>
+      <td
+        className="num"
+        title={
+          c.theta_deg != null
+            ? `ladder seed ${c.theta_deg.toFixed(1)}° (${c.theta_source ?? '?'})`
+            : undefined
+        }
+      >
+        {c.world_affine
+          ? `${poseRotationDeg(c.world_affine).toFixed(1)}°`
+          : c.theta_deg != null
+            ? `${c.theta_deg.toFixed(1)}°`
+            : '—'}
+      </td>
       <td className="num">
-        {c.theta_deg != null ? `${c.theta_deg.toFixed(1)}°` : '—'}
+        {c.world_affine ? posePxPerFoot(c.world_affine).toFixed(2) : '—'}
       </td>
       <td>{c.scale_source ?? '—'}</td>
       <td className="num">
@@ -140,7 +160,12 @@ export function SnapPanel({
             <th title="mean P(road)→OSM distance in metres (penalty)">
               chamfer
             </th>
-            <th>θ</th>
+            <th title="the pose's rotation in snap's convention (the priors' angle); hover a cell for the ladder seed it started from">
+              θ
+            </th>
+            <th title="the pose's scale in working-frame pixels per foot (the page list's convention)">
+              px/ft
+            </th>
             <th>scale src</th>
             <th>truth</th>
           </tr>

--- a/app/src/components/SnapPanel.tsx
+++ b/app/src/components/SnapPanel.tsx
@@ -1,5 +1,10 @@
-import { groupRotationPriors, rankedCandidates } from '../snap';
-import type { SnapCandidate, SnapRecord } from '../snap';
+import { groupRotationPriors, rankedCandidates, truthVerdict } from '../snap';
+import type {
+  SnapCandidate,
+  SnapDecisionBar,
+  SnapRecord,
+  SnapTruthPose,
+} from '../snap';
 
 /**
  * Per-page snap explorer (#325 phase 1): what the matcher searched, every
@@ -12,7 +17,7 @@ import type { SnapCandidate, SnapRecord } from '../snap';
 
 interface SnapPanelProps {
   record: SnapRecord;
-  /** Index into rankedCandidates(record), -1 for the incumbent, null for none. */
+  /** Index into rankedCandidates(record); -1 the incumbent, -2 the truth pose; null none. */
   selected: number | null;
   onSelect: (index: number | null) => void;
   onClose: () => void;
@@ -26,7 +31,7 @@ function CandidateRow({
   onClick,
 }: {
   label: string;
-  candidate: SnapCandidate | (SnapRecord['incumbent'] & object);
+  candidate: SnapCandidate | (SnapRecord['incumbent'] & object) | SnapTruthPose;
   isSelected: boolean;
   isBest: boolean;
   onClick: () => void;
@@ -57,6 +62,19 @@ function CandidateRow({
   );
 }
 
+// One decision bar as a line: "rule: need X, got Y — verdict (note)".
+function describeBar(bar: SnapDecisionBar): string {
+  const got =
+    bar.got === null
+      ? '—'
+      : typeof bar.got === 'number'
+        ? bar.got.toFixed(bar.got === Math.round(bar.got) ? 0 : 3)
+        : bar.got;
+  const symbol =
+    bar.verdict === 'pass' ? '✓' : bar.verdict === 'fail' ? '✗' : '–';
+  return `${symbol} ${bar.rule}: need ${bar.need}, got ${got}${bar.note ? ` (${bar.note})` : ''}`;
+}
+
 export function SnapPanel({
   record,
   selected,
@@ -69,9 +87,12 @@ export function SnapPanel({
       ? null
       : selected === -1
         ? (record.incumbent ?? null)
-        : (ranked[selected] ?? null);
+        : selected === -2
+          ? (record.truth_pose ?? null)
+          : (ranked[selected] ?? null);
   const activeCandidate = active as SnapCandidate | null;
   const priorGroups = groupRotationPriors(record.priors?.rotation ?? []);
+  const verdict = truthVerdict(record);
 
   return (
     <div className="snap-panel">
@@ -134,6 +155,15 @@ export function SnapPanel({
               onClick={() => onSelect(selected === -1 ? null : -1)}
             />
           )}
+          {record.truth_pose && (
+            <CandidateRow
+              label="truth"
+              candidate={record.truth_pose}
+              isSelected={selected === -2}
+              isBest={false}
+              onClick={() => onSelect(selected === -2 ? null : -2)}
+            />
+          )}
           {ranked.map((candidate, i) => (
             <CandidateRow
               key={i}
@@ -146,13 +176,37 @@ export function SnapPanel({
           ))}
         </tbody>
       </table>
-      {record.has_truth && (
-        <p className="snap-note">
-          truth column is each pose's grid RMSE; a truth-pose row (scored with
-          the same evidence) lands with the phase-2 pipeline record.
+      {verdict && (
+        <p className={`snap-note snap-truth-${verdict.kind}`}>
+          truth: {verdict.detail}
         </p>
       )}
-
+      {record.has_truth && !record.truth_pose && (
+        <p className="snap-note">
+          truth pose not scored in this record (re-run snap to add it).
+        </p>
+      )}
+      {record.decision && (
+        <details className="snap-decision">
+          <summary>
+            decision · {record.decision.path} → {record.decision.page_verdict}
+            {record.decision.argmax_reason &&
+              ` (${record.decision.argmax_reason})`}
+          </summary>
+          <ul>
+            {record.decision.bars.map((bar) => (
+              <li key={bar.rule} className={`snap-bar-${bar.verdict}`}>
+                {describeBar(bar)}
+              </li>
+            ))}
+            {record.decision.skipped.map((skip) => (
+              <li key={skip.rule} className="snap-skipped">
+                {skip.rule}: {skip.reason}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
       {activeCandidate && (activeCandidate.gate_reasons?.length ?? 0) > 0 && (
         <p className="snap-note">
           gates: {activeCandidate.gate_reasons!.join(' · ')}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -395,7 +395,9 @@ export function VolumeViewer() {
     const pose =
       snapSelected === -1
         ? snapRecord.incumbent
-        : rankedCandidates(snapRecord)[snapSelected];
+        : snapSelected === -2
+          ? snapRecord.truth_pose
+          : rankedCandidates(snapRecord)[snapSelected];
     if (!pose?.world_affine) return null;
     return {
       url: `/data/${volumeName}/artifacts/edge_join/roadprob/${snapRecord.target}.png`,

--- a/app/src/snap.test.ts
+++ b/app/src/snap.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   groupRotationPriors,
   parseSnapRecords,
+  posePxPerFoot,
+  poseRotationDeg,
   rankedCandidates,
   truthVerdict,
 } from './snap';
@@ -164,5 +166,32 @@ describe('truthVerdict', () => {
     expect(record.truth_pose?.select_score).toBe(1.5);
     expect('verification' in record.truth_pose!).toBe(false);
     expect(record.decision?.bars[0]?.verdict).toBe('fail');
+  });
+});
+
+describe('pose rotation and scale', () => {
+  // ~0.6 m/px at 40°N, north-up: a00 = 0.6/kx, a11 = -0.6/ky.
+  const kx = 111_320 * Math.cos((40 * Math.PI) / 180);
+  const northUp: [number, number, number][] = [
+    [0.6 / kx, 0, -74],
+    [0, -0.6 / 110_540, 40],
+  ];
+
+  it('reads 0° and the metre scale off a north-up affine', () => {
+    expect(poseRotationDeg(northUp)).toBeCloseTo(0, 6);
+    expect(posePxPerFoot(northUp)).toBeCloseTo(1 / (0.6 * 3.28084), 4);
+  });
+
+  it('reads a rotated pose in the ladder convention', () => {
+    // snap's theta is atan2(-a10, a00) on the RAW affine entries (the same
+    // formula the pipeline uses for truth_pose.theta_deg and the demoted-pose
+    // prior), so a 30° pose is one whose raw entries carry that rotation.
+    const theta = (30 * Math.PI) / 180;
+    const c = 1e-5;
+    const rotated: [number, number, number][] = [
+      [c * Math.cos(theta), c * Math.sin(theta), -74],
+      [-c * Math.sin(theta), -c * Math.cos(theta), 40],
+    ];
+    expect(poseRotationDeg(rotated)).toBeCloseTo(30, 6);
   });
 });

--- a/app/src/snap.test.ts
+++ b/app/src/snap.test.ts
@@ -55,7 +55,7 @@ describe('parseSnapRecords', () => {
 });
 
 describe('groupRotationPriors', () => {
-  it('groups the fargo p17 ladder by rounded (θ, σ) with source counts', () => {
+  it('groups the fargo p17 ladder by rounded (θ, σ), sorted by angle, with source counts', () => {
     const prior = (theta_deg: number, source: string, sigma_deg = 4) => ({
       theta_deg,
       sigma_deg,
@@ -77,11 +77,11 @@ describe('groupRotationPriors', () => {
       prior(-16.0, 'volume-median-theta', 15),
     ];
     expect(groupRotationPriors(ladder)).toEqual([
-      '0°±4 (label-pair-exact ×2, label-osm-mod180 ×2)',
       '-17°±4 (label-pair-exact ×2, label-osm-mod180 ×2)',
-      '180°±4 (label-osm-mod180 ×2)',
-      '163°±4 (label-osm-mod180 ×2)',
       '-16°±15 (volume-median-theta)',
+      '0°±4 (label-pair-exact ×2, label-osm-mod180 ×2)',
+      '163°±4 (label-osm-mod180 ×2)',
+      '180°±4 (label-osm-mod180 ×2)',
     ]);
   });
 

--- a/app/src/snap.test.ts
+++ b/app/src/snap.test.ts
@@ -3,9 +3,10 @@ import {
   groupRotationPriors,
   parseSnapRecords,
   rankedCandidates,
+  truthVerdict,
 } from './snap';
 
-const affine = [
+const affine: [number, number, number][] = [
   [1, 0, 0],
   [0, 1, 0],
 ];
@@ -91,5 +92,77 @@ describe('groupRotationPriors', () => {
         { theta_deg: 12, sigma_deg: 15, source: 'b' },
       ]),
     ).toEqual(['12°±4 (a)', '12°±15 (b)']);
+  });
+});
+
+describe('truthVerdict', () => {
+  const base = {
+    target: 'p1',
+    status: 'ok',
+    fit_state: 'none',
+    width: 100,
+    height: 80,
+  };
+  const candidate = (select_score: number, rmse_ft: number) => ({
+    world_affine: affine,
+    center: [0, 0] as [number, number],
+    select_score,
+    rmse_ft,
+  });
+
+  it('is null without a scored truth pose', () => {
+    expect(
+      truthVerdict({ ...base, candidates: [candidate(1, 10)] }),
+    ).toBeNull();
+  });
+
+  it('flags a search problem when truth outscores every candidate', () => {
+    const verdict = truthVerdict({
+      ...base,
+      truth_pose: { world_affine: affine, select_score: 1.8 },
+      candidates: [candidate(1.2, 900)],
+    });
+    expect(verdict?.kind).toBe('search');
+    expect(verdict?.detail).toContain('1.80 vs 1.20');
+  });
+
+  it('flags an alias when a far-off candidate outscores truth', () => {
+    const verdict = truthVerdict({
+      ...base,
+      truth_pose: { world_affine: affine, select_score: 0.9 },
+      candidates: [candidate(1.02, 14713)],
+    });
+    expect(verdict?.kind).toBe('alias');
+    expect(verdict?.detail).toContain('14713 ft');
+  });
+
+  it('reports agreement when the top candidate is near truth', () => {
+    const verdict = truthVerdict({
+      ...base,
+      truth_pose: { world_affine: affine, select_score: 0.9 },
+      candidates: [candidate(1.1, 12)],
+    });
+    expect(verdict?.kind).toBe('agrees');
+  });
+
+  it('keeps truth_pose and decision through parsing', () => {
+    const line = JSON.stringify({
+      ...base,
+      truth_pose: {
+        world_affine: affine,
+        select_score: 1.5,
+        verification: null,
+      },
+      decision: {
+        path: 'rescue',
+        page_verdict: 'abstain',
+        bars: [{ rule: 'select', need: '>= 1.35', got: 1.0, verdict: 'fail' }],
+        skipped: [],
+      },
+    });
+    const record = parseSnapRecords(line).get('p1')!;
+    expect(record.truth_pose?.select_score).toBe(1.5);
+    expect('verification' in record.truth_pose!).toBe(false);
+    expect(record.decision?.bars[0]?.verdict).toBe('fail');
   });
 });

--- a/app/src/snap.ts
+++ b/app/src/snap.ts
@@ -194,6 +194,33 @@ export function groupRotationPriors(
     });
 }
 
+const FEET_PER_METER = 3.28084;
+
+/**
+ * A pose's rotation in degrees, in snap's own convention (the angle the
+ * rotation ladder and the priors use: atan2(-a10, a00) of the page->lon/lat
+ * affine, 0 for a north-up page). Derived from the pose itself, so it is the
+ * refined pose's rotation — a candidate's recorded `theta_deg` is only the
+ * ladder seed it started from.
+ */
+export function poseRotationDeg(affine: [number, number, number][]): number {
+  const [row0, row1] = affine;
+  return (Math.atan2(-(row1?.[0] ?? 0), row0?.[0] ?? 1) * 180) / Math.PI;
+}
+
+/**
+ * A pose's scale in pixels per foot, in the frame of the pixels the affine
+ * maps (snap's working-scale page), which is the page list's convention.
+ */
+export function posePxPerFoot(affine: [number, number, number][]): number {
+  const [row0, row1] = affine;
+  const lat = row1?.[2] ?? 0;
+  const kx = 111_320 * Math.cos((lat * Math.PI) / 180);
+  const ky = 110_540;
+  const metresPerPx = Math.hypot((row0?.[0] ?? 0) * kx, (row1?.[0] ?? 0) * ky);
+  return metresPerPx > 0 ? 1 / (metresPerPx * FEET_PER_METER) : NaN;
+}
+
 /** Candidates sorted by select_score descending (unscored last, order kept). */
 export function rankedCandidates(record: SnapRecord): SnapCandidate[] {
   return [...(record.candidates ?? [])].sort(

--- a/app/src/snap.ts
+++ b/app/src/snap.ts
@@ -9,6 +9,14 @@
  * number shown in the UI was computed by the pipeline itself.
  */
 
+/** OCR street-name agreement with a pose (a boost, never a gate). */
+export interface SnapNameAlignment {
+  score: number;
+  n_labels: number;
+  n_hits: number;
+  hits?: { text: string; dist_m: number; angle_deg: number }[];
+}
+
 /** One candidate pose from the snap matcher, as recorded in candidates.jsonl. */
 export interface SnapCandidate {
   world_affine: [number, number, number][];
@@ -29,7 +37,7 @@ export interface SnapCandidate {
   refine_shift_m?: number;
   select_score?: number;
   verification?: number;
-  name?: number;
+  name?: SnapNameAlignment;
   plausible?: boolean;
   gate_reasons?: string[];
   /** Grid RMSE vs truth, present only when the volume has truth data. */
@@ -44,9 +52,35 @@ export interface SnapIncumbent {
   inlier_frac?: number;
   chamfer_mean_m?: number;
   n_points?: number;
-  name?: number;
+  name?: SnapNameAlignment;
   effective_gcps?: number;
   rmse_ft?: number;
+}
+
+/** The truth pose scored with the ladder's own evidence (#325 phase 2). */
+export interface SnapTruthPose extends SnapIncumbent {
+  select_score?: number;
+  theta_deg?: number;
+  region_containment?: number;
+  prior_theta_residual_sigma?: number;
+}
+
+/** One need/got/verdict line of the pipeline's decision trace. */
+export interface SnapDecisionBar {
+  rule: string;
+  need: string;
+  got: number | string | null;
+  verdict: 'pass' | 'fail' | 'n/a';
+  note?: string;
+}
+
+/** The per-page decision trace recorded at snap time (#325 phase 2). */
+export interface SnapDecision {
+  path: string;
+  page_verdict: string;
+  bars: SnapDecisionBar[];
+  skipped: { rule: string; reason: string }[];
+  argmax_reason?: string;
 }
 
 /** One page's full snap record. */
@@ -70,6 +104,8 @@ export interface SnapRecord {
     scale: { m_per_px: number; sigma_log: number; source: string }[];
   };
   incumbent?: SnapIncumbent;
+  truth_pose?: SnapTruthPose;
+  decision?: SnapDecision;
   candidates?: SnapCandidate[];
 }
 
@@ -161,4 +197,51 @@ export function rankedCandidates(record: SnapRecord): SnapCandidate[] {
   return [...(record.candidates ?? [])].sort(
     (a, b) => (b.select_score ?? -Infinity) - (a.select_score ?? -Infinity),
   );
+}
+
+/** How the truth pose fared against the ladder: the one-line failure class. */
+export interface TruthVerdict {
+  kind: 'search' | 'alias' | 'agrees';
+  detail: string;
+}
+
+/**
+ * Classify a page's snap outcome against its scored truth pose (#325).
+ *
+ * Truth outscoring every candidate means the search never reached the right
+ * pose (a search problem); a candidate far from truth outscoring it means the
+ * page's own evidence prefers a wrong pose (a data/aliasing problem); a top
+ * candidate near truth means the evidence agrees. Null without a scored truth.
+ */
+export function truthVerdict(record: SnapRecord): TruthVerdict | null {
+  const truth = record.truth_pose;
+  if (!truth || truth.select_score === undefined) return null;
+  const top = rankedCandidates(record).find(
+    (c) => c.select_score !== undefined,
+  );
+  const truthScore = truth.select_score.toFixed(2);
+  if (!top || top.select_score === undefined) {
+    return {
+      kind: 'search',
+      detail: `no plausible candidate; the truth pose scores ${truthScore}`,
+    };
+  }
+  const topScore = top.select_score.toFixed(2);
+  if (truth.select_score > top.select_score) {
+    return {
+      kind: 'search',
+      detail: `truth pose outscores every candidate (${truthScore} vs ${topScore}): the search never reached it`,
+    };
+  }
+  const rmse = top.rmse_ft;
+  if (rmse !== undefined && rmse > 200) {
+    return {
+      kind: 'alias',
+      detail: `a pose ${Math.round(rmse)} ft from truth outscores the truth pose (${topScore} vs ${truthScore}): the evidence prefers an alias`,
+    };
+  }
+  return {
+    kind: 'agrees',
+    detail: `top candidate is ${rmse === undefined ? 'near' : `${Math.round(rmse)} ft from`} truth and outscores it (${topScore} vs ${truthScore})`,
+  };
 }

--- a/app/src/snap.ts
+++ b/app/src/snap.ts
@@ -162,15 +162,15 @@ export function poseCorners(
  * The pipeline records one prior per vote (per label, per label pair), so the
  * raw ladder is full of repeats — the multiplicity is the corroboration
  * signal. Group by the rounded angle (−0 → 0, −180 → 180: same rotation) and
- * sigma, keeping first-appearance order (rung priority), and aggregate the
- * sources with ×N counts.
+ * sigma, sorted by angle then sigma, and aggregate the sources with ×N counts
+ * (in first-appearance order, which is rung priority).
  */
 export function groupRotationPriors(
   priors: { theta_deg: number; sigma_deg: number; source: string }[],
 ): string[] {
   const groups = new Map<
     string,
-    { label: string; counts: Map<string, number> }
+    { theta: number; sigma: number; counts: Map<string, number> }
   >();
   for (const prior of priors) {
     let theta = Math.round(prior.theta_deg);
@@ -179,17 +179,19 @@ export function groupRotationPriors(
     const label = `${theta}°±${prior.sigma_deg}`;
     let group = groups.get(label);
     if (!group) {
-      group = { label, counts: new Map() };
+      group = { theta, sigma: prior.sigma_deg, counts: new Map() };
       groups.set(label, group);
     }
     group.counts.set(prior.source, (group.counts.get(prior.source) ?? 0) + 1);
   }
-  return [...groups.values()].map((group) => {
-    const sources = [...group.counts.entries()]
-      .map(([source, n]) => (n > 1 ? `${source} ×${n}` : source))
-      .join(', ');
-    return `${group.label} (${sources})`;
-  });
+  return [...groups.values()]
+    .sort((a, b) => a.theta - b.theta || a.sigma - b.sigma)
+    .map((group) => {
+      const sources = [...group.counts.entries()]
+        .map(([source, n]) => (n > 1 ? `${source} ×${n}` : source))
+        .join(', ');
+      return `${group.theta}°±${group.sigma} (${sources})`;
+    });
 }
 
 /** Candidates sorted by select_score descending (unscored last, order kept). */

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -937,6 +937,29 @@ tr.relaxed {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
+.snap-decision {
+  margin: 4px 0;
+  font-size: 12px;
+}
+.snap-decision summary {
+  cursor: pointer;
+}
+.snap-decision ul {
+  margin: 2px 0;
+  padding-left: 22px;
+}
+.snap-bar-fail {
+  color: #b91c1c;
+}
+.snap-skipped {
+  color: #6b7280;
+}
+.snap-truth-search {
+  color: #b45309;
+}
+.snap-truth-alias {
+  color: #b91c1c;
+}
 .snap-priors {
   margin: 2px 0;
   padding-left: 22px;

--- a/docs/fit-pipeline.md
+++ b/docs/fit-pipeline.md
@@ -248,6 +248,17 @@ any change to which pages survive stage 1 perturbs snap's refinement on pages
 no gate touched (observed: nashville p4, 26.2 → 402.3 ft under the ±12%
 scale-band experiment).
 
+**Debugger records (#325 phase 2).** Each `candidates.jsonl` record also
+carries `truth_pose` — the truth affine scored with the ladder's own evidence
+and soft bonuses (`rank_pose`), present whenever truth exists, so the snap
+explorer can say whether the search never reached the right pose (truth
+outscores every candidate) or the evidence itself prefers a wrong one (a
+far-off candidate outscores truth) — and `decision`, the per-page bars
+(need/got/verdict) for the path the page's state selects, with the rules that
+cannot be judged from one record (panel sheet agreement, the volume energy
+committee, printed-note rung ratios) listed as skipped. The selection files
+remain the authority on what published; `decision` explains the per-page part.
+
 ---
 
 ## Stage 4: street-solve (`street_solve_run.py`)

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -151,18 +151,53 @@ class SnapCandidate:
 
     def select_score(self) -> float:
         """The ranking score: matcher verification plus soft evidence bonuses."""
-        if not math.isfinite(self.verification):
-            return -math.inf
-        score = self.verification
-        if self.name is not None:
-            score += W_NAME * self.name.score
-        if self.region_containment is not None:
-            score += W_CONTAIN * self.region_containment
-        if self.prior_theta_residual_sigma is not None:
-            # Signed: within 1 sigma earns the bonus, a gross disagreement
-            # (e.g. a 180-flip against agreeing directed priors) costs it.
-            score += W_PRIOR * max(-1.0, 1.0 - self.prior_theta_residual_sigma)
-        return score
+        return selection_score(
+            self.verification,
+            self.name.score if self.name is not None else None,
+            self.region_containment,
+            self.prior_theta_residual_sigma,
+        )
+
+
+def selection_score(
+    verification: float,
+    name_score: float | None,
+    region_containment: float | None,
+    prior_theta_residual_sigma: float | None,
+) -> float:
+    """The ranking score: matcher verification plus soft evidence bonuses.
+
+    One formula for the ladder's own candidates (SnapCandidate.select_score)
+    and for synthetic poses scored after the fact (rank_pose), so a truth pose
+    lands on the same footing as the search's candidates.
+    """
+    if not math.isfinite(verification):
+        return -math.inf
+    score = verification
+    if name_score is not None:
+        score += W_NAME * name_score
+    if region_containment is not None:
+        score += W_CONTAIN * region_containment
+    if prior_theta_residual_sigma is not None:
+        # Signed: within 1 sigma earns the bonus, a gross disagreement
+        # (e.g. a 180-flip against agreeing directed priors) costs it.
+        score += W_PRIOR * max(-1.0, 1.0 - prior_theta_residual_sigma)
+    return score
+
+
+def directed_prior_residual_sigma(
+    priors: list["RotationPrior"], theta_deg: float
+) -> float | None:
+    """How many sigmas a rotation sits from the nearest DIRECTED prior, or None.
+
+    Only directed priors can flag a 180-flip: the mod-180 rung emits both flips
+    as entries, so including it would let the wrong flip always match one of
+    the pair and pin the residual at zero.
+    """
+    directed = [p for p in priors if p.source != "label-osm-mod180"]
+    if not directed:
+        return None
+    return min(abs(wrap_deg(theta_deg - p.theta_deg)) / p.sigma_deg for p in directed)
 
 
 @dataclass
@@ -761,6 +796,53 @@ def evaluate_pose(
     return evaluation
 
 
+def rank_pose(
+    ctx: PageContext,
+    features: FeatureIndex,
+    world_affine: np.ndarray,
+    params: MatchParams = OSM_MATCH_PARAMS,
+) -> dict | None:
+    """Score an EXISTING pose with the ladder's FULL ranking features.
+
+    evaluate_pose's evidence plus the soft bonuses the search's own candidates
+    carry (key-map region containment, directed-prior rotation residual), so
+    the result has a ``select_score`` directly comparable with theirs. This is
+    what puts a synthetic candidate -- the truth pose in the debugger record
+    (#325) -- on the same footing as the ladder: if it outscores every
+    candidate the search never reached it; if a candidate outscores it the
+    page's evidence itself prefers a wrong pose. None when the pose cannot be
+    evaluated (see evaluate_pose).
+    """
+    evaluation = evaluate_pose(ctx, features, world_affine, params)
+    if evaluation is None:
+        return None
+    affine = np.asarray(world_affine, dtype=float)
+    theta = math.degrees(math.atan2(-affine[1, 0], affine[0, 0]))
+    containment = (
+        region_containment_frac(affine, (ctx.width, ctx.height), ctx.keymap_regions)
+        if ctx.keymap_regions
+        else None
+    )
+    residual = directed_prior_residual_sigma(ctx.rotation_priors, theta)
+    name = evaluation.get("name")
+    evaluation["world_affine"] = [[float(v) for v in row] for row in affine]
+    evaluation["theta_deg"] = round(theta, 2)
+    evaluation["select_score"] = round(
+        selection_score(
+            evaluation["verification"],
+            name["score"] if name is not None else None,
+            containment,
+            residual,
+        ),
+        4,
+    )
+    if containment is not None:
+        evaluation["region_containment"] = round(containment, 3)
+    if residual is not None:
+        evaluation["prior_theta_residual_sigma"] = round(residual, 2)
+    return evaluation
+
+
 def frame_thetas(
     ctx: PageContext,
     confident_deg: float | None,
@@ -943,17 +1025,9 @@ def snap_page(
                 if snap.region_containment < CONTAINMENT_MIN:
                     snap.plausible = False
                     snap.gate_reasons.append("containment")
-            # Only DIRECTED priors can flag a 180-flip: the mod-180 rung emits
-            # both flips as entries, so including it would let the wrong flip
-            # always match one of the pair and pin the residual at zero.
-            directed = [
-                p for p in ctx.rotation_priors if p.source != "label-osm-mod180"
-            ]
-            if directed:
-                snap.prior_theta_residual_sigma = min(
-                    abs(wrap_deg(candidate.theta_deg - p.theta_deg)) / p.sigma_deg
-                    for p in directed
-                )
+            snap.prior_theta_residual_sigma = directed_prior_residual_sigma(
+                ctx.rotation_priors, candidate.theta_deg
+            )
             if ctx.label_features and ctx.block_index:
                 snap.name = name_alignment(ctx.label_features, ctx.block_index, world)
             if not snap.plausible:

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -58,6 +58,7 @@ from mapsnap.osm_snap import (
     label_osm_rotations,
     osm_rasters,
     page_scale_priors,
+    rank_pose,
     snap_page,
 )
 from mapsnap.streets import Block, build_block_index
@@ -991,6 +992,15 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
                 "source": "demoted-pose",
             }
         )
+    if unit.truth is not None:
+        # #325: the truth pose as a synthetic candidate, scored with the very
+        # same evidence, soft bonuses and prior ladder as the search (rank_pose). One row
+        # classifies every snap failure: truth outscoring every candidate is
+        # a SEARCH problem; a candidate outscoring truth is a DATA problem
+        # (the page's P(road)/OSM evidence prefers a wrong pose).
+        truth = rank_pose(ctx, vctx.feature_index, unit.truth.affine_local)
+        if truth is not None:
+            record["truth_pose"] = truth
     candidates = snap_page(ctx, vctx.feature_index)
     # #324: a candidate whose pose reads the page upside-down is
     # corpus-impossible (0/1,332 truth pages in the zone); snap's rotation
@@ -1038,6 +1048,7 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
         if len(scores) >= 2
         else (round(scores[0], 4) if scores else None)
     )
+    record["decision"] = decision_block(record)
     return record
 
 
@@ -2547,6 +2558,321 @@ def uncorroborated_margin(record: dict) -> float:
         if c.get("select_score") is not None and not stamp_corroborated(c)
     ]
     return top_score - max(rivals) if rivals else math.inf
+
+
+def decision_bar(
+    rule: str, need: str, got: object, verdict: str, note: str | None = None
+) -> dict:
+    """One need/got/verdict line of a decision trace (JSON-safe values)."""
+    if isinstance(got, float):
+        got = None if math.isinf(got) else round(got, 4)
+    bar: dict = {"rule": rule, "need": need, "got": got, "verdict": verdict}
+    if note:
+        bar["note"] = note
+    return bar
+
+
+def incumbent_disagreement_ft(record: dict) -> float | None:
+    """Grid RMSE between the incumbent pose and the top candidate, if both exist."""
+    incumbent = record.get("incumbent") or {}
+    candidates = record.get("candidates") or []
+    if not incumbent.get("world_affine") or not candidates:
+        return None
+    return grid_rmse_ft_between(
+        np.array(incumbent["world_affine"]),
+        np.array(candidates[0]["world_affine"]),
+        record["width"],
+        record["height"],
+    )
+
+
+def decision_block(
+    record: dict,
+    gate_score: float = PRODUCTION_GATE_SCORE,
+    gate_margin: float = PRODUCTION_GATE_MARGIN,
+    arbitrate_gate: float = PRODUCTION_ARBITRATE_GATE,
+    refine_margin: float = REFINE_VER_MARGIN,
+) -> dict:
+    """The per-page decision trace for the debugger (#325 phase 2).
+
+    Every bar the page's path applies, as need/got/verdict, plus the rules that
+    could not be judged from one record (volume-level committees, printed-note
+    rung ratios) listed as skipped with the reason. ``page_verdict`` is what the
+    per-page rules alone conclude -- it comes from the REAL rule functions
+    (select_argmax / arbitrate_challenge / refine_adoption / rung_flip), so it
+    cannot drift from production; the bars only explain it. The selection
+    files stay the authority on what published: a volume-level rule may still
+    accept a page these bars abstain on.
+    """
+    from mapsnap.adjacency_gate import STAMP_REHOME_M
+    from mapsnap.reconcile import ENTRY_MARGIN_MIN, ENTRY_SELECT_MIN
+
+    fit_state = record.get("fit_state")
+    path = (
+        "rescue"
+        if fit_state in RESCUE_STATES
+        else ("challenge" if fit_state == "fitted" else "none")
+    )
+    decision: dict = {
+        "path": path,
+        "page_verdict": "abstain" if path == "rescue" else "keep",
+        "bars": [],
+        "skipped": [],
+    }
+    bars: list[dict] = decision["bars"]
+    skipped: list[dict] = decision["skipped"]
+    candidates = record.get("candidates") or []
+    if record.get("status") != "ok" or not candidates:
+        skipped.append(
+            {"rule": "all", "reason": f"status {record.get('status')}, no candidates"}
+        )
+        return decision
+    top = candidates[0]
+    score = top.get("select_score")
+    stem = record.get("target", "")
+
+    if path == "rescue":
+        gates = top.get("gate_reasons") or []
+        bars.append(
+            decision_bar(
+                "plausible",
+                "top candidate passes the plausibility gates",
+                ", ".join(gates) if gates else "no gate reasons",
+                "pass" if score is not None else "fail",
+            )
+        )
+        corroborated = score is not None and stamp_corroborated(top)
+        median = top.get("stamp_median_m")
+        bars.append(
+            decision_bar(
+                "stamp-corroborated",
+                f"median partner stamp separation <= {STAMP_REHOME_M:g} m",
+                median,
+                "pass" if corroborated else ("n/a" if median is None else "fail"),
+                None if median is not None else "no hinting neighbors",
+            )
+        )
+        effective_gate = STAMP_RESCUE_SCORE if corroborated else gate_score
+        bars.append(
+            decision_bar(
+                "select",
+                f">= {effective_gate:g}"
+                + (" (stamp-corroborated bar)" if corroborated else ""),
+                score,
+                "pass" if score is not None and score >= effective_gate else "fail",
+            )
+        )
+        if score is None:
+            margin = None
+        elif corroborated:
+            margin = uncorroborated_margin(record)
+        else:
+            margin = distinct_margin(record, pose_aware=True)
+        bars.append(
+            decision_bar(
+                "margin",
+                f">= {gate_margin:g} over the best distinct rival",
+                margin,
+                "pass" if margin is not None and margin >= gate_margin else "fail",
+                "no distinct rival"
+                if margin is not None and math.isinf(margin)
+                else None,
+            )
+        )
+        choice = select_argmax([record], gate_score, gate_margin, {})[0]
+        decision["page_verdict"] = (
+            "rescue" if choice.get("chosen") is not None else "abstain"
+        )
+        decision["argmax_reason"] = choice.get("reason")
+        if panel_base(stem) is not None:
+            skipped.append(
+                {
+                    "rule": "sheet-agreement",
+                    "reason": "volume-level: judged against fitted siblings at "
+                    f"select time (solo bar {PANEL_SOLO_GATE:g} applied here)",
+                }
+            )
+        skipped.append(
+            {
+                "rule": "volume-energy",
+                "reason": "volume-level committee may still accept an abstained page",
+            }
+        )
+    elif path == "challenge":
+        incumbent = record.get("incumbent")
+        if not incumbent:
+            skipped.append(
+                {"rule": "challenge/refine", "reason": "no incumbent evaluation"}
+            )
+            return decision
+        inc_ver = incumbent.get("verification")
+        top_ver = top.get("verification")
+        inc_name = (incumbent.get("name") or {}).get("score") or 0.0
+        top_name = (top.get("name") or {}).get("score") or 0.0
+        disagreement = incumbent_disagreement_ft(record)
+        legacy_margin = distinct_margin(record, pose_aware=False)
+        if inc_ver is not None and inc_ver >= INCUMBENT_DEFENSIBLE_VERIFICATION:
+            skipped.append(
+                {
+                    "rule": "remote-search",
+                    "reason": "incumbent defensible: search collapsed to a local challenge",
+                }
+            )
+        bars.append(
+            decision_bar(
+                "challenge/select",
+                f">= {arbitrate_gate:g}",
+                score,
+                "pass" if score is not None and score >= arbitrate_gate else "fail",
+            )
+        )
+        bars.append(
+            decision_bar(
+                "challenge/margin",
+                f">= {gate_margin:g}",
+                legacy_margin,
+                "pass"
+                if legacy_margin is not None and legacy_margin >= gate_margin
+                else "fail",
+            )
+        )
+        bars.append(
+            decision_bar(
+                "challenge/disagreement",
+                f">= {ARBITRATE_MIN_DISAGREE_FT:g} ft from the incumbent",
+                disagreement,
+                "pass"
+                if disagreement is not None
+                and disagreement >= ARBITRATE_MIN_DISAGREE_FT
+                else "fail",
+            )
+        )
+        bars.append(
+            decision_bar(
+                "challenge/incumbent-indefensible",
+                f"incumbent verification < {INCUMBENT_DEFENSIBLE_VERIFICATION:g}",
+                inc_ver,
+                "pass"
+                if inc_ver is not None and inc_ver < INCUMBENT_DEFENSIBLE_VERIFICATION
+                else "fail",
+            )
+        )
+        bars.append(
+            decision_bar(
+                "challenge/verification",
+                "candidate verification > incumbent's",
+                top_ver,
+                "pass"
+                if top_ver is not None and inc_ver is not None and top_ver > inc_ver
+                else "fail",
+                f"incumbent {inc_ver}",
+            )
+        )
+        bars.append(
+            decision_bar(
+                "challenge/name-parity",
+                "candidate name score >= incumbent's",
+                top_name,
+                "pass" if top_name >= inc_name else "fail",
+                f"incumbent {inc_name}",
+            )
+        )
+        effective_gcps = incumbent.get("effective_gcps")
+        bars.append(
+            decision_bar(
+                "refine/effective-gcps",
+                f"incumbent effective GCPs >= {REFINE_MIN_EFFECTIVE_GCPS}",
+                effective_gcps,
+                "n/a"
+                if effective_gcps is None
+                else (
+                    "pass" if effective_gcps >= REFINE_MIN_EFFECTIVE_GCPS else "fail"
+                ),
+                "not recorded (pre-dates the field)"
+                if effective_gcps is None
+                else None,
+            )
+        )
+        bars.append(
+            decision_bar(
+                "refine/verification-floor",
+                f"candidate verification > {REFINE_MIN_VERIFICATION:g}",
+                top_ver,
+                "pass"
+                if top_ver is not None and top_ver > REFINE_MIN_VERIFICATION
+                else "fail",
+            )
+        )
+        bars.append(
+            decision_bar(
+                "refine/verification-margin",
+                f"candidate verification > incumbent's + {refine_margin:g}",
+                top_ver,
+                "pass"
+                if top_ver is not None
+                and inc_ver is not None
+                and top_ver > inc_ver + refine_margin
+                else "fail",
+                f"incumbent {inc_ver}",
+            )
+        )
+        bars.append(
+            decision_bar(
+                "refine/agreement",
+                f"< {ARBITRATE_MIN_DISAGREE_FT:g} ft from the incumbent",
+                disagreement,
+                "pass"
+                if disagreement is not None and disagreement < ARBITRATE_MIN_DISAGREE_FT
+                else "fail",
+            )
+        )
+        flip = rung_flip(record, note_ratio=None)
+        bars.append(
+            decision_bar(
+                "rung-flip",
+                "double-scale candidate over a half-scale incumbent, verification + name parity",
+                "flip" if flip is not None else "no flip",
+                "pass" if flip is not None else "n/a",
+                "printed-note ratio is applied at select time (volume-level)",
+            )
+        )
+        if arbitrate_challenge(record, arbitrate_gate) is not None:
+            decision["page_verdict"] = "challenge"
+        elif refine_adoption(record, refine_margin) is not None:
+            decision["page_verdict"] = "refine"
+        elif flip is not None:
+            decision["page_verdict"] = "rung-flip"
+        else:
+            decision["page_verdict"] = "keep"
+    else:
+        skipped.append(
+            {"rule": "all", "reason": f"fit_state {fit_state} is not searched"}
+        )
+        return decision
+
+    record_margin = record.get("margin")
+    note = "reconcile's entry bar applies only to pages the pipeline left unplaced"
+    bars.append(
+        decision_bar(
+            "reconcile-entry/select",
+            f">= {ENTRY_SELECT_MIN:g}",
+            score,
+            "pass" if score is not None and score >= ENTRY_SELECT_MIN else "fail",
+            note,
+        )
+    )
+    bars.append(
+        decision_bar(
+            "reconcile-entry/margin",
+            f">= {ENTRY_MARGIN_MIN:g}",
+            record_margin,
+            "pass"
+            if record_margin is not None and record_margin >= ENTRY_MARGIN_MIN
+            else "fail",
+            note,
+        )
+    )
+    return decision
 
 
 def select_argmax(

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -20,6 +20,7 @@ from mapsnap.osm_snap_experiment import (
     arbitrate_challenge,
     candidates_record_fresh,
     canonicalize_refine_keys,
+    decision_block,
     init_worker,
     refine_adopt_set,
     refine_adoption,
@@ -559,3 +560,132 @@ def test_runner_up_affines_load_for_fitted_pages_only(tmp_path):
     assert affines[0].shape == (2, 3)
     assert runner_up_affines_of(None, 1000, 1000) == []
     assert runner_up_affines_of({"runner_up_poses": [{"bad": 1}]}, 1000, 1000) == []
+
+
+# --- #325 phase 2: the decision trace --------------------------------------
+
+
+def rescue_record(top_select: float, rival_select: float | None = None) -> dict:
+    """A rescue-state record with a plausible top candidate and optional rival."""
+    candidates = [
+        {
+            "world_affine": affine(),
+            "center": [-74.0 + 500 * SCALE_DEG, 39.99],
+            "theta_deg": 0.0,
+            "select_score": top_select,
+            "verification": top_select,
+            "plausible": True,
+            "gate_reasons": [],
+        }
+    ]
+    if rival_select is not None:
+        candidates.append(
+            {
+                "world_affine": affine(500.0),
+                "center": [-74.0 + 500 * SCALE_DEG + 500.0 / KX, 39.99],
+                "theta_deg": 0.0,
+                "select_score": rival_select,
+                "verification": rival_select,
+                "plausible": True,
+                "gate_reasons": [],
+            }
+        )
+    margin = top_select - rival_select if rival_select is not None else top_select
+    return {
+        "target": "p1",
+        "status": "ok",
+        "fit_state": "none",
+        "width": 1000,
+        "height": 1000,
+        "candidates": candidates,
+        "margin": round(margin, 4),
+    }
+
+
+def bars_by_rule(decision: dict) -> dict[str, dict]:
+    return {bar["rule"]: bar for bar in decision["bars"]}
+
+
+def test_decision_block_rescue_accepts_a_clear_winner():
+    decision = decision_block(rescue_record(2.0, 1.0))
+    assert decision["path"] == "rescue"
+    assert decision["page_verdict"] == "rescue"
+    bars = bars_by_rule(decision)
+    assert bars["select"]["verdict"] == "pass" and bars["select"]["got"] == 2.0
+    assert bars["margin"]["verdict"] == "pass" and bars["margin"]["got"] == 1.0
+    assert bars["stamp-corroborated"]["verdict"] == "n/a"
+    assert {s["rule"] for s in decision["skipped"]} == {"volume-energy"}
+
+
+def test_decision_block_rescue_reports_the_failing_bar():
+    # Below the production score gate: the verdict and the bar agree with
+    # select_argmax's own reason.
+    decision = decision_block(rescue_record(1.0, 0.2))
+    assert decision["page_verdict"] == "abstain"
+    assert bars_by_rule(decision)["select"]["verdict"] == "fail"
+    assert decision["argmax_reason"].startswith("score 1.00 <")
+    # Ambiguous near-tie: score clears, margin does not.
+    decision = decision_block(rescue_record(2.0, 1.9))
+    assert decision["page_verdict"] == "abstain"
+    bars = bars_by_rule(decision)
+    assert bars["select"]["verdict"] == "pass"
+    assert bars["margin"]["verdict"] == "fail"
+
+
+def test_decision_block_rescue_stamp_corroboration_relaxes_the_bar():
+    record = rescue_record(1.0)
+    record["candidates"][0]["stamp_median_m"] = 40.0
+    decision = decision_block(record)
+    bars = bars_by_rule(decision)
+    assert bars["stamp-corroborated"]["verdict"] == "pass"
+    assert "stamp-corroborated bar" in bars["select"]["need"]
+    assert decision["page_verdict"] == "rescue"
+
+
+def test_decision_block_challenge_matches_arbitrate_challenge():
+    record = fitted_record(incumbent_ver=-0.3, challenger_ver=1.5, shift_m=100.0)
+    decision = decision_block(record)
+    assert decision["path"] == "challenge"
+    assert decision["page_verdict"] == "challenge"
+    bars = bars_by_rule(decision)
+    assert all(
+        bars[rule]["verdict"] == "pass"
+        for rule in (
+            "challenge/select",
+            "challenge/margin",
+            "challenge/disagreement",
+            "challenge/incumbent-indefensible",
+            "challenge/verification",
+            "challenge/name-parity",
+        )
+    )
+    # A defensible incumbent blocks the challenge and is named as the reason.
+    record = fitted_record(incumbent_ver=0.6, challenger_ver=1.5, shift_m=100.0)
+    decision = decision_block(record)
+    assert decision["page_verdict"] == "keep"
+    assert (
+        bars_by_rule(decision)["challenge/incumbent-indefensible"]["verdict"] == "fail"
+    )
+    assert {s["rule"] for s in decision["skipped"]} >= {"remote-search"}
+
+
+def test_decision_block_refine_matches_refine_adoption():
+    record = fitted_record(incumbent_ver=0.6, challenger_ver=0.8, shift_m=15.0)
+    decision = decision_block(record)
+    assert decision["page_verdict"] == "refine"
+    bars = bars_by_rule(decision)
+    assert bars["refine/agreement"]["verdict"] == "pass"
+    assert bars["refine/verification-margin"]["verdict"] == "pass"
+    assert bars["challenge/disagreement"]["verdict"] == "fail"
+    # Same lock, no verification edge: keep.
+    record = fitted_record(incumbent_ver=0.6, challenger_ver=0.62, shift_m=15.0)
+    assert decision_block(record)["page_verdict"] == "keep"
+
+
+def test_decision_block_unsearched_page_is_skipped():
+    decision = decision_block(
+        {"target": "p1", "status": "no_prob", "fit_state": "none"}
+    )
+    assert decision["page_verdict"] == "abstain"
+    assert decision["bars"] == []
+    assert decision["skipped"][0]["rule"] == "all"

--- a/mapsnap/osm_snap_test.py
+++ b/mapsnap/osm_snap_test.py
@@ -10,12 +10,17 @@ import math
 
 import cv2
 import numpy as np
+import pytest
 
 from mapsnap.edge_join import MatchParams
 from mapsnap.feature_index import FeatureIndex
 from mapsnap.georef_from_labels import LabelFeature
 from mapsnap.osm_snap import (
     CHAMFER_CLAMP_M,
+    W_CONTAIN,
+    W_NAME,
+    W_PRIOR,
+    NameAlignment,
     PageContext,
     RotationPrior,
     ScalePrior,
@@ -26,6 +31,7 @@ from mapsnap.osm_snap import (
     cluster_rotation,
     confident_theta_deg,
     dedupe_thetas,
+    directed_prior_residual_sigma,
     frame_around,
     frame_thetas,
     label_osm_rotations,
@@ -35,6 +41,7 @@ from mapsnap.osm_snap import (
     osm_rasters,
     page_scale_priors,
     pose_theta_deg,
+    selection_score,
     snap_page,
     wrap_deg,
 )
@@ -551,3 +558,47 @@ def test_merge_candidates_dedupes_same_lock() -> None:
     d = make_candidate(1.1, LON0 + near, theta=90.0)
     kept = merge_candidates([a, d], top_k=8)
     assert len(kept) == 2
+
+
+def test_selection_score_matches_the_candidate_property():
+    candidate = SnapCandidate(
+        world_affine=np.eye(2, 3),
+        center=(0.0, 0.0),
+        theta_deg=0.0,
+        theta_source="t",
+        scale_m_per_px=1.0,
+        scale_source="s",
+        scale_adjust=1.0,
+        ncc=0.0,
+        ncc_fine=0.0,
+        chamfer_mean_m=0.0,
+        inlier_frac=0.0,
+        n_points=0,
+        jtj_eig_ratio=1.0,
+        overlap_frac=1.0,
+        refine_shift_m=0.0,
+        center_dist_m=0.0,
+        verification=0.5,
+        region_containment=0.8,
+        prior_theta_residual_sigma=0.5,
+        name=NameAlignment(score=0.4, n_labels=5, n_hits=2),
+    )
+    assert candidate.select_score() == selection_score(0.5, 0.4, 0.8, 0.5)
+    assert selection_score(0.5, 0.4, 0.8, 0.5) == pytest.approx(
+        0.5 + W_NAME * 0.4 + W_CONTAIN * 0.8 + W_PRIOR * 0.5
+    )
+    assert selection_score(-math.inf, 0.4, 0.8, 0.5) == -math.inf
+    # Absent bonuses add nothing, exactly as the property behaves.
+    assert selection_score(0.5, None, None, None) == 0.5
+
+
+def test_directed_prior_residual_ignores_the_mod180_rung():
+    priors = [
+        RotationPrior(10.0, 4.0, "label-pair-exact"),
+        RotationPrior(-170.0, 4.0, "label-osm-mod180"),
+    ]
+    # 12 deg is half a sigma from the directed prior; the mod-180 entry that
+    # would match a 180-flip exactly does not count.
+    assert directed_prior_residual_sigma(priors, 12.0) == pytest.approx(0.5)
+    assert directed_prior_residual_sigma(priors, -170.0) == pytest.approx(45.0)
+    assert directed_prior_residual_sigma(priors[1:], 12.0) is None


### PR DESCRIPTION
Implements #325 phase 2's pipeline records, and the debugger surfaces that consume them.

<img width="1268" height="903" alt="image" src="https://github.com/user-attachments/assets/97f3644f-ee46-4513-a559-2653a39c941f" />

## Pipeline (`candidates.jsonl`)

- **`truth_pose`** — when truth exists, the truth affine scored as a synthetic candidate by the ladder's own machinery: new `rank_pose` = `evaluate_pose` evidence (verification, inlier_frac, ncc_fine, chamfer, name alignment) plus the same soft bonuses the search's candidates get (key-map region containment, directed-prior rotation residual), yielding a `select_score` directly comparable with theirs. The block runs after the prior ladder is final (demoted-seed prior included), so truth and candidates see the same priors. `SnapCandidate.select_score` now delegates to a shared `selection_score` (one formula, two callers), and the directed-residual computation is factored into `directed_prior_residual_sigma`.
- **`decision`** — the per-page trace: `path` (rescue / challenge), every applicable bar as `{rule, need, got, verdict}` (rescue: plausibility, stamp corroboration, select vs the effective gate, margin; fitted: the six challenge gates, the four refine gates, rung-flip; both: reconcile's entry bars), plus rules that can't be judged from one record listed as `skipped` with reasons (panel sheet agreement, the volume energy committee, printed-note rung ratios, the defensible-incumbent local-search collapse). `page_verdict` comes from the **real** rule functions (`select_argmax` / `arbitrate_challenge` / `refine_adoption` / `rung_flip`), so it cannot drift from production; the bars only explain it.

Verified against the 2026-08-28 baseline records (286 records, three volumes, no crashes): richmond p311 → `keep` failing exactly select 1.02 < 1.6, margin 0.046 < 0.25, name-parity 0.0 < 0.17; NO-1896 p125 → stamp-corroborated `rescue` at bar 0.8; fargo p17 → `refine` (69 ft agreement). End-to-end `rank_pose` smoke on the real richmond p311 context: truth verifies 0.116 / name 0.43 / select 0.68, with a 7σ rotation residual against the directed priors.

## Debugger

- The truth pose is a **`truth` row** in the candidate table (selectable, index −2, overlays its P(road) like any pose), replacing the phase-1 placeholder note.
- A one-line **verdict** classifies the page (`truthVerdict`): truth outscores every candidate → *search problem*; a candidate >200 ft from truth outscores it → *the evidence prefers an alias*; otherwise *agrees*.
- A collapsed **decision** `<details>` lists the bars as `✓/✗/– rule: need X, got Y (note)` plus the skipped rules.
- **θ and a new px/ft column for every row, incumbent included**, derived from each pose's `world_affine` (snap's own θ convention — `atan2(-a10, a00)`, the priors' angle — and working-frame px/ft, the page list's convention). This also corrects the θ column: a candidate's recorded `theta_deg` is the ladder *seed*, not the refined pose (richmond p365's C0/C1 seeds 12.6°/1.0° both converged to −5.2°, matching truth −4.9°); the seed now lives in the cell's tooltip.
- Fixed the `name` field's TS type (the pipeline writes `{score, n_labels, n_hits}`, not a number).

## Tests

Python: 8 new (decision traces for rescue accept/abstain/corroborated, challenge and refine agreeing with the rule functions, unsearched pages; `selection_score` parity with the candidate property; directed residual ignores the mod-180 rung). App: `truthVerdict` cases, parse round-trip, and a `react-dom/server` render test of the panel (truth row, verdict, decision lines, selection). Full suite: 1,081 Python tests, 241 app tests, pyright clean.

## Note on existing caches

`candidates_record_fresh` keys on input mtimes, so already-cached records don't gain the new fields until the page is recomputed (`mapsnap snap --recompute` or the next fresh baseline); the panel says so explicitly ("truth pose not scored in this record"). I chose not to force a corpus-wide recompute from a schema gate — that's a multi-hour surprise on the next incremental run — but it's a one-line change if you'd rather caches self-upgrade.

Also adds a short stage-3 paragraph to docs/fit-pipeline.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
