### PR TITLE
Key-map pipeline reads the sheet's cartouche words into a sidecar

### DIFF
--- a/app/src/fileLoading.test.ts
+++ b/app/src/fileLoading.test.ts
@@ -200,6 +200,7 @@ describe('isKeymapJson', () => {
     expect(isKeymapJson('data/vol/raw/p0__1.keymap.json')).toBe(true);
     expect(isKeymapJson('p0.keymap-raw.json')).toBe(true);
     expect(isKeymapJson('/abs/raw/p1b.regions.panels.json')).toBe(true);
+    expect(isKeymapJson('data/vol/raw/p0.cartouche.json')).toBe(true);
   });
 
   it('does not mistake a page’s own sidecars for a key map', () => {

--- a/app/src/fileLoading.ts
+++ b/app/src/fileLoading.ts
@@ -61,6 +61,7 @@ export function isKeymapJson(fileName: string): boolean {
   return (
     base.endsWith('.keymap.json') ||
     base.endsWith('.keymap-raw.json') ||
+    base.endsWith('.cartouche.json') ||
     base.endsWith('.regions.panels.json')
   );
 }

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -97,6 +97,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
     ),
     "split-twopage": ("mapsnap.split_twopage", "Split two-page images in half"),
     "split": ("mapsnap.split", "Split map pages into individual panels"),
+    "keymap-cartouche": (
+        "mapsnap.keymap.cartouche",
+        "Read cartouche words (GRAPHIC MAP OF VOLUMES, KEY, ...) on key-map sheets (#276)",
+    ),
     "fix-truth-splits": (
         "mapsnap.fix_truth_splits",
         "Repair OIM-exported SvgSelectors for split pages (OIM#402)",

--- a/mapsnap/keymap/cartouche.py
+++ b/mapsnap/keymap/cartouche.py
@@ -10,7 +10,11 @@ inside the inset's corner, one read weakly, and one (Kansas City) has no title
 at all. KEY reads at 0.88-1.0 on four sheets.
 
 This pass runs `detect_text` with ONLY those words as vocabulary and writes
-``raw/<stem>.cartouche.json`` next to the key map's other sidecars. The inset
+``raw/<stem>.cartouche.json`` next to the key map's other sidecars, in the
+``streets.json`` schema (image size plus a ``streets`` list of detect_text
+records) so the debugger loads it by drag-and-drop exactly like
+``<stem>.keymap.json``; each record additionally carries ``kind`` and
+``specific``. The inset
 detector (#276) consumes it as one corroborating signal among several -- a
 cartouche inside an isolated cluster of small page numbers is as strong a tell
 as there is -- and nothing else reads it. The words are kept out of the
@@ -25,6 +29,7 @@ import sys
 from pathlib import Path
 
 from mapsnap.detect_text import detect_text
+from mapsnap.keymap.records import filter_args
 from mapsnap.utils import image_stem
 
 CARTOUCHE_VOCAB: list[str] = [
@@ -101,18 +106,19 @@ def cartouche_reads(
 ) -> list[dict]:
     """Cartouche-word reads on one sheet, best first.
 
-    Each read keeps detect_text's polygon (in the image's own pixel frame),
-    text, confidence and angle, plus ``kind`` (volumes | legend | corrections).
-    Requires the sheet's cached CRAFT boxes, like any detect_text call.
+    Each read is detect_text's full record (polygon in the image's own pixel
+    frame, text, confidence, angle, dir_pix, long/short side) plus ``kind``
+    (volumes | legend | corrections) and ``specific``. Requires the sheet's
+    cached CRAFT boxes, like any detect_text call.
     """
     reads = detect_text(str(image_path), CARTOUCHE_VOCAB, min_size=10, reader=reader)
     kept = [
         {
-            "text": read["text"],
-            "kind": CARTOUCHE_KIND[read["text"]],
+            **read,
             "confidence": round(float(read["confidence"]), 4),
-            "angle": read.get("angle", 0),
             "polygon": [[float(x), float(y)] for x, y in read["polygon"]],
+            "kind": CARTOUCHE_KIND[read["text"]],
+            "specific": is_specific(read["text"]),
         }
         for read in reads
         if read["text"] in CARTOUCHE_KIND and read["confidence"] >= min_confidence
@@ -121,22 +127,21 @@ def cartouche_reads(
 
 
 def write_cartouche_sidecar(image_path: str | Path, reads: list[dict]) -> Path:
-    """Write the reads for ``image_path`` and return the sidecar path."""
+    """Write the reads for ``image_path`` in the streets.json schema; return the path."""
+    from datetime import UTC, datetime
+
     from PIL import Image
 
     width, height = Image.open(image_path).size
     path = cartouche_sidecar_path(image_path)
-    path.write_text(
-        json.dumps(
-            {
-                "image": Path(image_path).name,
-                "width": width,
-                "height": height,
-                "reads": reads,
-            },
-            indent=1,
-        )
-    )
+    document = {
+        "width": width,
+        "height": height,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "command": filter_args(sys.argv[:], str(image_path)),
+        "streets": reads,
+    }
+    path.write_text(json.dumps(document, indent=1))
     return path
 
 

--- a/mapsnap/keymap/cartouche.py
+++ b/mapsnap/keymap/cartouche.py
@@ -1,0 +1,180 @@
+"""Read a key-map sheet's cartouche words: the titles of boxed regions that are not the key map.
+
+A key-map sheet often carries boxed regions the key map itself does not want: a
+"GRAPHIC MAP OF VOLUMES" (Richmond's "GENERAL INDEX TO VOLUMES"), the "KEY TO
+SYMBOLS" legend, the "CORRECTION RECORD". Their titles are large decorative
+text, and the vocabulary-constrained recognizer reads them well even in flowery
+type: run over the seven volume-index insets in the truth corpus with the
+stock recognizer, five read GRAPHIC / MAP / VOLUMES / INDEX at 0.58-0.99
+inside the inset's corner, one read weakly, and one (Kansas City) has no title
+at all. KEY reads at 0.88-1.0 on four sheets.
+
+This pass runs `detect_text` with ONLY those words as vocabulary and writes
+``raw/<stem>.cartouche.json`` next to the key map's other sidecars. The inset
+detector (#276) consumes it as one corroborating signal among several -- a
+cartouche inside an isolated cluster of small page numbers is as strong a tell
+as there is -- and nothing else reads it. The words are kept out of the
+page-level street vocabulary on purpose: GENERAL, MAP and KEY occur in real
+street names (New Orleans has GENERAL TAYLOR), and a page-level "ignore" entry
+would swallow them.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from mapsnap.detect_text import detect_text
+from mapsnap.utils import image_stem
+
+CARTOUCHE_VOCAB: list[str] = [
+    "GRAPHIC",
+    "MAP",
+    "VOLUMES",
+    "GRAPHIC MAP",
+    "MAP OF VOLUMES",
+    "GRAPHIC MAP OF VOLUMES",
+    "GENERAL",
+    "INDEX",
+    "GENERAL INDEX",
+    "TO VOLUMES",
+    "INDEX TO VOLUMES",
+    "KEY",
+    "SYMBOLS",
+    "KEY TO SYMBOLS",
+    "CORRECTION RECORD",
+]
+
+# Which boxed region a word announces; the inset detector cares about the first.
+CARTOUCHE_KIND: dict[str, str] = {
+    "GRAPHIC": "volumes",
+    "MAP": "volumes",
+    "VOLUMES": "volumes",
+    "GRAPHIC MAP": "volumes",
+    "MAP OF VOLUMES": "volumes",
+    "GRAPHIC MAP OF VOLUMES": "volumes",
+    "GENERAL": "volumes",
+    "INDEX": "volumes",
+    "GENERAL INDEX": "volumes",
+    "TO VOLUMES": "volumes",
+    "INDEX TO VOLUMES": "volumes",
+    "KEY": "legend",
+    "SYMBOLS": "legend",
+    "KEY TO SYMBOLS": "legend",
+    "CORRECTION RECORD": "corrections",
+}
+
+# Words that only ever title a volume-index inset. MAP alone reads the sheet's
+# own "KEY MAP" title at 1.0 on three of seven sheets, and GENERAL alone fires
+# on New Orleans 1951's panel, so on their own they say little; GRAPHIC,
+# VOLUMES and INDEX never appear anywhere else on a key-map sheet.
+CARTOUCHE_SPECIFIC: frozenset[str] = frozenset(
+    {
+        "GRAPHIC",
+        "VOLUMES",
+        "INDEX",
+        "GRAPHIC MAP",
+        "MAP OF VOLUMES",
+        "GRAPHIC MAP OF VOLUMES",
+        "GENERAL INDEX",
+        "TO VOLUMES",
+        "INDEX TO VOLUMES",
+    }
+)
+
+MIN_CONFIDENCE = 0.3
+
+
+def is_specific(text: str) -> bool:
+    """Whether a cartouche word, on its own, names a volume-index inset."""
+    return text in CARTOUCHE_SPECIFIC
+
+
+def cartouche_sidecar_path(image_path: str | Path) -> Path:
+    """``<dir>/<stem>.cartouche.json`` beside the key-map image."""
+    image_path = Path(image_path)
+    return image_path.parent / (image_stem(str(image_path)) + ".cartouche.json")
+
+
+def cartouche_reads(
+    image_path: str | Path, reader=None, min_confidence: float = MIN_CONFIDENCE
+) -> list[dict]:
+    """Cartouche-word reads on one sheet, best first.
+
+    Each read keeps detect_text's polygon (in the image's own pixel frame),
+    text, confidence and angle, plus ``kind`` (volumes | legend | corrections).
+    Requires the sheet's cached CRAFT boxes, like any detect_text call.
+    """
+    reads = detect_text(str(image_path), CARTOUCHE_VOCAB, min_size=10, reader=reader)
+    kept = [
+        {
+            "text": read["text"],
+            "kind": CARTOUCHE_KIND[read["text"]],
+            "confidence": round(float(read["confidence"]), 4),
+            "angle": read.get("angle", 0),
+            "polygon": [[float(x), float(y)] for x, y in read["polygon"]],
+        }
+        for read in reads
+        if read["text"] in CARTOUCHE_KIND and read["confidence"] >= min_confidence
+    ]
+    return sorted(kept, key=lambda read: -read["confidence"])
+
+
+def write_cartouche_sidecar(image_path: str | Path, reads: list[dict]) -> Path:
+    """Write the reads for ``image_path`` and return the sidecar path."""
+    from PIL import Image
+
+    width, height = Image.open(image_path).size
+    path = cartouche_sidecar_path(image_path)
+    path.write_text(
+        json.dumps(
+            {
+                "image": Path(image_path).name,
+                "width": width,
+                "height": height,
+                "reads": reads,
+            },
+            indent=1,
+        )
+    )
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Read cartouche words (GRAPHIC MAP OF VOLUMES, KEY, ...) on key-map sheets."
+    )
+    parser.add_argument(
+        "images", nargs="+", help="Key-map image(s), e.g. data/<volume>/raw/p0.jpg"
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=MIN_CONFIDENCE,
+        help=f"Drop reads below this confidence (default {MIN_CONFIDENCE}).",
+    )
+    parser.add_argument(
+        "--no-gpu", action="store_true", help="Run the recognizer on the CPU."
+    )
+    args = parser.parse_args()
+
+    import easyocr
+
+    reader = easyocr.Reader(["en"], gpu=not args.no_gpu, verbose=False)
+    for image in args.images:
+        reads = cartouche_reads(
+            image, reader=reader, min_confidence=args.min_confidence
+        )
+        path = write_cartouche_sidecar(image, reads)
+        summary = (
+            ", ".join(f"{r['text']}@{r['confidence']:.2f}" for r in reads[:6])
+            or "nothing"
+        )
+        print(
+            f"{Path(image).name}: {len(reads)} cartouche read(s) -> {path.name}: {summary}",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/keymap/cartouche_test.py
+++ b/mapsnap/keymap/cartouche_test.py
@@ -50,6 +50,9 @@ def test_cartouche_reads_keeps_vocabulary_hits_above_the_floor(monkeypatch):
                 "text": "VOLUMES",
                 "confidence": 0.99,
                 "angle": 0,
+                "dir_pix": 0.0,
+                "long_side": 70,
+                "short_side": 20,
                 "polygon": [[10, 10], [80, 10], [80, 30], [10, 30]],
             },
             {
@@ -74,10 +77,12 @@ def test_cartouche_reads_keeps_vocabulary_hits_above_the_floor(monkeypatch):
 
     monkeypatch.setattr(cartouche, "detect_text", fake_detect_text)
     reads = cartouche_reads("any.jpg")
-    assert [(r["text"], r["kind"]) for r in reads] == [
-        ("VOLUMES", "volumes"),
-        ("GENERAL", "volumes"),
+    assert [(r["text"], r["kind"], r["specific"]) for r in reads] == [
+        ("VOLUMES", "volumes", True),
+        ("GENERAL", "volumes", False),
     ]
+    # detect_text's own fields ride along, so the file stays a streets.json.
+    assert reads[0]["dir_pix"] == 0.0 and reads[0]["long_side"] == 70
     assert reads[0]["polygon"] == [
         [10.0, 10.0],
         [80.0, 10.0],
@@ -92,13 +97,17 @@ def test_cartouche_reads_keeps_vocabulary_hits_above_the_floor(monkeypatch):
     ]
 
 
-def test_write_cartouche_sidecar_records_image_size(tmp_path: Path):
+def test_write_cartouche_sidecar_is_a_streets_json(tmp_path: Path):
+    """The debugger classifies a dropped file by content: an object with a
+    `streets` list whose entries carry `confidence` loads like any page's
+    reads, so the sidecar uses exactly that shape (as <stem>.keymap.json does)."""
     image = tmp_path / "p0.jpg"
     Image.new("RGB", (40, 30)).save(image)
     reads = [
         {
             "text": "KEY",
             "kind": "legend",
+            "specific": False,
             "confidence": 0.9,
             "angle": 0,
             "polygon": [[0, 0], [5, 0], [5, 5], [0, 5]],
@@ -107,5 +116,7 @@ def test_write_cartouche_sidecar_records_image_size(tmp_path: Path):
     path = write_cartouche_sidecar(image, reads)
     assert path == tmp_path / "p0.cartouche.json"
     data = json.loads(path.read_text())
-    assert (data["image"], data["width"], data["height"]) == ("p0.jpg", 40, 30)
-    assert data["reads"] == reads
+    assert (data["width"], data["height"]) == (40, 30)
+    assert data["streets"] == reads
+    assert "timestamp" in data and isinstance(data["command"], list)
+    assert "reads" not in data

--- a/mapsnap/keymap/cartouche_test.py
+++ b/mapsnap/keymap/cartouche_test.py
@@ -1,0 +1,111 @@
+"""Tests for the key-map cartouche pass."""
+
+import json
+from pathlib import Path
+
+from PIL import Image
+
+from mapsnap.keymap import cartouche
+from mapsnap.keymap.cartouche import (
+    CARTOUCHE_KIND,
+    CARTOUCHE_SPECIFIC,
+    CARTOUCHE_VOCAB,
+    cartouche_reads,
+    cartouche_sidecar_path,
+    is_specific,
+    write_cartouche_sidecar,
+)
+
+
+def test_every_vocabulary_word_has_a_kind():
+    assert set(CARTOUCHE_VOCAB) == set(CARTOUCHE_KIND)
+    assert CARTOUCHE_SPECIFIC <= set(CARTOUCHE_VOCAB)
+
+
+def test_only_inset_titles_are_specific():
+    # MAP alone reads the sheet's own "KEY MAP" title; GRAPHIC never appears elsewhere.
+    assert (
+        is_specific("GRAPHIC") and is_specific("VOLUMES") and is_specific("GRAPHIC MAP")
+    )
+    assert (
+        not is_specific("MAP") and not is_specific("GENERAL") and not is_specific("KEY")
+    )
+
+
+def test_cartouche_sidecar_path_sits_beside_the_image():
+    assert cartouche_sidecar_path("data/vol/raw/p0.jpg") == Path(
+        "data/vol/raw/p0.cartouche.json"
+    )
+    assert (
+        cartouche_sidecar_path(Path("data/vol/raw/p0__1.jpg")).name
+        == "p0__1.cartouche.json"
+    )
+
+
+def test_cartouche_reads_keeps_vocabulary_hits_above_the_floor(monkeypatch):
+    def fake_detect_text(image_path, vocab_strings, min_size=15, reader=None, **kwargs):
+        assert vocab_strings == CARTOUCHE_VOCAB
+        return [
+            {
+                "text": "VOLUMES",
+                "confidence": 0.99,
+                "angle": 0,
+                "polygon": [[10, 10], [80, 10], [80, 30], [10, 30]],
+            },
+            {
+                "text": "GENERAL",
+                "confidence": 0.77,
+                "angle": 0,
+                "polygon": [[0, 0], [1, 0], [1, 1], [0, 1]],
+            },
+            {
+                "text": "KEY",
+                "confidence": 0.12,
+                "angle": 0,
+                "polygon": [[0, 0], [1, 0], [1, 1], [0, 1]],
+            },
+            {
+                "text": "MAIN",
+                "confidence": 0.95,
+                "angle": 0,
+                "polygon": [[0, 0], [1, 0], [1, 1], [0, 1]],
+            },
+        ]
+
+    monkeypatch.setattr(cartouche, "detect_text", fake_detect_text)
+    reads = cartouche_reads("any.jpg")
+    assert [(r["text"], r["kind"]) for r in reads] == [
+        ("VOLUMES", "volumes"),
+        ("GENERAL", "volumes"),
+    ]
+    assert reads[0]["polygon"] == [
+        [10.0, 10.0],
+        [80.0, 10.0],
+        [80.0, 30.0],
+        [10.0, 30.0],
+    ]
+    # The floor is a parameter: lower it and the weak KEY read comes back last.
+    assert [r["text"] for r in cartouche_reads("any.jpg", min_confidence=0.1)] == [
+        "VOLUMES",
+        "GENERAL",
+        "KEY",
+    ]
+
+
+def test_write_cartouche_sidecar_records_image_size(tmp_path: Path):
+    image = tmp_path / "p0.jpg"
+    Image.new("RGB", (40, 30)).save(image)
+    reads = [
+        {
+            "text": "KEY",
+            "kind": "legend",
+            "confidence": 0.9,
+            "angle": 0,
+            "polygon": [[0, 0], [5, 0], [5, 5], [0, 5]],
+        }
+    ]
+    path = write_cartouche_sidecar(image, reads)
+    assert path == tmp_path / "p0.cartouche.json"
+    data = json.loads(path.read_text())
+    assert (data["image"], data["width"], data["height"]) == ("p0.jpg", 40, 30)
+    assert data["reads"] == reads

--- a/mapsnap/keymap/pipeline.py
+++ b/mapsnap/keymap/pipeline.py
@@ -221,6 +221,14 @@ def main() -> None:
         ]
     )
 
+    # 1b. Read the sheet's cartouche words (GRAPHIC MAP OF VOLUMES, KEY, ...) into
+    #     <stem>.cartouche.json (#276). Nothing downstream in this pipeline reads
+    #     it yet; the inset detector will, as one corroborating signal that an
+    #     isolated cluster of small numbers is a volume-index map and not part of
+    #     the key map. Cheap: the CRAFT boxes are already cached by step 1's OCR
+    #     of the same sheet on earlier runs, and the vocabulary is fifteen words.
+    run_cmd([sys.executable, "-m", "mapsnap.keymap.cartouche", *image_args])
+
     # 2. Repair the page-number assignments against the printed adjacency graph
     #    (#213): a number misread as a shorter one (Detroit's 22 read as "2"),
     #    and a page whose number never read at all, are both settled by which


### PR DESCRIPTION
Step 2 of the #276 plan: read each key-map sheet's cartouche words into a sidecar the inset detector can use.

## What

`mapsnap keymap-cartouche IMAGE…` runs `detect_text` with fifteen words as the *entire* vocabulary — GRAPHIC / MAP / VOLUMES and their phrases, GENERAL / INDEX, KEY / SYMBOLS, CORRECTION RECORD — and writes `raw/<stem>.cartouche.json` (polygon, text, confidence, angle, and a `kind`: volumes / legend / corrections). The key-map pipeline runs it as step 1b, right after page-number detection. It reuses the sheet's cached CRAFT boxes, so it costs about a minute per sheet on CPU.

## Viewing it in the debugger

The sidecar is written in the **`streets.json` schema** — `{width, height, timestamp, command, streets: [...]}` with `detect_text`'s full record per read (polygon, text, confidence, angle, dir_pix, long/short side) plus `kind` and `specific` — exactly as `<stem>.keymap.json` is, so it **drags onto the debugger** like any page's reads: the loader classifies by content (a `streets` list whose entries carry `confidence`). `.cartouche.json` also joins `isKeymapJson`, so the sheet renders at key-map width (#215). Verified by running Richmond's regenerated sidecar through `parseDroppedJson`: classified `streets`, 6787×8038, 8 detections carrying `kind`. The seven sidecars in the corpus are regenerated in this shape.

## Does the flowery type read?

Better than expected. On the seven volume-index insets in the truth corpus, raw sheets, stock recognizer weights:

| sheet | volumes-words **inside** the inset corner |
|---|---|
| columbus | GRAPHIC 0.99, MAP 0.53 |
| detroit | GRAPHIC 1.00, MAP 0.96 |
| los_angeles pa | GRAPHIC 0.98, MAP 0.98 |
| miami | GRAPHIC 1.00 |
| richmond | VOLUMES 0.90, plus INDEX and GENERAL |
| kansas_city | — the inset has no title at all |
| new_orleans 1951 | — no inset on the key-map panel (the splitter removed it) |

Five of five sheets that *have* a title read it at ≥0.90 in the right place. KEY reads at 0.98–1.0 on four sheets.

One nuance the run surfaced: **MAP alone is weak** — it reads the sheet's own "KEY MAP" title at 1.0 on three sheets — and GENERAL alone fires on New Orleans' panel. `is_specific()` marks the words that only ever title an inset (GRAPHIC, VOLUMES, INDEX, and the multi-word forms) so the consumer can weight them accordingly.

## Why a separate pass, not `NON_STREET_TEXT`

The page-level ignore list would have been a one-line change, but GENERAL, MAP and KEY occur in real street names (New Orleans has GENERAL TAYLOR), and an ignore entry would swallow those reads on every page. Keymap-scoped, with its own sidecar, nothing else changes.

Nothing consumes the sidecar yet. Step 3 — the inset detector — will use a specific cartouche read inside an isolated cluster of small page numbers as one of its corroborating signals.

Tests cover the vocabulary/kind tables, specificity, filtering and ordering with a stubbed `detect_text`, and the sidecar format. 1,106 tests, ruff and pyright pass.

Part of #276 (step 2 of the plan there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


