### PR TITLE
IIIF labels carry our own split marker, never the reference item's

### DIFF
--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -201,6 +201,30 @@ def _label_parent_page_key(label: str) -> str | None:
     return key.split("__")[0] if key else None
 
 
+def own_label(reference_label: str, split_index: int | None) -> str:
+    """The label for OUR annotation: the reference item's label with OUR split marker.
+
+    The reference (OIM) file carries one item per panel, labeled "… p10 [1]" /
+    "… p10 [2]", and the index keys them by parent page with the last one
+    winning. Copying that label verbatim leaked its marker onto whatever we
+    wrote for the page: an unsplit placement said "[2]" while its id said
+    whole-page (#343, 22 items in the 2026-08-28 corpus), and both of our own
+    panels said the same "[2]" (#306, 59 duplicates). The id already carries
+    our panel number, so the label says the same thing: no marker when we fit
+    the whole sheet, "[N]" with OUR N when we fit panel N.
+
+      ("Fargo, N.D. | 1958 p10 [2]", None) -> "Fargo, N.D. | 1958 p10"
+      ("Fargo, N.D. | 1958 p10 [2]", 1)    -> "Fargo, N.D. | 1958 p10 [1]"
+      ("Fargo, N.D. | 1958 p10", 2)        -> "Fargo, N.D. | 1958 p10 [2]"
+
+    Our N and OIM's division number are independent orderings and can differ
+    (#379 narrows that for two-panel sheets); `mapsnap compare` pairs panels by
+    geometry, never by label, so grading is unaffected either way.
+    """
+    base = re.sub(r"\s*\[\d+\]\s*$", "", reference_label)
+    return base if split_index is None else f"{base} [{split_index}]"
+
+
 def _load_oim_index(data: dict) -> dict[str, dict]:
     """Build parent-page_key → item dict from an OIM IIIF AnnotationPage.
 
@@ -434,7 +458,6 @@ def make_annotation(
     source_type: str = source.get("type", "ImageService2")
     source_width: int = source["width"]
     source_height: int = source["height"]
-    label: str = item["label"]
 
     creator = {"id": creator_url, "type": "Person"}
     georef_width = georef["width"]
@@ -451,6 +474,7 @@ def make_annotation(
     if "__" in page_key:
         split_index = int(page_key.split("__")[1])
         canvas_id += f"__{split_index}"
+    label = own_label(item["label"], split_index)
 
     gcp_pts = georef_gcp_points(georef)
     split_canvas: tuple[float, float, float, float] | None = None

--- a/mapsnap/make_iiif_georef_test.py
+++ b/mapsnap/make_iiif_georef_test.py
@@ -14,6 +14,7 @@ from mapsnap.make_iiif_georef import (
     georef_gcp_points,
     georef_path_to_page_key,
     make_annotation,
+    own_label,
 )
 from mapsnap.split import write_panels_json
 
@@ -455,6 +456,66 @@ def _metadata_value(annotation: dict, label: str) -> str | None:
         if entry["label"] == label:
             return entry["value"]
     return None
+
+
+def test_own_label_carries_our_split_marker_not_the_reference_items():
+    """The label says what the id says: our panel number, or nothing (#343, #306).
+
+    The reference index keeps one OIM item per parent page (last one wins), so
+    copying its label verbatim leaked "[2]" onto unsplit placements and onto
+    both of our own panels.
+    """
+    reference = "Fargo, N.D. | 1958 p10 [2]"
+    # We fit the whole sheet: no marker at all, whatever the reference carried.
+    assert own_label(reference, None) == "Fargo, N.D. | 1958 p10"
+    # We fit panel 1: OUR number, not the reference item's.
+    assert own_label(reference, 1) == "Fargo, N.D. | 1958 p10 [1]"
+    # A reference with no marker still gains ours when we split the sheet.
+    assert own_label("Fargo, N.D. | 1958 p10", 2) == "Fargo, N.D. | 1958 p10 [2]"
+    # Untouched when nothing needs changing (the common whole-page case).
+    assert own_label("Chicago, Ill. | 1950 | Vol. 1 p16N", None) == (
+        "Chicago, Ill. | 1950 | Vol. 1 p16N"
+    )
+    # Stray whitespace around the marker does not survive into the output.
+    assert own_label("Page 6  [1] ", None) == "Page 6"
+
+
+def test_make_annotation_labels_match_their_ids(tmp_path):
+    """Label marker and id suffix never disagree — the ambiguity compare had to
+    heuristically resolve (annotation_is_own_output) is gone at the source."""
+    write_panels_json(
+        tmp_path / "p4.jpg",
+        [box(0, 0, 200, 200), box(0, 200, 200, 400)],
+        width=200,
+        height=400,
+    )
+    item = {
+        "label": "Test | 1900 p4 [2]",  # last-wins reference label
+        "target": {
+            "source": {
+                "id": "http://example/p4/info.json",
+                "type": "ImageService3",
+                "width": 800,
+                "height": 1600,
+            }
+        },
+    }
+    georef = make_georef(width=200, height=200, intersections=[])
+    panel_one = make_annotation(
+        item, georef, "p4__1", tmp_path / "p4__1.jpg", "http://x", "now"
+    )
+    assert panel_one["id"].endswith("p4__1/georef")
+    assert panel_one["label"] == "Test | 1900 p4 [1]"
+    whole = make_annotation(
+        item,
+        make_georef(width=200, height=400, intersections=[]),
+        "p4",
+        tmp_path / "p4.jpg",
+        "http://x",
+        "now",
+    )
+    assert whole["id"].endswith("p4/georef")
+    assert whole["label"] == "Test | 1900 p4"
 
 
 def test_make_annotation_split_uses_panels_json(tmp_path):


### PR DESCRIPTION
The reference (OIM) file carries one item **per panel** — `… p10 [1]`, `… p10 [2]` — and [`_load_oim_index`](mapsnap/make_iiif_georef.py) keys them by parent page with the last one winning. `make_annotation` then copied that item's label verbatim, so the marker leaked onto whatever we wrote for the page:

- an **unsplit** placement whose id says whole-page (`…-0010/georef`) carried a `[2]` label — #343
- **both** of our own panels carried the same `[2]` — #306's duplicates

Re-counted on the 2026-08-28 corpus: **22 leaked markers and 59 duplicate labels across 15 volumes.**

## Change

`own_label(reference_label, split_index)` strips the reference marker and appends **our** panel number when, and only when, our page key has one — the same fact the id already states.

```
("Fargo, N.D. | 1958 p10 [2]", None) -> "Fargo, N.D. | 1958 p10"
("Fargo, N.D. | 1958 p10 [2]", 1)    -> "Fargo, N.D. | 1958 p10 [1]"
("Fargo, N.D. | 1958 p10", 2)        -> "Fargo, N.D. | 1958 p10 [2]"
```

## Acceptance (from #343), on fargo regenerated from its existing sidecars

| check | result |
|---|---|
| p10 (unsplit) label | `Fargo, N.D. | 1958 p10` — no marker |
| items with a label marker but no `__N` id | **0** (was 6) |
| duplicate labels | **0** (was 7) |
| id suffix ≠ label marker | **0** |
| `mapsnap compare` vs the archived run | **byte-identical**: Score 74.9%, 95/115 placed, all 115 per-page rmse equal |

The last row is the important one: `compare` pairs panels by geometry, never by label, so this is purely a presentation fix — the metadata-signature path (`annotation_is_own_output`) simply stops being exercised for fresh files. It stays in `compare`, because archived generated files keep their old labels and must keep grading correctly.

## What this does and does not settle from #306

It settles the duplicate-label half: a label now identifies which of **our** panels an item is, matching its id and its on-disk stem, so a human cross-referencing `panels.json` against a `compare` page key reads the right panel. It does **not** make our numbers agree with OIM's — those are independent orderings — which is #379 (measured there: OIM's division 1 is the panel containing the sheet's bottom-left corner on 200/200 two-panel pages; ours is reading order, so they disagree on half of them).

Tests: `own_label` unit cases plus a `make_annotation` test pinning that label marker and id suffix never disagree. 1,094 tests, ruff and pyright pass.

Fixes #343
Fixes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
