### PR TITLE
OCR re-reads failed large boxes via cross-orientation transfer

### DIFF
--- a/mapsnap/ctc_vocab_decode.py
+++ b/mapsnap/ctc_vocab_decode.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from functools import lru_cache
+from typing import Any
 
 import numpy as np
 
@@ -204,6 +205,14 @@ def generate_vocab_strings(normalized_streets: set[str]) -> list[str]:
 class TrieNode:
     children: dict[str, TrieNode] = field(default_factory=dict)
     is_end: bool = False
+
+
+# The TRUE originals of the functions patch_easyocr_reader replaces, stashed on
+# first patch. Re-patching happens on every vocabulary switch (several times per
+# page); wrapping the previous wrapper instead grew the call stack by one frame
+# per patch and crashed long OCR runs with RecursionError inside torch's LSTM
+# (found by the #144 A/B, where the transfer pass doubles the patch rate).
+_PATCH_ORIGINALS: dict[str, Any] = {}
 
 
 def build_trie(strings: list[str]) -> TrieNode:
@@ -429,10 +438,9 @@ def patch_easyocr_reader(
     # wrapper and the growing call stack eventually hits Python's recursion
     # limit mid-inference (observed at ~1,000 patches: RecursionError inside
     # torch's LSTM on the #144 A/B, where the transfer pass doubles the rate).
-    original_predict = getattr(_recog, "_mapsnap_original_recognizer_predict", None)
-    if original_predict is None:
-        original_predict = _recog.recognizer_predict
-        _recog._mapsnap_original_recognizer_predict = original_predict
+    original_predict = _PATCH_ORIGINALS.setdefault(
+        "recognizer_predict", _recog.recognizer_predict
+    )
 
     def _patched_recognizer_predict(
         model,
@@ -525,10 +533,9 @@ def patch_easyocr_reader(
     import easyocr.utils as _eu
     from easyocr.recognition import get_text as _get_text
 
-    original_recognize = getattr(easyocr.Reader, "_mapsnap_original_recognize", None)
-    if original_recognize is None:
-        original_recognize = easyocr.Reader.recognize
-        easyocr.Reader._mapsnap_original_recognize = original_recognize
+    original_recognize = _PATCH_ORIGINALS.setdefault(
+        "recognize", easyocr.Reader.recognize
+    )
 
     def _patched_recognize(
         self,

--- a/mapsnap/ctc_vocab_decode.py
+++ b/mapsnap/ctc_vocab_decode.py
@@ -424,7 +424,15 @@ def patch_easyocr_reader(
     trie_root = build_trie(vocab_strings)
     char_list: list[str] = reader.converter.character
 
-    original_predict = _recog.recognizer_predict
+    # Re-patching happens on every vocabulary switch (several times per page).
+    # Wrap the TRUE original, stashed once, or each call would nest another
+    # wrapper and the growing call stack eventually hits Python's recursion
+    # limit mid-inference (observed at ~1,000 patches: RecursionError inside
+    # torch's LSTM on the #144 A/B, where the transfer pass doubles the rate).
+    original_predict = getattr(_recog, "_mapsnap_original_recognizer_predict", None)
+    if original_predict is None:
+        original_predict = _recog.recognizer_predict
+        _recog._mapsnap_original_recognizer_predict = original_predict
 
     def _patched_recognizer_predict(
         model,
@@ -517,7 +525,10 @@ def patch_easyocr_reader(
     import easyocr.utils as _eu
     from easyocr.recognition import get_text as _get_text
 
-    original_recognize = easyocr.Reader.recognize
+    original_recognize = getattr(easyocr.Reader, "_mapsnap_original_recognize", None)
+    if original_recognize is None:
+        original_recognize = easyocr.Reader.recognize
+        easyocr.Reader._mapsnap_original_recognize = original_recognize
 
     def _patched_recognize(
         self,

--- a/mapsnap/ctc_vocab_decode_test.py
+++ b/mapsnap/ctc_vocab_decode_test.py
@@ -1,5 +1,7 @@
 """Tests for ctc_vocab_decode helpers."""
 
+from typing import ClassVar
+
 import numpy as np
 
 from mapsnap.ctc_vocab_decode import (
@@ -290,22 +292,22 @@ def test_patch_easyocr_reader_is_idempotent_across_vocab_switches():
     import easyocr
     import easyocr.recognition as _recog
 
-    from mapsnap.ctc_vocab_decode import patch_easyocr_reader
+    from mapsnap.ctc_vocab_decode import _PATCH_ORIGINALS, patch_easyocr_reader
 
     class FakeConverter:
-        character = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ ")
+        character: ClassVar[list[str]] = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ ")
 
     class FakeReader:
         converter = FakeConverter()
 
     for i in range(50):
         patch_easyocr_reader(FakeReader(), ["MAIN", f"ELM{i}"], beam_width=5)
-    stash = _recog._mapsnap_original_recognizer_predict
+    stash = _PATCH_ORIGINALS["recognizer_predict"]
     assert stash.__name__ == "recognizer_predict"
     # The live patched function wraps the stash directly (depth 1, not 50).
     cells = [c.cell_contents for c in _recog.recognizer_predict.__closure__ or []]
     assert stash in cells
-    stash_rec = easyocr.Reader._mapsnap_original_recognize
+    stash_rec = _PATCH_ORIGINALS["recognize"]
     assert stash_rec.__name__ == "recognize"
     cells = [c.cell_contents for c in easyocr.Reader.recognize.__closure__ or []]
     assert stash_rec in cells

--- a/mapsnap/ctc_vocab_decode_test.py
+++ b/mapsnap/ctc_vocab_decode_test.py
@@ -281,3 +281,31 @@ def test_ctc_empty_sequence_returns_empty():
     text, prob = prefix_constrained_ctc(mat, trie, _CHARS, beam_width=10)
     assert text == ""
     assert prob == 0.0
+
+
+def test_patch_easyocr_reader_is_idempotent_across_vocab_switches():
+    # Re-patching per vocabulary switch must wrap the TRUE original, not the
+    # previous wrapper: nesting grew the call stack by one frame per patch and
+    # crashed long OCR runs with RecursionError (found by the #144 A/B).
+    import easyocr
+    import easyocr.recognition as _recog
+
+    from mapsnap.ctc_vocab_decode import patch_easyocr_reader
+
+    class FakeConverter:
+        character = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ ")
+
+    class FakeReader:
+        converter = FakeConverter()
+
+    for i in range(50):
+        patch_easyocr_reader(FakeReader(), ["MAIN", f"ELM{i}"], beam_width=5)
+    stash = _recog._mapsnap_original_recognizer_predict
+    assert stash.__name__ == "recognizer_predict"
+    # The live patched function wraps the stash directly (depth 1, not 50).
+    cells = [c.cell_contents for c in _recog.recognizer_predict.__closure__ or []]
+    assert stash in cells
+    stash_rec = easyocr.Reader._mapsnap_original_recognize
+    assert stash_rec.__name__ == "recognize"
+    cells = [c.cell_contents for c in easyocr.Reader.recognize.__closure__ or []]
+    assert stash_rec in cells

--- a/mapsnap/detect_text.py
+++ b/mapsnap/detect_text.py
@@ -639,7 +639,11 @@ TRANSFER_MIN_ASPECT = 2.0
 # A read at or above this confidence needs no help.
 TRANSFER_CONFIDENT = 0.3
 # Transferred reads below this are junk splits of titles/legends; drop them.
-TRANSFER_FLOOR = 0.2
+# 0.5, not lower: the NO-1896 A/B's one damaging read was a 0.49-confidence
+# ORLEANS fragment whose name/rotation-prior contributions spawned a snap alias
+# that suppressed p162's refinement (15.7 -> 55.5 ft); every reviewed win
+# (TILLARY, HAMMOND, TENNESSEE, THALIA, BRIDGE) reads at 0.64+.
+TRANSFER_FLOOR = 0.5
 # Same-text overlap dedupe: within this confidence delta the EXISTING read wins,
 # so a transferred twin of a read we already had is never flagged as new.
 TRANSFER_TIE = 0.02

--- a/mapsnap/detect_text.py
+++ b/mapsnap/detect_text.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 
 from mapsnap.ctc_vocab_decode import HINT_STRINGS, generate_vocab_strings
 from mapsnap.keymap.locate import KeymapLocator, page_key, resolve_keymaps
+from mapsnap.panel_boxes import rotate_point, unrotate_point
 from mapsnap.streets import build_block_index, polygon_side_lengths
 from mapsnap.utils import default_centerlines, image_stem
 
@@ -620,6 +621,297 @@ def _merge_vocab_passes(primary: list[dict], fallback: list[dict]) -> list[dict]
     return merged
 
 
+# --- Cross-orientation box transfer (#144) -----------------------------------
+#
+# CRAFT segments the same text differently at 0/90/270: the natural orientation
+# can cut a word in half (brooklyn v2 p19 TILLARY), glom it with an adjacency
+# stamp (richmond p365 "373 HAMMOND"), or attach a prefix that poisons the
+# constrained decode (detroit p85 "S. TENNESSEE"). When a LARGE box fails to
+# read, the other orientations' differently-segmented footprints are re-read in
+# the frame where the text is upright, and the failing footprint itself is
+# re-read in the other frames. Transferred reads are flagged ``transferred``
+# (with ``transfer_kind`` and ``transfer_source_angle``) for downstream use.
+
+# A trigger box is at least this long and this wide-to-tall in its own frame
+# (TILLARY's polygon is 111x55, "S. TENNESSEE" 92x24).
+TRANSFER_MIN_LONG = 80
+TRANSFER_MIN_ASPECT = 2.0
+# A read at or above this confidence needs no help.
+TRANSFER_CONFIDENT = 0.3
+# Transferred reads below this are junk splits of titles/legends; drop them.
+TRANSFER_FLOOR = 0.2
+# Same-text overlap dedupe: within this confidence delta the EXISTING read wins,
+# so a transferred twin of a read we already had is never flagged as new.
+TRANSFER_TIE = 0.02
+
+
+def reading_order(quad: list) -> list[list[int]]:
+    """Order a quad [tl, tr, br, bl] with tl->tr along its long axis, left to right.
+
+    EasyOCR's four_point_transform takes the FIRST edge as the crop width, so a
+    quad rotated into another frame must be re-ordered or the warped crop comes
+    out sideways/mirrored (TILLARY read 'E' until this).
+    """
+    pts = [(float(x), float(y)) for x, y in quad]
+    cx = sum(q[0] for q in pts) / 4
+    cy = sum(q[1] for q in pts) / 4
+    e0 = (pts[1][0] - pts[0][0], pts[1][1] - pts[0][1])
+    e1 = (pts[2][0] - pts[1][0], pts[2][1] - pts[1][1])
+    ux, uy = e0 if math.hypot(*e0) >= math.hypot(*e1) else e1
+    norm = math.hypot(ux, uy) or 1.0
+    ux, uy = ux / norm, uy / norm
+    if ux < 0 or (ux == 0 and uy < 0):
+        ux, uy = -ux, -uy
+    nx, ny = -uy, ux
+    proj = [
+        ((q[0] - cx) * ux + (q[1] - cy) * uy, (q[0] - cx) * nx + (q[1] - cy) * ny, q)
+        for q in pts
+    ]
+    top = sorted([q for q in proj if q[1] < 0], key=lambda q: q[0])
+    bottom = sorted([q for q in proj if q[1] >= 0], key=lambda q: q[0])
+    if len(top) != 2:
+        return [[int(v) for v in q] for q in pts]
+    return [
+        [int(v) for v in top[0][2]],
+        [int(v) for v in top[1][2]],
+        [int(v) for v in bottom[1][2]],
+        [int(v) for v in bottom[0][2]],
+    ]
+
+
+def _page_bbox(pts: list, angle: int, width: int, height: int) -> tuple:
+    rw, rh = (width, height) if angle == 0 else (height, width)
+    cs = [unrotate_point(x, y, angle, rw, rh) for x, y in pts]
+    xs = [c[0] for c in cs]
+    ys = [c[1] for c in cs]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def _bbox_inter(a: tuple, b: tuple) -> float:
+    return max(0.0, min(a[2], b[2]) - max(a[0], b[0])) * max(
+        0.0, min(a[3], b[3]) - max(a[1], b[1])
+    )
+
+
+def _bbox_area(a: tuple) -> float:
+    return max(1.0, (a[2] - a[0]) * (a[3] - a[1]))
+
+
+def _bbox_iou(a: tuple, b: tuple) -> float:
+    i = _bbox_inter(a, b)
+    return i / (_bbox_area(a) + _bbox_area(b) - i) if i else 0.0
+
+
+def transfer_candidates(
+    angle_boxes: list[dict], detections: list[dict], width: int, height: int
+) -> tuple[list[dict], list[dict]]:
+    """Cross-orientation footprints to re-read, as angle_boxes-shaped additions.
+
+    A trigger is a large wide box in its own frame whose best read is below
+    TRANSFER_CONFIDENT. For each trigger the OTHER orientations' clean
+    split/merge footprints join the trigger's frame, and the trigger's own
+    footprint joins the other frames (horizontal boxes as rotated bboxes,
+    free polygons as reading-ordered quads). Returns (additions, provenance);
+    each provenance record carries the target angle, page-frame bbox,
+    transfer kind and source angle.
+    """
+    best_conf: dict[tuple, float] = {}
+    for det in detections:
+        xs = [p[0] for p in det["polygon"]]
+        ys = [p[1] for p in det["polygon"]]
+        key = (
+            det["angle"],
+            round(min(xs)),
+            round(min(ys)),
+            round(max(xs)),
+            round(max(ys)),
+        )
+        best_conf[key] = max(best_conf.get(key, 0.0), det["confidence"])
+    items: dict[int, list] = {}
+    for angle_data in angle_boxes:
+        angle = angle_data["angle"]
+        rw, rh = (width, height) if angle == 0 else (height, width)
+        entries = []
+        for x0, x1, y0, y1 in angle_data["horizontal_list"]:
+            pts = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+            entries.append(
+                (
+                    "h",
+                    _page_bbox(pts, angle, width, height),
+                    [unrotate_point(x, y, angle, rw, rh) for x, y in pts],
+                    x1 - x0,
+                    y1 - y0,
+                )
+            )
+        for poly in angle_data["free_list"]:
+            xs = [p[0] for p in poly]
+            ys = [p[1] for p in poly]
+            entries.append(
+                (
+                    "f",
+                    _page_bbox(poly, angle, width, height),
+                    [unrotate_point(x, y, angle, rw, rh) for x, y in poly],
+                    max(xs) - min(xs),
+                    max(ys) - min(ys),
+                )
+            )
+        items[angle] = entries
+    additions: dict[int, dict] = {
+        a: {"angle": a, "horizontal_list": [], "free_list": []} for a in items
+    }
+    provenance: list[dict] = []
+
+    def add(
+        target_angle: int,
+        kind: str,
+        page_box: tuple,
+        page_pts: list,
+        why: str,
+        source_angle: int,
+    ) -> None:
+        for _, q, _, _, _ in items[target_angle]:
+            if _bbox_iou(page_box, q) > 0.8:
+                return
+        for record in provenance:
+            if (
+                record["angle"] == target_angle
+                and _bbox_iou(page_box, record["page_bbox"]) > 0.8
+            ):
+                return
+        if kind == "h":
+            cs = [
+                rotate_point(x, y, target_angle, width, height)
+                for x, y in (
+                    (page_box[0], page_box[1]),
+                    (page_box[2], page_box[1]),
+                    (page_box[2], page_box[3]),
+                    (page_box[0], page_box[3]),
+                )
+            ]
+            xs = [c[0] for c in cs]
+            ys = [c[1] for c in cs]
+            additions[target_angle]["horizontal_list"].append(
+                [int(min(xs)), int(max(xs)), int(min(ys)), int(max(ys))]
+            )
+        else:
+            additions[target_angle]["free_list"].append(
+                reading_order(
+                    [
+                        rotate_point(x, y, target_angle, width, height)
+                        for x, y in page_pts
+                    ]
+                )
+            )
+        provenance.append(
+            {
+                "angle": target_angle,
+                "page_bbox": tuple(page_box),
+                "kind": why,
+                "source_angle": source_angle,
+            }
+        )
+
+    for angle, entries in items.items():
+        for kind, page_box, page_pts, w, h in entries:
+            if w < TRANSFER_MIN_LONG or w < TRANSFER_MIN_ASPECT * h:
+                continue
+            key = (
+                angle,
+                round(page_box[0]),
+                round(page_box[1]),
+                round(page_box[2]),
+                round(page_box[3]),
+            )
+            if best_conf.get(key, 0.0) >= TRANSFER_CONFIDENT:
+                continue
+            for other in items:
+                if other != angle:
+                    add(other, kind, page_box, page_pts, "footprint", angle)
+            for other, other_entries in items.items():
+                if other == angle:
+                    continue
+                for kind2, q, pts2, _, _ in other_entries:
+                    overlap = _bbox_inter(page_box, q)
+                    if not overlap:
+                        continue
+                    if (
+                        overlap >= 0.9 * _bbox_area(q)
+                        and 0.25 <= _bbox_area(q) / _bbox_area(page_box) <= 0.75
+                    ):
+                        add(angle, kind2, q, pts2, "split", other)
+                    elif (
+                        overlap >= 0.9 * _bbox_area(page_box)
+                        and 0.4 <= _bbox_area(page_box) / _bbox_area(q) <= 0.9
+                    ):
+                        add(angle, kind2, q, pts2, "merge", other)
+    filled = [
+        additions[a]
+        for a in additions
+        if additions[a]["horizontal_list"] or additions[a]["free_list"]
+    ]
+    return filled, provenance
+
+
+def merge_transferred(
+    detections: list[dict], transferred: list[dict], provenance: list[dict]
+) -> list[dict]:
+    """Merge transfer-pass reads into the main detections with dedupe.
+
+    Every transfer-pass read is flagged and given its provenance (matched by
+    page-frame IoU). Reads below TRANSFER_FLOOR are dropped. Same-text
+    overlapping pairs involving a transferred read keep the higher confidence,
+    with a TRANSFER_TIE margin preferring the existing read.
+    """
+
+    def bbox(det: dict) -> tuple:
+        xs = [p[0] for p in det["polygon"]]
+        ys = [p[1] for p in det["polygon"]]
+        return (min(xs), min(ys), max(xs), max(ys))
+
+    kept = []
+    for det in transferred:
+        if det["confidence"] < TRANSFER_FLOOR:
+            continue
+        det["transferred"] = True
+        rb = bbox(det)
+        for record in provenance:
+            if (
+                record["angle"] == det["angle"]
+                and _bbox_iou(rb, record["page_bbox"]) >= 0.5
+            ):
+                det["transfer_kind"] = record["kind"]
+                det["transfer_source_angle"] = record["source_angle"]
+                break
+        kept.append(det)
+    merged = detections + kept
+    drop: set[int] = set()
+    for i, a in enumerate(merged):
+        for j in range(i + 1, len(merged)):
+            b = merged[j]
+            if not a.get("transferred") and not b.get("transferred"):
+                continue
+            text = a["text"].strip().upper()
+            if not text or text != b["text"].strip().upper():
+                continue
+            ba, bb = bbox(a), bbox(b)
+            ca = ((ba[0] + ba[2]) / 2, (ba[1] + ba[3]) / 2)
+            cb = ((bb[0] + bb[2]) / 2, (bb[1] + bb[3]) / 2)
+            touching = (
+                _bbox_iou(ba, bb) >= 0.2
+                or (bb[0] <= ca[0] <= bb[2] and bb[1] <= ca[1] <= bb[3])
+                or (ba[0] <= cb[0] <= ba[2] and ba[1] <= cb[1] <= ba[3])
+            )
+            if not touching:
+                continue
+            if abs(a["confidence"] - b["confidence"]) < TRANSFER_TIE and a.get(
+                "transferred"
+            ) != b.get("transferred"):
+                drop.add(i if a.get("transferred") else j)
+            else:
+                drop.add(j if a["confidence"] >= b["confidence"] else i)
+    return [d for k, d in enumerate(merged) if k not in drop]
+
+
 def detect_text(
     image_path: str,
     vocab_strings: list[str],
@@ -632,6 +924,7 @@ def detect_text(
     craft_scale: float = 1.0,
     tile_size: int = 2560,
     fallback_vocab: list[str] | None = None,
+    transfer: bool = True,
 ) -> list[dict]:
     """Run CRAFT-based text detection at 0°, 90°, and 270° and return all results.
 
@@ -730,6 +1023,31 @@ def detect_text(
     all_detections = recognize(vocab_strings)
     if fallback_vocab is not None:
         all_detections = _merge_vocab_passes(all_detections, recognize(fallback_vocab))
+    if transfer:
+        # Cross-orientation transfer (#144): re-read failed large boxes with the
+        # other orientations' segmentation, through the same vocab passes.
+        additions, provenance = transfer_candidates(
+            angle_boxes, all_detections, orig_width, orig_height
+        )
+        if additions:
+
+            def recognize_added(vocab: list[str]) -> list[dict]:
+                return _recognize_pass(
+                    reader,
+                    img,
+                    additions,
+                    vocab=vocab,
+                    beam_width=beam_width,
+                    allowlist=allowlist,
+                    min_long_side=min_long_side,
+                    orig_width=orig_width,
+                    orig_height=orig_height,
+                )
+
+            extra = recognize_added(vocab_strings)
+            if fallback_vocab is not None:
+                extra = _merge_vocab_passes(extra, recognize_added(fallback_vocab))
+            all_detections = merge_transferred(all_detections, extra, provenance)
 
     for det in all_detections:
         pts = np.array(det["polygon"], dtype=float)
@@ -775,6 +1093,7 @@ def _worker_init(
     tile_size: int,
     gpu: bool,
     recognizer_weights: str | None,
+    transfer: bool = True,
 ) -> None:
     """Initialize per-worker state once per process: create the EasyOCR reader."""
     _worker_state["reader"] = easyocr.Reader(["en"], gpu=gpu, verbose=False)
@@ -788,6 +1107,7 @@ def _worker_init(
     _worker_state["beam_width"] = beam_width
     _worker_state["craft_scale"] = craft_scale
     _worker_state["tile_size"] = tile_size
+    _worker_state["transfer"] = transfer
 
 
 def _process_image(image_path: str) -> str:
@@ -803,6 +1123,7 @@ def _process_image(image_path: str) -> str:
         beam_width=_worker_state["beam_width"],
         craft_scale=_worker_state["craft_scale"],
         tile_size=_worker_state["tile_size"],
+        transfer=_worker_state["transfer"],
     )
     return image_path
 
@@ -913,6 +1234,15 @@ def main() -> None:
             "Do not use key maps. By default, when --keymap is not given, key-map detections "
             "files (<stem>.keymap.json with a sibling .georef.json) next to the images or under "
             "raw/ are discovered and used automatically; this flag turns that off."
+        ),
+    )
+    parser.add_argument(
+        "--no-transfer",
+        action="store_true",
+        help=(
+            "Disable the cross-orientation box transfer (#144): failed large boxes "
+            "are normally re-read using the other CRAFT orientations' segmentation. "
+            "For A/B controls and debugging."
         ),
     )
     parser.add_argument(
@@ -1126,6 +1456,7 @@ def main() -> None:
             args.tile_size,
             gpu,
             args.recognizer_weights,
+            not args.no_transfer,
         )
         with multiprocessing.Pool(
             args.num_workers,
@@ -1158,6 +1489,7 @@ def main() -> None:
                 craft_scale=args.craft_scale,
                 tile_size=args.tile_size,
                 fallback_vocab=fallback_vocab,
+                transfer=not args.no_transfer,
             )
 
 

--- a/mapsnap/detect_text_test.py
+++ b/mapsnap/detect_text_test.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from mapsnap.detect_text import (
     NON_STREET_TEXT,
+    TRANSFER_FLOOR,
     _axis_starts,
     _iou_xxyy,
     _iter_tiles,
@@ -15,9 +16,12 @@ from mapsnap.detect_text import (
     filter_args,
     has_split_panels,
     lab_to_hex,
+    merge_transferred,
     page_lab,
     page_vocabs,
+    reading_order,
     region_color,
+    transfer_candidates,
 )
 from mapsnap.keymap.locate import KeymapLocator
 from mapsnap.streets import (
@@ -563,3 +567,152 @@ def test_resume_skips_only_reads_from_the_same_recognizer(tmp_path):
     assert not reads_are_current(tuned, None)
     # A page with no read at all is always due.
     assert not reads_are_current(tmp_path / "missing.streets.json", None)
+
+
+# --- cross-orientation transfer (#144) ---------------------------------------
+
+
+def test_reading_order_puts_the_long_axis_first_left_to_right():
+    # A diagonal quad listed short-edge-first (as CRAFT does for TILLARY).
+    quad = [[100, 107], [124, 100], [155, 203], [131, 210]]
+    tl, tr, br, bl = reading_order(quad)
+    # The first edge is the long axis and runs left to right.
+    assert (tr[0] - tl[0]) ** 2 + (tr[1] - tl[1]) ** 2 > (bl[0] - tl[0]) ** 2 + (
+        bl[1] - tl[1]
+    ) ** 2
+    assert tr[0] > tl[0]
+    assert sorted(map(tuple, [tl, tr, br, bl])) == sorted(map(tuple, quad))
+
+
+def angle_boxes_fixture() -> list[dict]:
+    # 0deg: one large wide box (a glommed label) and one confident-read box.
+    # 90deg: a clean sub-piece of the large box (the split that reads).
+    return [
+        {
+            "angle": 0,
+            "horizontal_list": [[100, 300, 100, 140], [400, 500, 100, 124]],
+            "free_list": [],
+        },
+        {"angle": 90, "horizontal_list": [[100, 132, 700, 850]], "free_list": []},
+        {"angle": 270, "horizontal_list": [], "free_list": []},
+    ]
+
+
+def test_transfer_candidates_fires_on_the_failing_box_only():
+    width = height = 1000
+    detections = [
+        # The large box read poorly...
+        {
+            "polygon": [[100, 100], [300, 100], [300, 140], [100, 140]],
+            "text": "13TH",
+            "confidence": 0.01,
+            "angle": 0,
+        },
+        # ...the small box read confidently.
+        {
+            "polygon": [[400, 100], [500, 100], [500, 124], [400, 124]],
+            "text": "MAIN",
+            "confidence": 0.99,
+            "angle": 0,
+        },
+    ]
+    additions, provenance = transfer_candidates(
+        angle_boxes_fixture(), detections, width, height
+    )
+    kinds = {(r["angle"], r["kind"]) for r in provenance}
+    # The failing footprint is re-read in the other frames, and the 90deg
+    # sub-piece (page bbox (150,100)-(300,132), 47% of the big box) joins 0deg.
+    assert (90, "footprint") in kinds and (270, "footprint") in kinds
+    assert (0, "split") in kinds
+    # The confident box triggers nothing of its own.
+    assert not any(r["page_bbox"][0] == 400 for r in provenance)
+
+
+def test_transfer_candidates_quiet_when_reads_are_confident():
+    detections = [
+        {
+            "polygon": [[100, 100], [300, 100], [300, 140], [100, 140]],
+            "text": "ELM",
+            "confidence": 0.9,
+            "angle": 0,
+        },
+        {
+            "polygon": [[400, 100], [500, 100], [500, 124], [400, 124]],
+            "text": "MAIN",
+            "confidence": 0.99,
+            "angle": 0,
+        },
+    ]
+    additions, provenance = transfer_candidates(
+        angle_boxes_fixture(), detections, 1000, 1000
+    )
+    assert additions == [] and provenance == []
+
+
+def test_merge_transferred_dedupes_and_floors():
+    existing = [
+        {
+            "polygon": [[0, 0], [100, 0], [100, 20], [0, 20]],
+            "text": "STATE",
+            "confidence": 0.29,
+            "angle": 270,
+        },
+        {
+            "polygon": [[500, 0], [600, 0], [600, 20], [500, 20]],
+            "text": "OAK",
+            "confidence": 1.0,
+            "angle": 0,
+        },
+    ]
+    provenance = [
+        {
+            "angle": 270,
+            "page_bbox": (0, 0, 100, 20),
+            "kind": "footprint",
+            "source_angle": 90,
+        },
+        {
+            "angle": 0,
+            "page_bbox": (500, 0, 600, 20),
+            "kind": "split",
+            "source_angle": 90,
+        },
+        {
+            "angle": 0,
+            "page_bbox": (200, 0, 300, 20),
+            "kind": "split",
+            "source_angle": 90,
+        },
+    ]
+    transferred = [
+        # Better read of the same footprint: replaces the 0.29 original.
+        {
+            "polygon": [[0, 0], [100, 0], [100, 20], [0, 20]],
+            "text": "STATE",
+            "confidence": 0.93,
+            "angle": 270,
+        },
+        # Near-tie twin of a confident existing read: the original wins.
+        {
+            "polygon": [[500, 0], [600, 0], [600, 20], [500, 20]],
+            "text": "OAK",
+            "confidence": 0.995,
+            "angle": 0,
+        },
+        # Below the floor: dropped.
+        {
+            "polygon": [[200, 0], [300, 0], [300, 20], [200, 20]],
+            "text": "JUNK",
+            "confidence": 0.1,
+            "angle": 0,
+        },
+    ]
+    merged = merge_transferred(existing, transferred, provenance)
+    by_text = {d["text"]: d for d in merged}
+    assert len(merged) == 2
+    assert by_text["STATE"]["confidence"] == 0.93
+    assert by_text["STATE"]["transferred"] is True
+    assert by_text["STATE"]["transfer_kind"] == "footprint"
+    assert by_text["STATE"]["transfer_source_angle"] == 90
+    assert "transferred" not in by_text["OAK"]
+    assert 0.1 < TRANSFER_FLOOR

--- a/mapsnap/detect_text_test.py
+++ b/mapsnap/detect_text_test.py
@@ -619,6 +619,9 @@ def test_transfer_candidates_fires_on_the_failing_box_only():
     additions, provenance = transfer_candidates(
         angle_boxes_fixture(), detections, width, height
     )
+    # The additions are angle_boxes-shaped and carry the transferred footprints.
+    assert {a["angle"] for a in additions} == {0, 90, 270}
+    assert all(a["horizontal_list"] or a["free_list"] for a in additions)
     kinds = {(r["angle"], r["kind"]) for r in provenance}
     # The failing footprint is re-read in the other frames, and the 90deg
     # sub-piece (page bbox (150,100)-(300,132), 47% of the big box) joins 0deg.


### PR DESCRIPTION
Implements #144. CRAFT segments the same text differently at 0°/90°/270°, and the recognizer only ever reads each orientation's own boxes — so when the natural orientation cuts a word in half (brooklyn v2 p19 TILLARY), gloms it with an adjacency stamp (richmond p365 "373 HAMMOND"), or attaches a poisoning prefix (detroit p85 "S. TENNESSEE"), the label is lost even though another orientation segmented it correctly.

## The transfer pass

After the normal primary+fallback vocab passes, any **large wide box** (≥80 px, aspect ≥2 in its own frame) whose best read is **below 0.3**:
- has the *other* orientations' clean **split/merge** footprints re-read in its frame, and
- has its own footprint re-read in the other frames,

through the same primary+fallback vocab structure. Horizontal boxes transfer as rotated bboxes; free polygons as **reading-ordered quads** (EasyOCR's `four_point_transform` takes the first edge as the crop width, so rotated quads must be re-ordered or the crop comes out mirrored — TILLARY read `'E'` until this). Quads keep the true label orientation in the output polygon (`dir_pix` 1.29 rad for the diagonal TILLARY), which georef needs.

Transferred reads are flagged `transferred` / `transfer_kind` (footprint|split|merge) / `transfer_source_angle`, floored at 0.2 confidence, and deduped: same-text overlapping pairs keep the higher confidence, with near-ties (<0.02) preferring the existing read so a transferred twin never masquerades as new. `--no-transfer` disables the pass (A/B control, debugging).

## Evidence so far (10-page before/after sample, reviewed)

Pickups: TILLARY@1.00, HAMMOND@1.00, TENNESSEE@1.00, THALIA@0.64 (possibly fit-critical for NO-1896 p119), BRIDGE@0.95, ST@1.00. Residual noise: pipe annotations (`S W PIPE`/`EW PIPE`), `PRESS`×2, and city/title words via the **fallback vocab** (RICHMOND, CHICAGO, STATE) — a "no transferred reads from the fallback pass" gate would remove those, deliberately **not** included yet pending evidence of real damage (per review).

Unit tests: reading_order, trigger/footprint construction, merge/dedupe/floor semantics. Single-page CLI check: p365 with transfer gains exactly HAMMOND@1.00 + RICHMOND@0.82 flagged; `--no-transfer` output is unchanged production behavior.

## A/B status — two volumes, no win

| volume | control | transfer | delta |
|---|---|---|---|
| new_orleans_la_1896_vol_2 | 78.7 | 76.4 | −2.3 |
| richmond_va_1925_vol_3 | 83.2 | 82.0 | −1.2 |

Neither delta is caused by a bad read: NO-1896's two regressions are on pages whose reads are **byte-identical** between arms (snap coupled through a 0.2% shift in the volume-calibrated search radius), and Richmond's entire −1.2 is **one page moving 0.9 ft** (p377, 24.6 → 25.5) across the band line via RANSAC-consensus jitter.

The motivating rescue works and doesn't help: richmond p365 gains `HAMMOND`@1.00 as a 16th matched label (+6 intersections) and moves **9.9 → 10.7 ft** — it already had 15 inliers. Across ~230 transferred reads on two volumes, no page's fit materially improved.

**Not merging as default-on.** The promising variant is to gate transfer on **label-starved pages** (<5 matched labels or <2 intersections), where a recovered street can actually change the outcome — see the Richmond comment for the full argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

