### PR TITLE
Log admitted street reads that match no street name

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -3147,6 +3147,7 @@ def prepare_label_features(
                 file=sys.stderr,
             )
     labels_data = []
+    unmatched: list[dict] = []
     for det in all_detections:
         is_promoted = det.get("promoted")
         if is_promoted:
@@ -3175,6 +3176,15 @@ def prepare_label_features(
             ):
                 continue
         canonicals = canonical_street_matches(det["text"], normalized_streets)
+        if not canonicals:
+            # The one drop in this function that would otherwise leave no trace: the loop
+            # below is simply a no-op, and "Filtered detections" counts what survived
+            # canonicalization, so the loss does not show up as a delta either. A confident,
+            # gate-passing read that names no known street is worth seeing -- it is usually
+            # a name the centerlines carry under an unstrippable leading word ("JOHNSTON"
+            # for Nashville's Jo Johnston Avenue), which no later stage can recover (#373).
+            unmatched.append(det)
+            continue
         # Deduplicate by block-list identity: aliases like "HENRY" and "HENRY STREET"
         # map to the *same list object* in block_index (set by build_block_index), so
         # id() detects them as duplicates and keeps only the longest (most specific) name.
@@ -3193,6 +3203,16 @@ def prepare_label_features(
             else:
                 entry = det
             labels_data.append(entry)
+
+    if unmatched:
+        print(
+            f"Dropped {len(unmatched)} admitted detection(s) matching no street: "
+            + ", ".join(
+                f"{d['text']}({d.get('short_side', 0):.0f}px,{d.get('confidence', 0):.2f})"
+                for d in unmatched
+            ),
+            file=sys.stderr,
+        )
 
     print(f"Filtered detections: {len(labels_data)}")
 

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1978,3 +1978,81 @@ def test_cluster_gcp_hints_ranks_consistent_cluster_first():
     # Largest cluster (the 3 near points) first, its median inside the group.
     assert abs(hints[0][0] - -96.0001) < 1e-3 and abs(hints[0][1] - 46.0002) < 1e-3
     assert cluster_gcp_hints([]) == []
+
+
+def _street_block_index(names: list[str]) -> dict[str, list[Block]]:
+    """A block_index keyed by normalized street name, one throwaway block per street."""
+    return {
+        name: [
+            Block(street_name=name, coords=np.array([(-86.8, 36.16), (-86.79, 36.16)]))
+        ]
+        for name in names
+    }
+
+
+def test_prepare_label_features_logs_reads_that_match_no_street(tmp_path, capsys):
+    """A confident, gate-passing read naming no known street is reported, not dropped silently.
+
+    Nashville p24's "JOHNSTON" (conf 1.000) names Jo Johnston Avenue, whose leading "JO" the
+    prefix-anchored matcher cannot strip. It cleared every gate and then vanished with no log
+    line at all, because the canonicalization loop is simply a no-op on an empty match list
+    and "Filtered detections" counts what survived it (#373).
+    """
+    from mapsnap.georef_from_labels import prepare_label_features
+
+    labels_path = tmp_path / "p24.streets.json"
+    _write_streets_json(
+        labels_path,
+        [
+            _make_det(
+                "CHARLOTTE", 400, 1700, long_side=118.0, short_side=24.0, confidence=1.0
+            ),
+            _make_det(
+                "JOHNSTON", 900, 180, long_side=118.0, short_side=24.0, confidence=1.0
+            ),
+        ],
+    )
+    block_index = _street_block_index(["CHARLOTTE AVENUE", "JO JOHNSTON AVENUE"])
+
+    features = prepare_label_features(
+        str(labels_path),
+        block_index,
+        (1650, 2010),
+        min_confidence=0.5,
+        min_short_side=20.0,
+        min_long_side=40.0,
+        min_aspect_ratio=1.0,
+    )
+
+    assert [f.text for f in features] == ["CHARLOTTE AVENUE"]
+    err = capsys.readouterr().err
+    assert (
+        "Dropped 1 admitted detection(s) matching no street: JOHNSTON(24px,1.00)" in err
+    )
+
+
+def test_prepare_label_features_stays_quiet_when_every_read_matches(tmp_path, capsys):
+    """No line when there is nothing to report -- the log fires per page, so silence matters."""
+    from mapsnap.georef_from_labels import prepare_label_features
+
+    labels_path = tmp_path / "p25.streets.json"
+    _write_streets_json(
+        labels_path,
+        [
+            _make_det(
+                "CHARLOTTE", 400, 1700, long_side=118.0, short_side=24.0, confidence=1.0
+            )
+        ],
+    )
+
+    prepare_label_features(
+        str(labels_path),
+        _street_block_index(["CHARLOTTE AVENUE"]),
+        (1650, 2010),
+        min_confidence=0.5,
+        min_short_side=20.0,
+        min_long_side=40.0,
+        min_aspect_ratio=1.0,
+    )
+
+    assert "matching no street" not in capsys.readouterr().err


### PR DESCRIPTION
`prepare_label_features` drops a detection at canonicalization by letting the `for canonical in sorted(canonicals, ...)` loop no-op on an empty match list. It is the only drop path in the function that prints nothing, and the loss is invisible in the counts too — `Filtered detections` is measured *after* canonicalization, so there is no delta to notice.

Nashville p24 is the case that surfaced it. A confidence-1.000 `JOHNSTON` read clears the hint split, assembly, dedup, the coloured-fill drop and the admission gate, then disappears with no mention anywhere in `p24.txt`:

```
Deduped detections: 45
Dropped 6 detection(s) on coloured fill
Filtered detections: 7          <- JOHNSTON went missing somewhere in here
```

It names Jo Johnston Avenue, whose leading `JO` the prefix-anchored matcher cannot strip. Reconstructing that took re-running the pipeline by hand against the sidecar.

After, on the same page:

```
Dropped 5 detection(s) on coloured fill; street-matching: 5 TH, 7TH ST, HUME, POLK
Dropped 1 admitted detection(s) matching no street: JOHNSTON(24px,1.00)
```

Format follows the neighbouring coloured-fill and collinear-dominated drop logs (text, short side, confidence).

**Log volume.** Printed unconditionally rather than behind `--debug`, because it is rare: measured over Nashville 1957 v1a (71 pages) and DC 1916 v2 (149 pages), the median page has **0** such reads, p90 is **2**, worst page **6**. Silence is the normal case, so a line is a real signal.

**Scope.** Diagnostic only — which reads are accepted is unchanged, and no artifact or metric moves. What to do about the matching itself is #373, which this makes self-reporting: the ~115 genuine misses that scan found across six volumes will now name themselves in the page logs instead of needing a corpus script to find.

Two tests: the p24 shape (one matching read, one not) asserts the line and that only the matching read becomes a feature; a second asserts silence when every read matches.
