### PR TITLE
Key-map splits must cut away edge-flush boxes, or the parent sheet is used

### DIFF
--- a/mapsnap/keymap/identify.py
+++ b/mapsnap/keymap/identify.py
@@ -52,6 +52,7 @@ from mapsnap.keymap.fit_keymap import (
 )
 from mapsnap.keymap.number_model import build_model, select_device
 from mapsnap.keymap.records import page_key_sort, write_keymaps_record
+from mapsnap.split import panels_json_path, read_panels_json
 from mapsnap.utils import image_stem
 
 DEFAULT_CNN_WEIGHTS = Path("models/number_detector.pt")
@@ -135,6 +136,59 @@ def page_zero_stems(volume: Path) -> tuple[list[str], list[str]]:
     return unsplit, splits
 
 
+# A panel edge within this fraction of the sheet's size counts as flush with it.
+FLUSH_EDGE_TOLERANCE = 0.02
+# A panel covering at least this fraction of the sheet is the sheet itself, not
+# something cut away from it.
+CUT_AWAY_MAX_AREA = 0.5
+
+
+def panel_flush_edges(ring: list[list[float]], width: float, height: float) -> int:
+    """How many of the sheet's four edges a panel ring touches (0-4)."""
+    xs = [point[0] for point in ring]
+    ys = [point[1] for point in ring]
+    tol_x, tol_y = FLUSH_EDGE_TOLERANCE * width, FLUSH_EDGE_TOLERANCE * height
+    return sum(
+        (
+            min(xs) <= tol_x,
+            min(ys) <= tol_y,
+            max(xs) >= width - tol_x,
+            max(ys) >= height - tol_y,
+        )
+    )
+
+
+def legitimate_keymap_split(volume: Path, parent: str) -> bool:
+    """Whether a split of a key-map sheet cut away real boxed regions, not a notch.
+
+    What a key-map sheet legitimately loses to a split is a boxed region in a
+    corner or along an edge: the KEY legend (Detroit, Chicago), a "graphic map
+    of volumes" inset (Kansas City, New Orleans 1951). Every one of those is
+    flush with at least two sheet edges. A cut-away flush with fewer is the
+    splitter latching onto interior linework -- Chicago's 4% notch at the top
+    of the sheet, flush with one edge, carried ten page numbers (1-5, 17, 18,
+    31, 61, 64) that the key-map panel then never read. Measured over every
+    split key-map sheet in the corpus (9 panels): key-map panels are flush
+    with four edges, legitimate cut-aways with two, the one bad cut with one.
+
+    Without a panels.json there is nothing to judge, so the split stands.
+    """
+    path = panels_json_path(volume / f"{parent}.jpg")
+    if not path.exists():
+        return True
+    data = read_panels_json(path)
+    width, height = float(data["width"]), float(data["height"])
+    for ring in data["panels"]:
+        xs = [point[0] for point in ring]
+        ys = [point[1] for point in ring]
+        area = (max(xs) - min(xs)) * (max(ys) - min(ys))
+        if area >= CUT_AWAY_MAX_AREA * width * height:
+            continue  # the sheet itself, whatever was cut from it
+        if panel_flush_edges(ring, width, height) < 2:
+            return False
+    return True
+
+
 def detection_plan(volume: Path) -> tuple[list[str], list[str]]:
     """(keys assumed to be key maps untested, keys to confirm by coverage).
 
@@ -145,20 +199,25 @@ def detection_plan(volume: Path) -> tuple[list[str], list[str]]:
     composite page-0 sheet that has been split into panels: there the sheet
     mixes the key map with a volume-index map or symbol legend (Kansas City
     p0__2, New Orleans 1951 p0__1, New York 1905 p0__2), so each panel is
-    confirmed individually by coverage and the unsplit parent is dropped.
+    confirmed individually by coverage and the unsplit parent is dropped --
+    unless the split is not a legitimate one (legitimate_keymap_split), in
+    which case the panels are ignored and the parent sheet is tested whole.
     """
     page_zero, page_zero_splits = page_zero_stems(volume)
     if page_zero and not page_zero_splits:
         return page_zero, []
     # A candidate sheet that has been split into panels is tested panel-by-panel
     # (the composite may mix the key map with an index map or legend) and the
