### PR TITLE
Compare tables name both the truth page and the generated page

### DIFF
--- a/app/server/compareTxt.test.ts
+++ b/app/server/compareTxt.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  hasTwoPageColumns,
   parseCompareFooter,
   parseCompareTxt,
   parseLandByPage,
+  parseMissingTruthKeys,
 } from './compareTxt.ts';
 
 const HEADER =
@@ -118,5 +120,69 @@ describe('land columns', () => {
     expect(
       parseLandByPage([oldHeader, '-'.repeat(100), oldRow].join('\n')),
     ).toBeNull();
+  });
+});
+
+// The two-key layout (#267): page_truth and page_gen lead every row. Rows built from a
+// real 2026-08-28 richmond table plus the three shapes that used to hide behind "(t)":
+// a whole page, a split whose numbering disagrees, a whole truth page we split, and a
+// truth-only "(no fit)" row.
+const HEADER2 =
+  'page_truth    page_gen      n_t n_g  str  int  t.px/ft  g.px/ft   rmse_ft    max_ft   trans_ft   rot_err  scale_%   skew°   aniso   area_km2   land_km2';
+const RULE2 = '-'.repeat(HEADER2.length);
+const TABLE2 = [
+  HEADER2,
+  RULE2,
+  'p311          p311            9   4    0    0     5.72     5.61      18.8      31.2       10.4    -0.31    +1.84   +2.13   1.067     0.0837     0.0837',
+  'p13__1        p13__2         10   2    9    6     2.97     3.00      10.5      16.3        8.6    -0.01    -1.12   -0.26   1.015     0.0412     0.0398',
+  'p16N          p16N__1         6   4    0    0     6.12     6.30      60.4     100.9       50.2    +4.88    -2.88   -0.19   1.006     0.0761     0.0761',
+  'p12__2        —               3   —    —    —        —        —         —         —          —        —        —   -3.62   1.015     0.0222     0.0176  (no fit)',
+  RULE2,
+  '',
+  '3/4 = 75.00% pages georeferenced (1 total losses)',
+].join('\n');
+
+describe('two page columns (#267)', () => {
+  it('detects the layout from the header', () => {
+    expect(hasTwoPageColumns(HEADER2)).toBe(true);
+    expect(hasTwoPageColumns(HEADER)).toBe(false);
+  });
+
+  it('keys paired rows by the page_gen column, not the truth key', () => {
+    const keys = parseCompareTxt(TABLE2).map((p) => p.genPageKey);
+    expect(keys).toEqual(['p311', 'p13__2', 'p16n__1']);
+  });
+
+  it('reads the metrics after both key columns', () => {
+    const p13 = parseCompareTxt(TABLE2).find((p) => p.genPageKey === 'p13__2')!;
+    expect(p13.rmseFt).toBe(10.5);
+    expect(p13.maxFt).toBe(16.3);
+    expect(p13.translationFt).toBe(8.6);
+    expect(p13.rotationErrorDegrees).toBe(-0.01);
+    expect(p13.scaleErrorPercent).toBe(-1.12);
+    expect(p13.skewDegrees).toBe(-0.26);
+    expect(p13.anisotropy).toBe(1.015);
+    expect(p13.landKm2).toBe(0.0398);
+  });
+
+  it('reports "(no fit)" rows by their truth key and keeps them out of pages', () => {
+    expect(parseMissingTruthKeys(TABLE2)).toEqual(['p12__2']);
+    expect(parseCompareTxt(TABLE2).some((p) => p.genPageKey === '—')).toBe(
+      false,
+    );
+  });
+
+  it('keys land by the truth page in both layouts', () => {
+    const land = parseLandByPage(TABLE2)!;
+    expect(land['p13__1']).toBe(0.0398);
+    expect(land['p12__2']).toBe(0.0176);
+    expect(land['p13__2']).toBeUndefined();
+  });
+
+  it('still reads the legacy single-column layout unchanged', () => {
+    const legacy = parseCompareTxt(TABLE).find(
+      (p) => p.genPageKey === 'p1499l',
+    )!;
+    expect(legacy.rmseFt).toBe(10.5);
   });
 });