-    # unsplit parent is dropped.
+    # unsplit parent is dropped -- when the split cut away real boxed regions.
     keys: list[str] = []
     for key in candidate_keys(volume):
         panels = sorted(
             image_stem(str(image)) for image in volume.glob(f"{key}__*.jpg")
         )
-        keys.extend(panels or [key])
+        if panels and legitimate_keymap_split(volume, key):
+            keys.extend(panels)
+        else:
+            keys.append(key)
     return [], keys
 
 

--- a/mapsnap/keymap/identify.py
+++ b/mapsnap/keymap/identify.py
@@ -52,7 +52,12 @@ from mapsnap.keymap.fit_keymap import (
 )
 from mapsnap.keymap.number_model import build_model, select_device
 from mapsnap.keymap.records import page_key_sort, write_keymaps_record
-from mapsnap.split import panels_json_path, read_panels_json
+from mapsnap.split import (
+    CUT_AWAY_MAX_AREA,
+    panel_flush_edges,
+    panels_json_path,
+    read_panels_json,
+)
 from mapsnap.utils import image_stem
 
 DEFAULT_CNN_WEIGHTS = Path("models/number_detector.pt")
@@ -136,28 +141,6 @@ def page_zero_stems(volume: Path) -> tuple[list[str], list[str]]:
     return unsplit, splits
 
 
-# A panel edge within this fraction of the sheet's size counts as flush with it.
-FLUSH_EDGE_TOLERANCE = 0.02
-# A panel covering at least this fraction of the sheet is the sheet itself, not
-# something cut away from it.
-CUT_AWAY_MAX_AREA = 0.5
-
-
-def panel_flush_edges(ring: list[list[float]], width: float, height: float) -> int:
-    """How many of the sheet's four edges a panel ring touches (0-4)."""
-    xs = [point[0] for point in ring]
-    ys = [point[1] for point in ring]
-    tol_x, tol_y = FLUSH_EDGE_TOLERANCE * width, FLUSH_EDGE_TOLERANCE * height
-    return sum(
-        (
-            min(xs) <= tol_x,
-            min(ys) <= tol_y,
-            max(xs) >= width - tol_x,
-            max(ys) >= height - tol_y,
-        )
-    )
-
-
 def legitimate_keymap_split(volume: Path, parent: str) -> bool:
     """Whether a split of a key-map sheet cut away real boxed regions, not a notch.
 
@@ -171,7 +154,11 @@ def legitimate_keymap_split(volume: Path, parent: str) -> bool:
     split key-map sheet in the corpus (9 panels): key-map panels are flush
     with four edges, legitimate cut-aways with two, the one bad cut with one.
 
-    Without a panels.json there is nothing to judge, so the split stands.
+    The splitter itself now refuses such a cut on a key-map sheet
+    (split.keymap_split_rejection), so this is the backstop for volumes split
+    by older code: it routes the key-map pipeline around the bad panels until
+    the next re-split removes them. Without a panels.json there is nothing to
+    judge, so the split stands.
     """
     path = panels_json_path(volume / f"{parent}.jpg")
     if not path.exists():

--- a/mapsnap/keymap/identify_test.py
+++ b/mapsnap/keymap/identify_test.py
@@ -1,10 +1,13 @@
+import json
 from pathlib import Path
 
 from mapsnap.keymap.identify import (
     candidate_keys,
     detection_plan,
     is_keymap,
+    legitimate_keymap_split,
     page_zero_stems,
+    panel_flush_edges,
     volume_valid_pages,
 )
 
@@ -98,6 +101,68 @@ def test_detection_plan_split_panels_tested_individually(tmp_path: Path):
     assumed, to_test = detection_plan(volume)
     assert assumed == []
     assert to_test == ["p0__1", "p0__2", "p1N"]
+
+
+def _write_panels(volume: Path, parent: str, rings: list[list[list[float]]]) -> None:
+    (volume / f"{parent}.panels.json").write_text(
+        json.dumps(
+            {"image": f"{parent}.jpg", "width": 1000, "height": 2000, "panels": rings}
+        )
+    )
+
+
+def _rect(x0: float, y0: float, x1: float, y1: float) -> list[list[float]]:
+    return [[x0, y0], [x1, y0], [x1, y1], [x0, y1], [x0, y0]]
+
+
+def test_panel_flush_edges_counts_touched_sheet_edges():
+    full = _rect(0, 0, 1000, 2000)
+    assert panel_flush_edges(full, 1000, 2000) == 4
+    corner = _rect(0, 1400, 300, 2000)  # bottom-left inset: left + bottom
+    assert panel_flush_edges(corner, 1000, 2000) == 2
+    notch = _rect(150, 0, 320, 600)  # hangs off the top edge only
+    assert panel_flush_edges(notch, 1000, 2000) == 1
+    floating = _rect(300, 300, 600, 900)
+    assert panel_flush_edges(floating, 1000, 2000) == 0
+    # Within 2% of an edge counts as flush (scan borders, polygon rounding).
+    nearly = _rect(15, 1400, 300, 1990)
+    assert panel_flush_edges(nearly, 1000, 2000) == 2
+
+
+def test_detection_plan_rejects_a_split_with_a_one_edge_notch(tmp_path: Path):
+    """Chicago: a 4% notch flush with one edge is the splitter chasing linework,
+    and testing the panels would lose the ten page numbers inside it. The
+    parent sheet is tested whole instead; the KEY box (two edges) is fine."""
+    volume = make_volume(
+        tmp_path, ["p0.jpg", "p0__1.jpg", "p0__2.jpg", "p0__3.jpg", "p1N.jpg", "p5.jpg"]
+    )
+    _write_panels(
+        volume,
+        "p0",
+        [
+            _rect(0, 0, 1000, 2000),
+            _rect(140, 0, 320, 580),
+            _rect(770, 1640, 1000, 2000),
+        ],
+    )
+    assert legitimate_keymap_split(volume, "p0") is False
+    assumed, to_test = detection_plan(volume)
+    assert assumed == []
+    assert to_test == ["p0", "p1N"]
+
+
+def test_detection_plan_keeps_a_split_of_edge_boxes(tmp_path: Path):
+    # Kansas City: the volume-index inset is a boxed corner region flush with
+    # two edges, so the panels are still confirmed one by one.
+    volume = make_volume(tmp_path, ["p0.jpg", "p0__1.jpg", "p0__2.jpg", "p1N.jpg"])
+    _write_panels(volume, "p0", [_rect(0, 0, 1000, 2000), _rect(0, 1360, 320, 2000)])
+    assert legitimate_keymap_split(volume, "p0") is True
+    assert detection_plan(volume) == ([], ["p0__1", "p0__2", "p1N"])
+
+
+def test_legitimate_keymap_split_without_panels_json_stands(tmp_path: Path):
+    volume = make_volume(tmp_path, ["p0.jpg", "p0__1.jpg", "p0__2.jpg"])
+    assert legitimate_keymap_split(volume, "p0") is True
 
 
 def test_detection_plan_no_page_zero_uses_candidates(tmp_path: Path):

--- a/mapsnap/split.py
+++ b/mapsnap/split.py
@@ -15,6 +15,7 @@ Usage:
 
 import argparse
 import json
+import re
 from itertools import pairwise
 from pathlib import Path
 from typing import TypedDict
@@ -1228,6 +1229,71 @@ def write_panels(image_path: Path, panels: list, base: str) -> list[Path]:
     return out_paths
 
 