--- a/app/server/compareTxt.ts
+++ b/app/server/compareTxt.ts
@@ -8,8 +8,15 @@
  *
  * The table (see compare_iiif_georef.print_table) has a header, a `---` rule, one row per truth
  * page — paired rows carry error metrics, `(no fit)` rows are truth-only — a closing `---`, then
- * summary lines. A paired row's Page column is the truth page key; when our split numbering
- * differs it is marked `(t)` and the generated key follows in trailing parens.
+ * summary lines. Two layouts exist, told apart by the header (#267):
+ *
+ * - current: `page_truth` and `page_gen` columns lead every row — the truth page key and the
+ *   generated page key it was paired with (`—` on `(no fit)` rows). They differ exactly when
+ *   OIM and our splitter numbered a sheet's panels differently.
+ * - legacy (archived runs): a single `Page` column holding the truth key; when the numbering
+ *   differed the key was marked `(t)` and the generated key followed in trailing parens.
+ *
+ * Old runs are never regenerated, so both layouts stay readable.
  */
 
 /** One paired page's truth-comparison error, keyed by the generated page's file stem. */
@@ -56,6 +63,11 @@ function isSeparator(line: string): boolean {
   return /^-{3,}$/.test(line.trim());
 }
 
+/** Whether a table header announces the two-key layout (`page_truth page_gen …`). */
+export function hasTwoPageColumns(header: string): boolean {
+  return /^\s*page_truth\s+page_gen\b/.test(header);
+}
+
 /** The truth page key of a `(no fit)` row, or null for any other line. */
 export function parseMissingRow(line: string): string | null {
   const trailing = line.match(/\s+\(no fit\)\s*$/);
@@ -83,6 +95,8 @@ export function parseLandByPage(text: string): Record<string, number> | null {
 }
 
 // The land pair of one row; only meaningful when the header carries land columns.
+// Layout-independent: the truth key leads every row in both layouts, and the land
+// pair trails it (a `—` in a two-key row's page_gen column is just another token).
 function parseRowLandKm2(line: string): [string, number] | null {
   let body = line;
   const trailing = body.match(/\s+\(([^)]*)\)\s*$/);
@@ -98,10 +112,15 @@ function parseRowLandKm2(line: string): [string, number] | null {
 }
 
 // Parse one data row; returns null for `(no fit)` (truth-only) rows and unparseable lines.
-function parseRow(line: string): ComparePageStats | null {
+// `twoPageColumns` says which layout the table's header announced (see the module doc).
+function parseRow(
+  line: string,
+  twoPageColumns: boolean,
+): ComparePageStats | null {
   let body = line;
   let genKeyOverride: string | null = null;
-  // A trailing "(…)" is either "(no fit)" or, when split numbers disagree, the generated key.
+  // A trailing "(…)" is either "(no fit)" or, in the legacy layout when split numbers
+  // disagree, the generated key.
   const trailing = body.match(/\s+\(([^)]*)\)\s*$/);
   if (trailing) {
     if (trailing[1] === 'no fit') return null;
@@ -110,8 +129,17 @@ function parseRow(line: string): ComparePageStats | null {
   }
   const tokens = body.trim().split(/\s+/);
   if (tokens.length < 2) return null;
-  const disagree = tokens[1] === '(t)';
-  const numeric = tokens.slice(disagree ? 2 : 1);
+  let genPageKey: string;
+  let numeric: string[];
+  if (twoPageColumns) {
+    // page_truth page_gen n_t n_g …
+    genPageKey = tokens[1] ?? '';
+    numeric = tokens.slice(2);
+  } else {
+    const disagree = tokens[1] === '(t)';
+    numeric = tokens.slice(disagree ? 2 : 1);
+    genPageKey = (disagree ? (genKeyOverride ?? tokens[0]) : tokens[0]) ?? '';
+  }
   // n_t n_g str int t.px g.px rmse max trans rot scale skew aniso
   const rmseFt = Number(numeric[6]);
   const maxFt = Number(numeric[7]);
@@ -133,8 +161,6 @@ function parseRow(line: string): ComparePageStats | null {
   const anisotropy = Number(numeric[12]);
   const areaKm2 = Number(numeric[13]);
   const landKm2 = Number(numeric[14]);
-  const genPageKey =
-    (disagree ? (genKeyOverride ?? tokens[0]) : tokens[0]) ?? '';
   return {
     genPageKey: genPageKey.toLowerCase(),
     rmseFt,
@@ -161,12 +187,13 @@ export function parseCompareTxt(text: string): ComparePageStats[] {
   if (!header || !header.includes('rmse_ft')) return [];
   const start = lines.findIndex(isSeparator);
   if (start < 0) return [];
+  const twoPageColumns = hasTwoPageColumns(header);
   const pages: ComparePageStats[] = [];
   for (let i = start + 1; i < lines.length; i++) {
     const line = lines[i]!;
     if (isSeparator(line)) break; // end of the data section
     if (line.trim() === '') continue;
-    const row = parseRow(line);
+    const row = parseRow(line, twoPageColumns);
     if (row) pages.push(row);
   }
   return pages;

--- a/docs/fit-pipeline.md
+++ b/docs/fit-pipeline.md
@@ -298,10 +298,11 @@ precedence left to reason about: exactly one sidecar answers for each page.
 - A poseless `georef-final.json` leaves the page unplaced *and* claims its
   page key, so nothing else can supply a pose for it.
 - Truth comparison then cross-matches split panels: a truth panel with no fit
-  of its own is scored against another panel's fit — the `(p59__1)`-style
-  marker in compare output (#267). This is how an *unfitted* page (fargo
-  p59__2) can still contribute a disaster: the fit being graded belongs to
-  p59__1.
+  of its own is scored against another panel's fit — a row whose `page_truth`
+  and `page_gen` columns differ in compare output (#267; older archived tables
+  wrote a `(t)` marker with the generated key in trailing parens instead). This
+  is how an *unfitted* page (fargo p59__2) can still contribute a disaster: the
+  fit being graded belongs to p59__1.
 
 ---
 

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -579,16 +579,6 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
             for r in landed
             if r.get("rmse_ft") is not None and r["rmse_ft"] >= 200.0
         )
-        # The pre-#300 land-weighted figures, clearly labelled as such: the
-        # authoritative sheet-equal score prints from `mapsnap fit` (via the
-        # manifest) and `mapsnap score`. An unlabelled "Score:" here spent a
-        # week being mistaken for the project metric (#330).
-        print(
-            f"Land-weighted (legacy): {100 * (good - disaster) / total_land:.1f}% "
-            f"(<=25ft {100 * good / total_land:.1f}% of land, "
-            f">=200ft {100 * disaster / total_land:.1f}%, "
-            f"total {total_land / 1e6:.2f} km2)"
-        )
 
     if rows:
         rmsers = np.array([r["rmse_ft"] for r in rows])
@@ -618,8 +608,7 @@ def print_sheet_equal_score(truth_path: Path, generated_path: Path) -> None:
 
     The number matches ``mapsnap score`` and the Score line of ``mapsnap fit``
     exactly: the volume is the GENERATED file's directory, whose oim/ panels
-    and centerlines.geojson supply the split weights and land fractions. The
-    "Land-weighted (legacy)" footer above it predates #300.
+    and centerlines.geojson supply the split weights and land fractions.
     """
     # Imported here because score.py imports compare_pages from this module.
     from mapsnap.score import summarize, volume_page_scores

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -500,9 +500,18 @@ def split_numbers_disagree(row: dict) -> bool:
     return gen_page_key is not None and gen_page_key != row["page_key"]
 
 
-def page_label(row: dict) -> str:
-    """Page column text: the truth page key, marked '(t)' when our numbering disagrees."""
-    return f"{row['page_key']} (t)" if split_numbers_disagree(row) else row["page_key"]
+def gen_page_label(row: dict) -> str:
+    """The generated-page column: the matched generated key, or a dash when unplaced.
+
+    The table carries BOTH keys (#267): the truth page key and the generated
+    page key. They coincide for whole pages and for splits whose numbering
+    agrees, and differ exactly when OIM and our splitter numbered the panels
+    differently — an unavoidable disagreement (OIM's numbering is the order a
+    volunteer drew the regions) that used to hide in a "(t)" marker plus a
+    trailing parenthetical, and misled readers into taking a number off the
+    wrong panel.
+    """
+    return row.get("gen_page_key") or "—"
 
 
 def fmt_km2(area_m2: float | None) -> str:
@@ -515,7 +524,7 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
     rows_sorted = sorted(rows, key=lambda r: r["rmse_ft"], reverse=True)
 
     header = (
-        f"{'Page':<13} {'n_t':>3} {'n_g':>3} {'str':>4} {'int':>4}  "
+        f"{'page_truth':<13} {'page_gen':<13} {'n_t':>3} {'n_g':>3} {'str':>4} {'int':>4}  "
         f"{'t.px/ft':>7}  {'g.px/ft':>7}  "
         f"{'rmse_ft':>8}  {'max_ft':>8}  {'trans_ft':>9}  "
         f"{'rot_err':>8}  {'scale_%':>7}  {'skew°':>6}  {'aniso':>6}  "
@@ -527,22 +536,20 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
     for r in rows_sorted:
         n_str = r["n_streets"] if r["n_streets"] is not None else "—"
         n_int = r["n_intersections"] if r["n_intersections"] is not None else "—"
-        # When the split numbers disagree, note the matched generated page in the trailing
-        # column (where missing rows show "(no fit)").
-        trailing = f"  ({r['gen_page_key']})" if split_numbers_disagree(r) else ""
         print(
-            f"{page_label(r):<13} {r['n_truth']:>3} {r['n_gen']:>3} {n_str!s:>4} {n_int!s:>4}  "
+            f"{r['page_key']:<13} {gen_page_label(r):<13} "
+            f"{r['n_truth']:>3} {r['n_gen']:>3} {n_str!s:>4} {n_int!s:>4}  "
             f"{r['truth_px_per_ft']:>7.2f}  {r['gen_px_per_ft']:>7.2f}  "
             f"{r['rmse_ft']:>8.1f}  {r['max_ft']:>8.1f}  {r['trans_ft']:>9.1f}  "
             f"{r['rot_err']:>+8.2f}  {r['scale_pct']:>+7.2f}  "
             f"{r['skew_deg']:>+6.2f}  {r['aniso']:>6.3f}  "
-            f"{fmt_km2(r.get('area_m2')):>9}  {fmt_km2(r.get('land_m2')):>9}{trailing}"
+            f"{fmt_km2(r.get('area_m2')):>9}  {fmt_km2(r.get('land_m2')):>9}"
         )
     if missing:
         missing_sorted = sorted(missing, key=lambda r: r["page_key"])
         for r in missing_sorted:
             print(
-                f"{r['page_key']:<13} {r['n_truth']:>3} {'—':>3} {'—':>4} {'—':>4}  "
+                f"{r['page_key']:<13} {'—':<13} {r['n_truth']:>3} {'—':>3} {'—':>4} {'—':>4}  "
                 f"{'—':>7}  {'—':>7}  "
                 f"{'—':>8}  {'—':>8}  {'—':>9}  "
                 f"{'—':>8}  {'—':>7}  "
@@ -655,6 +662,7 @@ def print_tsv(rows: list[dict], missing: list[dict]) -> None:
     """
     fields = [
         "page_key",
+        "gen_page_key",
         "n_truth",
         "n_gen",
         "n_streets",
@@ -671,7 +679,7 @@ def print_tsv(rows: list[dict], missing: list[dict]) -> None:
     ]
     print("\t".join(fields))
     for r in sorted(rows, key=lambda x: x["page_key"]):
-        print("\t".join(str(r[f]) for f in fields))
+        print("\t".join(str(r.get(f, "")) for f in fields))
     for r in sorted(missing, key=lambda x: x["page_key"]):
         row_vals = {f: "" for f in fields}
         row_vals["page_key"] = r["page_key"]

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -566,20 +566,6 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
         f"\n{n_paired}/{n_truth_total} = {pct:.02f}% pages georeferenced ({n_missing} total losses)"
     )
 
-    landed = [r for r in rows + missing if r.get("land_m2") is not None]
-    total_land = sum(r["land_m2"] for r in landed)
-    if landed and total_land > 0:
-        good = sum(
-            r["land_m2"]
-            for r in landed
-            if r.get("rmse_ft") is not None and r["rmse_ft"] <= 25.0
-        )
-        disaster = sum(
-            r["land_m2"]
-            for r in landed
-            if r.get("rmse_ft") is not None and r["rmse_ft"] >= 200.0
-        )
-
     if rows:
         rmsers = np.array([r["rmse_ft"] for r in rows])
         rot_errs = np.abs([r["rot_err"] for r in rows])

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -8,10 +8,11 @@ from shapely.geometry import Polygon as ShapelyPolygon
 from mapsnap.compare_iiif_georef import (
     annotation_split_index,
     annotations_by_source,
+    gen_page_label,
     load_split_polygons,
-    page_label,
     parse_svg_polygon,
     polygon_iou,
+    print_table,
     split_numbers_disagree,
     truth_page_number,
     truth_polygon_world,
@@ -47,20 +48,84 @@ def test_annotations_by_source_null_ids_key_by_label(tmp_path):
 
 
 def test_split_numbering_annotations():
-    # Numbers agree → plain key, no disagreement.
+    # Numbers agree → the generated column repeats the truth key.
     agree = {"page_key": "p13__1", "gen_page_key": "p13__1"}
     assert split_numbers_disagree(agree) is False
-    assert page_label(agree) == "p13__1"
+    assert gen_page_label(agree) == "p13__1"
 
-    # Numbers disagree → '(t)' marker on the truth key.
+    # Numbers disagree → the generated column shows the key that was actually
+    # graded, instead of the old "(t)" marker plus trailing parenthetical.
     disagree = {"page_key": "p13__1", "gen_page_key": "p13__2"}
     assert split_numbers_disagree(disagree) is True
-    assert page_label(disagree) == "p13__1 (t)"
+    assert gen_page_label(disagree) == "p13__2"
 
-    # Full pages (no gen_page_key, e.g. missing rows) are never flagged.
+    # Full pages (no gen_page_key, e.g. missing rows) are never flagged and
+    # show a dash where the generated key would be.
     full = {"page_key": "p13"}
     assert split_numbers_disagree(full) is False
-    assert page_label(full) == "p13"
+    assert gen_page_label(full) == "—"
+
+
+def _paired_row(page_key: str, gen_page_key: str, rmse_ft: float) -> dict:
+    """A print_table row with every column filled (values are not under test)."""
+    return {
+        "page_key": page_key,
+        "gen_page_key": gen_page_key,
+        "n_truth": 5,
+        "n_gen": 4,
+        "n_streets": 3,
+        "n_intersections": 2,
+        "truth_px_per_ft": 6.0,
+        "gen_px_per_ft": 6.1,
+        "rmse_ft": rmse_ft,
+        "max_ft": rmse_ft * 2,
+        "trans_ft": rmse_ft / 2,
+        "rot_err": 0.1,
+        "scale_pct": -0.5,
+        "skew_deg": 0.2,
+        "aniso": 1.001,
+        "area_m2": 50_000.0,
+        "land_m2": 40_000.0,
+    }
+
+
+def test_print_table_carries_both_page_keys(capsys):
+    """Every row names the truth page AND the generated page it was graded against (#267).
+
+    The two coincide for whole pages and agreeing splits, and differ when OIM
+    and our splitter numbered a sheet's panels differently — which the old
+    single column expressed as "p13__1 (t) … (p13__2)", a format that misled
+    readers into taking a number off the wrong panel.
+    """
+    rows = [
+        _paired_row("p7", "p7", 8.0),
+        _paired_row("p13__1", "p13__2", 30.0),
+        _paired_row("p16N", "p16N__1", 60.0),
+    ]
+    missing = [
+        {
+            "page_key": "p12__2",
+            "n_truth": 3,
+            "skew_deg": -0.8,
+            "aniso": 1.009,
+            "area_m2": 15_900.0,
+            "land_m2": 15_900.0,
+        }
+    ]
+    print_table(rows, missing)
+    lines = capsys.readouterr().out.splitlines()
+    header = lines[0]
+    assert header.startswith("page_truth    page_gen      n_t")
+    assert "(t)" not in "\n".join(lines)
+    by_truth = {line.split()[0]: line for line in lines if line.startswith("p")}
+    assert by_truth["p7"].split()[1] == "p7"
+    assert by_truth["p13__1"].split()[1] == "p13__2"
+    assert by_truth["p16N"].split()[1] == "p16N__1"
+    assert not by_truth["p13__1"].rstrip().endswith(")")
+    # Unplaced truth pages keep the "(no fit)" trailer and show a dash for the
+    # generated key, so both readers and the viewer's parser see one shape.
+    assert by_truth["p12__2"].split()[1] == "—"
+    assert by_truth["p12__2"].rstrip().endswith("(no fit)")
 
 
 def _square(x: float, y: float, side: float) -> ShapelyPolygon:


### PR DESCRIPTION
The `mapsnap compare` table named only the truth page. When OIM and our splitter numbered a sheet's panels differently — unavoidable, since OIM's `division_number` is the order a volunteer drew the regions — the row was marked `(t)` and the generated key trailed in parentheses:

```
p13__1 (t)   10   2    9    6     2.97     3.00      10.5 …   1.015  (p13__2)
```

170 rows across the 2026-08-28 corpus print that way, in three shapes: **105** split-vs-split renumberings, **53** truth splits graded against a whole-page placement, and **12** whole truth pages that we split. The format has misled readers (including me, repeatedly) into taking a number off the wrong panel.

## Change

Every row now leads with two columns, `page_truth` and `page_gen`. They coincide for whole pages and agreeing splits, and differ exactly when the numbering does:

```
page_truth    page_gen      n_t n_g  str  int  t.px/ft  g.px/ft   rmse_ft …
p383__2       p383            4   4    0    0     2.81     2.99    1620.4 …
p327          —               5   —    —    —        —        —         — …  (no fit)
```

Unplaced truth pages show `—` for the generated key and keep their `(no fit)` trailer. TSV output gains `gen_page_key` beside `page_key`, matching the CSV, which already carried both.

## Old runs keep working

The volume viewer reads these tables ([app/server/compareTxt.ts](app/server/compareTxt.ts)), and archived tagged runs are never regenerated. The parser now tells the layouts apart by the header (`hasTwoPageColumns`) and keeps the legacy `(t)`/trailing-parens path intact. `parseMissingRow` and `parseLandByPage` key on the truth page in both layouts, so nothing above them changes.

**Equivalence check:** parsing richmond's archived `2026-08-28.txt` (legacy) and a freshly generated table of the same annotations through the same parser yields identical paired pages, per-page rmse, missing keys, and land maps — 89 / 2 / 92.

Tests: a `print_table` test pins all three row shapes plus the `(no fit)` row on the Python side; six new parser cases cover the two-key layout, `(no fit)` handling, land keyed by truth, and the legacy path. 1,093 Python tests, 249 app tests, `tsc`, ruff and pyright all pass.

`docs/fit-pipeline.md`'s description of the trailing marker is updated. Nothing else in the repo parses the table.

Fixes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