+# A panel edge within this fraction of the sheet's size counts as flush with it.
+FLUSH_EDGE_TOLERANCE = 0.02
+# A panel covering at least this fraction of the sheet is the sheet itself, not
+# something cut away from it.
+CUT_AWAY_MAX_AREA = 0.5
+
+
+def panel_flush_edges(
+    ring: list[list[float]] | list[tuple[float, float]], width: float, height: float
+) -> int:
+    """How many of the sheet's four edges a panel ring touches (0-4)."""
+    xs = [point[0] for point in ring]
+    ys = [point[1] for point in ring]
+    tol_x, tol_y = FLUSH_EDGE_TOLERANCE * width, FLUSH_EDGE_TOLERANCE * height
+    return sum(
+        (
+            min(xs) <= tol_x,
+            min(ys) <= tol_y,
+            max(xs) >= width - tol_x,
+            max(ys) >= height - tol_y,
+        )
+    )
+
+
+def is_keymap_sheet(stem: str) -> bool:
+    """Whether a page stem is a key-map candidate: page 0/1 families or a letter sheet.
+
+    Mirrors mapsnap.keymap.identify.candidate_keys (page numbers 0 and 1 with
+    any letter suffix -- p0, p0b, p0L, p1, p1N, p1a -- plus letter-only ids
+    like pa/pb), kept here as a plain regex so the splitter does not import
+    the key-map package.
+    """
+    if re.fullmatch(r"p[a-z]{1,2}", stem):
+        return True
+    match = re.fullmatch(r"p(\d+)[A-Za-z]{0,2}", stem)
+    return match is not None and int(match.group(1)) in (0, 1)
+
+
+def keymap_split_rejection(panels: list, width: float, height: float) -> str | None:
+    """Why a key-map sheet's split must be refused, or None when it may stand.
+
+    What a key-map sheet legitimately loses to a split is a boxed region in a
+    corner or along an edge -- a KEY legend, a "graphic map of volumes" inset
+    -- and every one of those is flush with at least two sheet edges. A cut-
+    away flush with fewer is the splitter latching onto the key map's own
+    linework: Chicago's 4% notch hanging off the top edge carried ten page
+    numbers that the key-map panel then never read. Measured over every split
+    key-map sheet in the corpus (9 panels): key-map panels are flush with four
+    edges, legitimate cut-aways with two, the one bad cut with one. Regular
+    map pages are not judged here: their panels are insets and composites of
+    every shape.
+    """
+    for index, panel in enumerate(panels, start=1):
+        x0, y0, x1, y1 = panel.bounds
+        if (x1 - x0) * (y1 - y0) >= CUT_AWAY_MAX_AREA * width * height:
+            continue  # the sheet itself, whatever was cut from it
+        flush = panel_flush_edges(list(panel.exterior.coords), width, height)
+        if flush < 2:
+            return (
+                f"panel {index} is flush with {flush} sheet edge(s), "
+                "not a boxed corner or edge region"
+            )
+    return None
+
+
 def remove_split_outputs(image_path: Path) -> None:
     """Delete any existing <base>__N.jpg panels and <base>.panels.json for image_path.
 
@@ -1299,6 +1365,18 @@ def process_image(image_path: Path, debug: bool = False) -> None:
         for index in range(1, len(previous_rings) + 1):
             remove_panel_sidecars(image_path, index)
         return
+    # A key-map sheet only gives up boxed edge regions; anything else is a bad
+    # cut and the sheet stands whole (#276). The stale panels were removed
+    # above; drop their sidecars too so nothing downstream keeps reading them.
+    if is_keymap_sheet(base):
+        rejection = keymap_split_rejection(panels, full_w, full_h)
+        if rejection:
+            print(f"{image_path.name}: key-map sheet, split rejected — {rejection}")
+            for index in range(1, len(previous_rings) + 1):
+                remove_panel_sidecars(image_path, index)
+            if raw_path.exists():
+                remove_split_outputs(raw_path)
+            return
     ordered = order_panels(panels, full_h)  # panels are in the uncropped frame
     out_paths = write_panels(image_path, ordered, base)
     print(

--- a/mapsnap/split_test.py
+++ b/mapsnap/split_test.py
@@ -12,6 +12,8 @@ from mapsnap.split import (
     assemble_panels,
     crop_border,
     invalidate_changed_panels,
+    is_keymap_sheet,
+    keymap_split_rejection,
     merge_collinear,
     order_panels,
     panel_basename,
@@ -170,6 +172,36 @@ def test_invalidate_changed_panels_keeps_unchanged_reads(tmp_path):
     (tmp_path / "p9__1.streets.json").touch()
     assert invalidate_changed_panels(tmp_path / "p9.jpg", new, new) == []
     assert (tmp_path / "p9__1.streets.json").exists()
+
+
+# --- key-map sheets refuse bad cuts (#276) ---
+
+
+def test_is_keymap_sheet_mirrors_the_key_map_candidates():
+    from mapsnap.keymap.identify import is_letter_page
+
+    for stem in ("p0", "p0b", "p0L", "p1", "p1N", "p1a", "pa", "pb"):
+        assert is_keymap_sheet(stem), stem
+    for stem in ("p2", "p57", "p1499m", "p125", "covr", "ind1"):
+        assert not is_keymap_sheet(stem), stem
+    assert is_letter_page("pa") and is_keymap_sheet("pa")
+
+
+def test_keymap_split_rejection_accepts_edge_boxes_and_refuses_notches():
+    sheet = box(0, 0, 1000, 2000)
+    key_box = box(770, 1640, 1000, 2000)  # bottom-right corner: two edges
+    inset = box(0, 1360, 320, 2000)  # bottom-left corner: two edges
+    notch = box(140, 0, 320, 580)  # hangs off the top edge only
+    assert (
+        keymap_split_rejection([sheet.difference(key_box), key_box], 1000, 2000) is None
+    )
+    assert keymap_split_rejection([sheet.difference(inset), inset], 1000, 2000) is None
+    reason = keymap_split_rejection(
+        [sheet.difference(notch).difference(key_box), notch, key_box], 1000, 2000
+    )
+    assert reason is not None and "panel 2" in reason and "1 sheet edge" in reason
+    # A panel the size of the sheet is never a cut-away, whatever its edges say.
+    assert keymap_split_rejection([sheet], 1000, 2000) is None
 
 
 # --- crop_border ---


### PR DESCRIPTION
First step of the #276 plan: bad key-map splits are refused at the source, and routed around where they already exist.

## Why

A key-map sheet the splitter cut into panels is tested panel by panel, so a composite sheet's inset or legend can be set aside. That is right for four of the five split key-map sheets in the corpus. Chicago is the fifth: besides the KEY legend box, the splitter took a **4% notch hanging off the top edge** — interior linework of the key map itself — and that notch carries pages **1–5, 17, 18, 31, 61, 64**. None of them is read on the key-map panel, so ten pages lost their key-map location.

## Which sheets this applies to

Every **key-map candidate**, exactly the set `identify.candidate_keys` nominates: the page-0 and page-1 families with any letter suffix (`p0`, `p0b`, `p0L`, `p1`, `p1N`, `p1a`) and letter-only sheets (`pa`, `pb`). Regular pages are never judged — their panels are insets and composites of every shape. The volumes with a split `p1` on disk today (hudson, kingston, nashville, schenectady) all have an unsplit `p0`, so `detection_plan` short-circuits before the gate and `p1` is treated as the regular first map page it is.

## The rule

What a key-map sheet legitimately loses to a split is always a boxed region in a corner or along an edge, and every one of those is flush with at least two sheet edges:

| panel | area | flush edges | role |
|---|---|---|---|
| chicago p0__1 | 92% | 4 | key map |
| chicago p0__2 | 4% | **1** | **bad cut** (the notch) |
| chicago p0__3 | 4% | 2 | KEY legend |
| detroit p0__2 | 10% | 2 | KEY legend |
| kansas_city p0__2 | 10% | 2 | volume-index inset |
| new_orleans_1951 p0__1 | 14% | 2 | volume-index inset |
| *(key-map panels of the other three)* | 86–90% | 4 | key map |

## Two layers

**At the source — `split.keymap_split_rejection`.** On a key-map candidate sheet, a split whose cut-away (any panel under half the sheet) is flush with fewer than two edges is refused: the sheet stands whole, and the stale panel images, `panels.json`, per-panel sidecars and raw panel copies from earlier runs are removed. So the next baseline re-split **cleans Chicago up on its own**. Verified on a scratch copy of Chicago's p0: the splitter re-derives the notch, prints `split rejected — panel 2 is flush with 1 sheet edge(s)`, and leaves only `p0.jpg` and `raw/p0.jpg`.

**Backstop — `identify.legitimate_keymap_split`.** `detection_plan` applies the same test to whatever panels are on disk and tests the parent sheet whole when they fail, so volumes split by older code are handled correctly *before* their next re-split. On the real volumes today: Chicago flips to `p0`; Kansas City, New Orleans 1951 and Detroit keep their panels; unsplit volumes are unchanged. No `panels.json` means nothing to judge.

Tests: flush-edge counting (including the 2% tolerance), the candidate predicate against `identify`, the rejection rule on edge boxes vs notches, the Chicago and Kansas City shapes through `detection_plan`, and the no-`panels.json` case. 1,106 tests, ruff and pyright pass.

Part of #276 (step 1 of the plan there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
