### PR TITLE
Find and mask the volume-index insets on key-map sheets

### DIFF
--- a/app/src/fileLoading.test.ts
+++ b/app/src/fileLoading.test.ts
@@ -201,6 +201,7 @@ describe('isKeymapJson', () => {
     expect(isKeymapJson('p0.keymap-raw.json')).toBe(true);
     expect(isKeymapJson('/abs/raw/p1b.regions.panels.json')).toBe(true);
     expect(isKeymapJson('data/vol/raw/p0.cartouche.json')).toBe(true);
+    expect(isKeymapJson('data/vol/raw/p0.inset.panels.json')).toBe(true);
   });
 
   it('does not mistake a page’s own sidecars for a key map', () => {

--- a/app/src/fileLoading.ts
+++ b/app/src/fileLoading.ts
@@ -62,6 +62,7 @@ export function isKeymapJson(fileName: string): boolean {
     base.endsWith('.keymap.json') ||
     base.endsWith('.keymap-raw.json') ||
     base.endsWith('.cartouche.json') ||
+    base.endsWith('.inset.panels.json') ||
     base.endsWith('.regions.panels.json')
   );
 }

--- a/docs/fit-pipeline.md
+++ b/docs/fit-pipeline.md
@@ -11,7 +11,9 @@ stood, per-panel share and edge-flushness, stale sidecars removed),
 `keymap-plan` / `keymap-detect` (how the sheet was nominated and confirmed as a
 key map), `detect-numbers` (candidates, reads, valid page keys not read),
 `assignment-repair`, `cartouche` (the GRAPHIC MAP / KEY / INDEX words read and
-where), and, once #276 lands, `inset`. A rerun replaces a stage's section in
+where), and `inset` (each isolated small-number cluster, its no-snap re-read,
+the cartouche words near it, and the verdict; the confirmed masks are written
+to `raw/<stem>.inset.panels.json`). A rerun replaces a stage's section in
 place, each header carries a UTC timestamp, and `archive_run` copies the logs
 into `<run>/raw/`.
 

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -97,6 +97,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
     ),
     "split-twopage": ("mapsnap.split_twopage", "Split two-page images in half"),
     "split": ("mapsnap.split", "Split map pages into individual panels"),
+    "keymap-inset": (
+        "mapsnap.keymap.inset",
+        "Find and mask volume-index insets on key-map sheets (#276)",
+    ),
     "keymap-cartouche": (
         "mapsnap.keymap.cartouche",
         "Read cartouche words (GRAPHIC MAP OF VOLUMES, KEY, ...) on key-map sheets (#276)",

--- a/mapsnap/keymap/inset.py
+++ b/mapsnap/keymap/inset.py
@@ -1,0 +1,409 @@
+"""Find the volume-index insets on a key-map sheet and mask them (#276).
+
+Many key-map sheets carry a "GRAPHIC MAP OF VOLUMES" (Richmond: "GENERAL INDEX
+TO VOLUMES"): a second map of the whole city, at a coarser scale, whose
+numerals are volume numbers. The page-number detector reads them like any
+other number, and the damage is downstream -- Richmond p311 was published
+14,713 ft from truth because the inset's "1" was snapped to the sole valid
+page within edit distance and became a third search center.
+
+The tell is *distance*, on the reads themselves. Measured over the 23
+truth-labeled key-map sheets, clustering reads by single linkage at
+EPS_SPACING times the sheet's median nearest-neighbour spacing and flagging a
+cluster with at least MIN_READS reads, at most DOMINANCE of the largest
+cluster, and a majority of small numbers caught 38 junk reads and masked zero
+true page numbers, robustly across the parameter sweep. Ink connectivity was
+tried first and does worse: the faint base street grid or the inset's own
+border bridges the ink on columbus and los_angeles, but the reads stay
+isolated. Ellenville-shaped sheets -- two real key maps side by side (the
+village and Napanoch), all small page numbers -- are not flagged because
+neither cluster is dominated; they are reported as separate key maps.
+
+Isolation carries the rule; small numbers only corroborate, because
+Richmond's inset reads ``2 3 4 311`` and miami's inset numerals 1-5 are also
+real pages of that volume. Two corroborations, either of which confirms:
+
+- re-reading the cluster's numerals against a 1..SMALL_MAX vocabulary with no
+  edit-distance repair (the "311" glyph reads as "1"), and
+- a *specific* cartouche word (GRAPHIC, VOLUMES, INDEX; see cartouche.py)
+  inside the cluster's hull.
+
+Output is ``raw/<stem>.inset.panels.json`` in the panels.json shape the
+debugger renders (one ring per inset, labelled), plus an ``inset`` section in
+the sheet's decision log. ``inset_rings`` is the consumer's entry point.
+"""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+from shapely.geometry import MultiPoint, Point, Polygon, box
+
+from mapsnap.keymap.cartouche import cartouche_sidecar_path, is_specific
+from mapsnap.keymap.log import append_keymap_log
+from mapsnap.keymap.records import keymap_path, page_key_sort
+from mapsnap.utils import image_stem
+
+SMALL_MAX = 15  # a "small number": plausible volume index, 1..15
+EPS_SPACING = (
+    3.0  # cluster radius, as a multiple of the median nearest-neighbour spacing
+)
+DOMINANCE = 1 / 3  # a cluster larger than this share of the biggest is part of the map
+MIN_READS = 2
+SMALL_MAJORITY = 0.5
+MARGIN_SPACING = 1.0  # mask margin around the cluster hull, in spacings
+# How far from the cluster hull a cartouche title may sit and still belong to
+# it: the title is printed above or beside the inset map, not among its
+# numerals -- richmond 1.3, detroit 1.3, columbus 1.7, los_angeles 2.2 spacings
+# (miami's 4.4 is confirmed by the re-read instead). Only *specific* words
+# count, and those never appear elsewhere on a key-map sheet.
+CARTOUCHE_SPACINGS = 3.0
+SEPARATE_MIN_READS = 5  # a non-dominant cluster this big is a key map of its own
+REREAD_MIN_CONFIDENCE = 0.2
+
+
+@dataclass
+class Read:
+    """One page-number read on the sheet, in its own pixel frame."""
+
+    text: str
+    confidence: float
+    polygon: list[list[float]]
+    center: tuple[float, float]
+
+
+@dataclass
+class Inset:
+    """One flagged cluster and the evidence behind its verdict."""
+
+    indices: list[int]
+    texts: list[str]
+    n_small: int
+    ring: list[list[float]]
+    reread: tuple[int, int] | None = None  # (raw decodes that are small, decodes)
+    cartouche: list[str] = field(default_factory=list)
+
+    @property
+    def confirmed(self) -> bool:
+        """Whether a corroboration backs the distance rule."""
+        by_reread = (
+            self.reread is not None
+            and self.reread[1] > 0
+            and (self.reread[0] >= SMALL_MAJORITY * self.reread[1])
+        )
+        return by_reread or bool(self.cartouche)
+
+    def label(self) -> str:
+        """The panels.json label: what was read and what confirmed it."""
+        evidence = []
+        if self.reread is not None:
+            evidence.append(f"re-read small {self.reread[0]}/{self.reread[1]}")
+        if self.cartouche:
+            evidence.append("cartouche " + ", ".join(self.cartouche))
+        return f"volumes inset: {', '.join(self.texts)}" + (
+            f" ({'; '.join(evidence)})" if evidence else " (unconfirmed)"
+        )
+
+
+@dataclass
+class InsetResult:
+    """Everything the detector decided about one sheet."""
+
+    width: int
+    height: int
+    spacing: float
+    insets: list[Inset]
+    candidates: list[Inset]  # rule clusters, confirmed or not
+    separate_keymaps: bool
+    n_reads: int
+
+
+def is_small(text: str) -> bool:
+    """A read that could be a volume index rather than a page number."""
+    return text.isdigit() and 1 <= int(text) <= SMALL_MAX
+
+
+def polygon_center(polygon: list[list[float]]) -> tuple[float, float]:
+    xs = [p[0] for p in polygon]
+    ys = [p[1] for p in polygon]
+    return (sum(xs) / len(xs), sum(ys) / len(ys))
+
+
+def load_reads(image_path: str | Path) -> tuple[list[Read], int, int]:
+    """(reads, width, height) from the sheet's <stem>.keymap.json."""
+    doc = json.loads(Path(keymap_path(str(image_path))).read_text())
+    reads = [
+        Read(
+            text=str(d["text"]),
+            confidence=float(d.get("confidence", 0.0)),
+            polygon=[[float(x), float(y)] for x, y in d["polygon"]],
+            center=polygon_center(d["polygon"]),
+        )
+        for d in doc.get("streets", [])
+    ]
+    return reads, int(doc["width"]), int(doc["height"])
+
+
+def median_spacing(centers: list[tuple[float, float]]) -> float:
+    """Median nearest-neighbour distance between reads (0 for fewer than two)."""
+    if len(centers) < 2:
+        return 0.0
+    pts = np.asarray(centers, dtype=float)
+    dists = np.sqrt(((pts[:, None, :] - pts[None, :, :]) ** 2).sum(-1))
+    np.fill_diagonal(dists, np.inf)
+    return float(np.median(dists.min(axis=1)))
+
+
+def cluster_reads(centers: list[tuple[float, float]], eps: float) -> list[list[int]]:
+    """Single-linkage clusters of read indices at radius ``eps``, largest first."""
+    n = len(centers)
+    parent = list(range(n))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    pts = np.asarray(centers, dtype=float)
+    for i in range(n):
+        for j in range(i + 1, n):
+            if float(np.hypot(*(pts[i] - pts[j]))) <= eps:
+                parent[find(i)] = find(j)
+    groups: dict[int, list[int]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(i)
+    return sorted(groups.values(), key=len, reverse=True)
+
+
+def cluster_ring(
+    reads: list[Read], indices: list[int], margin: float, width: int, height: int
+) -> list[list[float]]:
+    """Convex hull of the cluster's read polygons, buffered by ``margin`` and clipped."""
+    points = [tuple(p) for i in indices for p in reads[i].polygon]
+    hull = (
+        MultiPoint(points)
+        .convex_hull.buffer(margin)
+        .intersection(box(0, 0, width, height))
+    )
+    if not isinstance(hull, Polygon):  # clipping can split a sliver off
+        hull = hull.convex_hull
+    assert isinstance(hull, Polygon)
+    return [[round(x, 1), round(y, 1)] for x, y in hull.exterior.coords]
+
+
+def cartouche_words_near(
+    image_path: str | Path, ring: list[list[float]], radius: float
+) -> list[str]:
+    """Specific cartouche words within ``radius`` of ``ring`` (from <stem>.cartouche.json)."""
+    path = cartouche_sidecar_path(image_path)
+    if not path.exists():
+        return []
+    hull = Polygon(ring)
+    words = []
+    for read in json.loads(path.read_text()).get("streets", []):
+        if not is_specific(read["text"]):
+            continue
+        if hull.distance(Point(polygon_center(read["polygon"]))) <= radius:
+            words.append(read["text"])
+    return words
+
+
+def reread_small_count(
+    image: np.ndarray, reads: list[Read], indices: list[int], crnn, device
+) -> tuple[int, int]:
+    """(raw decodes that are small numbers, decodes) for the cluster's numerals.
+
+    The main pass snaps every read to the nearest valid page number, which is
+    exactly how an inset's "1" became a valid "311". Here the CRNN's raw
+    greedy decode is kept as is: no vocabulary, no repair.
+    """
+    from mapsnap.keymap.crnn_model import central_group, ctc_greedy_decode
+    from mapsnap.keymap.detect_numbers_crnn import read_candidates
+    from mapsnap.keymap.keymap_patches import working_scale
+
+    height, width = image.shape[:2]
+    factor = working_scale(width, height)
+    centers = [reads[i].center for i in indices]
+    results, _ = read_candidates(image, centers, factor, crnn, device)
+    n_small = n_decoded = 0
+    for confidence, path in results:
+        group = central_group(path)
+        if group is None or confidence < REREAD_MIN_CONFIDENCE:
+            continue
+        text = ctc_greedy_decode(path[group[0] : group[1] + 1])
+        if not text:
+            continue
+        n_decoded += 1
+        n_small += is_small(text)
+    return n_small, n_decoded
+
+
+def detect_insets(
+    image_path: str | Path,
+    *,
+    reread: bool = False,
+    crnn=None,
+    device=None,
+) -> InsetResult:
+    """Apply the distance rule and its corroborations to one sheet's reads."""
+    reads, width, height = load_reads(image_path)
+    centers = [r.center for r in reads]
+    spacing = median_spacing(centers)
+    clusters = cluster_reads(centers, EPS_SPACING * spacing) if spacing > 0 else []
+    biggest = len(clusters[0]) if clusters else 0
+    candidates: list[Inset] = []
+    for indices in clusters:
+        if len(indices) < MIN_READS or len(indices) > DOMINANCE * biggest:
+            continue
+        texts = [reads[i].text for i in indices]
+        n_small = sum(is_small(t) for t in texts)
+        if n_small < SMALL_MAJORITY * len(indices):
+            continue
+        ring = cluster_ring(reads, indices, MARGIN_SPACING * spacing, width, height)
+        inset = Inset(
+            indices=indices,
+            texts=sorted(texts, key=page_key_sort),
+            n_small=n_small,
+            ring=ring,
+            cartouche=cartouche_words_near(
+                image_path, ring, CARTOUCHE_SPACINGS * spacing
+            ),
+        )
+        candidates.append(inset)
+    if reread and candidates:
+        from PIL import Image
+
+        image = np.asarray(Image.open(image_path).convert("RGB"))
+        for inset in candidates:
+            inset.reread = reread_small_count(image, reads, inset.indices, crnn, device)
+    # Two or more sizeable clusters with no dominant one: separate key maps on
+    # one sheet (Ellenville's village + Napanoch), never an inset.
+    sizeable = [c for c in clusters if len(c) >= SEPARATE_MIN_READS]
+    separate = len(sizeable) >= 2 and all(
+        len(c) > DOMINANCE * biggest for c in sizeable
+    )
+    return InsetResult(
+        width=width,
+        height=height,
+        spacing=spacing,
+        insets=[c for c in candidates if c.confirmed],
+        candidates=candidates,
+        separate_keymaps=separate,
+        n_reads=len(reads),
+    )
+
+
+def inset_sidecar_path(image_path: str | Path) -> Path:
+    """``<dir>/<stem>.inset.panels.json`` beside the key-map image."""
+    image_path = Path(image_path)
+    return image_path.parent / (image_stem(str(image_path)) + ".inset.panels.json")
+
+
+def write_inset_sidecar(image_path: str | Path, result: InsetResult) -> Path:
+    """Write the confirmed insets as a labelled panels.json; return the path."""
+    path = inset_sidecar_path(image_path)
+    path.write_text(
+        json.dumps(
+            {
+                "image": Path(image_path).name,
+                "width": result.width,
+                "height": result.height,
+                "panels": [inset.ring for inset in result.insets],
+                "labels": [inset.label() for inset in result.insets],
+            },
+            indent=1,
+        )
+    )
+    return path
+
+
+def inset_rings(image_path: str | Path) -> list[Polygon]:
+    """The sheet's confirmed inset masks as polygons, or [] with no sidecar."""
+    path = inset_sidecar_path(image_path)
+    if not path.exists():
+        return []
+    return [Polygon(ring).buffer(0) for ring in json.loads(path.read_text())["panels"]]
+
+
+def log_lines(result: InsetResult) -> list[str]:
+    """The decision-log section for one sheet."""
+    lines = [
+        (
+            f"{result.n_reads} reads, median spacing {result.spacing:.0f} px, "
+            f"cluster radius {EPS_SPACING * result.spacing:.0f} px"
+        )
+    ]
+    if not result.candidates:
+        lines.append("no isolated small-number cluster")
+    for inset in result.candidates:
+        verdict = "INSET (masked)" if inset.confirmed else "unconfirmed (not masked)"
+        lines.append(
+            f"cluster of {len(inset.indices)} reads, {inset.n_small} small: "
+            + ", ".join(inset.texts)
+        )
+        if inset.reread is not None:
+            lines.append(
+                f"  re-read without snapping: {inset.reread[0]}/{inset.reread[1]} small"
+            )
+        lines.append(
+            f"  specific cartouche within {CARTOUCHE_SPACINGS:g} spacings: "
+            + (", ".join(inset.cartouche) if inset.cartouche else "none")
+        )
+        lines.append(f"  → {verdict}")
+    if result.separate_keymaps:
+        lines.append(
+            "several sizeable clusters and no dominant one: separate key maps, nothing masked"
+        )
+    return lines
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Find and mask volume-index insets on key-map sheets (#276)."
+    )
+    parser.add_argument(
+        "images", nargs="+", help="Key-map image(s), e.g. data/<volume>/raw/p0.jpg"
+    )
+    parser.add_argument(
+        "--no-reread",
+        action="store_true",
+        help="Skip the CRNN re-read corroboration (cartouche words alone then confirm).",
+    )
+    parser.add_argument(
+        "--crnn-weights", type=Path, default=Path("models/number_crnn.pt")
+    )
+    parser.add_argument(
+        "--no-gpu", action="store_true", help="Run the recognizer on the CPU."
+    )
+    args = parser.parse_args()
+
+    crnn = device = None
+    if not args.no_reread:
+        import torch
+
+        from mapsnap.keymap.crnn_model import build_crnn
+        from mapsnap.keymap.number_model import select_device
+
+        device = select_device() if not args.no_gpu else torch.device("cpu")
+        crnn = build_crnn()
+        crnn.load_state_dict(torch.load(args.crnn_weights, map_location=device))
+        crnn.to(device)
+    for image in args.images:
+        result = detect_insets(
+            image, reread=not args.no_reread, crnn=crnn, device=device
+        )
+        path = write_inset_sidecar(image, result)
+        append_keymap_log(image, "inset", log_lines(result))
+        summary = "; ".join(inset.label() for inset in result.insets) or "none"
+        print(
+            f"{Path(image).name}: {len(result.insets)} inset(s) -> {path.name}: {summary}",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/keymap/inset_test.py
+++ b/mapsnap/keymap/inset_test.py
@@ -1,0 +1,199 @@
+"""Tests for the volume-index inset detector."""
+
+import json
+from pathlib import Path
+
+from shapely.geometry import Point
+
+from mapsnap.keymap.inset import (
+    Inset,
+    cluster_reads,
+    detect_insets,
+    inset_rings,
+    inset_sidecar_path,
+    is_small,
+    log_lines,
+    median_spacing,
+    write_inset_sidecar,
+)
+
+
+def _record(text: str, x: float, y: float, size: float = 30.0) -> dict:
+    return {
+        "text": text,
+        "confidence": 0.95,
+        "angle": 0,
+        "polygon": [[x, y], [x + size, y], [x + size, y + size], [x, y + size]],
+    }
+
+
+def _sheet(
+    tmp_path: Path, reads: list[dict], cartouche: list[dict] | None = None
+) -> Path:
+    raw = tmp_path / "vol" / "raw"
+    raw.mkdir(parents=True)
+    image = raw / "p0.jpg"
+    image.touch()
+    (raw / "p0.keymap.json").write_text(
+        json.dumps({"width": 4000, "height": 5000, "streets": reads})
+    )
+    if cartouche is not None:
+        (raw / "p0.cartouche.json").write_text(
+            json.dumps({"width": 4000, "height": 5000, "streets": cartouche})
+        )
+    return image
+
+
+def _grid(
+    n_cols: int, n_rows: int, x0: float, y0: float, step: float, start: int = 300
+):
+    """A main key map: page numbers on a regular grid."""
+    return [
+        _record(str(start + r * n_cols + c), x0 + c * step, y0 + r * step)
+        for r in range(n_rows)
+        for c in range(n_cols)
+    ]
+
+
+def test_is_small_is_a_volume_index_range():
+    assert is_small("1") and is_small("15")
+    assert (
+        not is_small("0")
+        and not is_small("16")
+        and not is_small("4A")
+        and not is_small("311")
+    )
+
+
+def test_cluster_reads_single_linkage_largest_first():
+    centers = [(0.0, 0.0), (10.0, 0.0), (20.0, 0.0), (500.0, 500.0), (505.0, 500.0)]
+    assert cluster_reads(centers, 15) == [[0, 1, 2], [3, 4]]
+    assert median_spacing(centers) == 10.0
+
+
+def test_richmond_shaped_inset_is_found_with_its_snapped_read(tmp_path: Path):
+    """An isolated cluster reading `2 3 4 311` (the inset's "1" snapped to a valid
+    page) is an inset: small majority, far from the grid, GENERAL INDEX cartouche."""
+    main = _grid(6, 6, 1500, 800, 300)  # 36 pages, 300 px apart
+    inset = [
+        _record("2", 300, 4300),
+        _record("3", 450, 4200),
+        _record("4", 250, 4450),
+        _record("311", 400, 4500),
+    ]
+    cartouche = [
+        {
+            "text": "VOLUMES",
+            "confidence": 0.9,
+            "polygon": [[300, 3950], [500, 3950], [500, 4000], [300, 4000]],
+        },
+        {
+            "text": "KEY",
+            "confidence": 1.0,
+            "polygon": [[3000, 100], [3200, 100], [3200, 150], [3000, 150]],
+        },
+    ]
+    image = _sheet(tmp_path, main + inset, cartouche)
+    result = detect_insets(image)
+    assert [c.texts for c in result.candidates] == [["2", "3", "4", "311"]]
+    assert result.candidates[0].cartouche == ["VOLUMES"]
+    assert len(result.insets) == 1 and result.insets[0].confirmed
+    assert not result.separate_keymaps
+    path = write_inset_sidecar(image, result)
+    assert (
+        path
+        == inset_sidecar_path(image)
+        == tmp_path / "vol" / "raw" / "p0.inset.panels.json"
+    )
+    data = json.loads(path.read_text())
+    assert (data["width"], data["height"], len(data["panels"])) == (4000, 5000, 1)
+    assert data["labels"] == ["volumes inset: 2, 3, 4, 311 (cartouche VOLUMES)"]
+    # The mask covers the inset's reads and none of the key map's.
+    (ring,) = inset_rings(image)
+    assert all(ring.contains(Point(r["polygon"][0])) for r in inset)
+    assert not any(ring.contains(Point(r["polygon"][0])) for r in main)
+
+
+def test_cartouche_title_counts_within_a_few_spacings_of_the_cluster(tmp_path: Path):
+    """The title is printed above or beside the inset map, not among its numerals."""
+    main = _grid(6, 6, 1500, 800, 300)  # spacing 300
+    inset = [
+        _record("2", 300, 4300),
+        _record("3", 450, 4200),
+        _record("4", 250, 4450),
+        _record("1", 400, 4500),
+    ]
+
+    def title_at(y: float) -> list[dict]:
+        return [
+            {
+                "text": "GRAPHIC",
+                "confidence": 0.9,
+                "polygon": [[300, y], [500, y], [500, y + 40], [300, y + 40]],
+            }
+        ]
+
+    near = _sheet(tmp_path / "near", inset + main, title_at(3500))  # ~2 spacings above
+    (tmp_path / "near").mkdir(exist_ok=True)
+    assert detect_insets(near).candidates[0].cartouche == ["GRAPHIC"]
+    far = _sheet(tmp_path / "far", inset + main, title_at(2300))  # ~6 spacings above
+    assert detect_insets(far).candidates[0].cartouche == []
+
+
+def test_unconfirmed_cluster_is_reported_but_not_masked(tmp_path: Path):
+    main = _grid(6, 6, 1500, 800, 300)
+    junk = [_record("5", 300, 4300), _record("7", 450, 4400)]
+    image = _sheet(tmp_path, main + junk)  # no cartouche sidecar, no re-read
+    result = detect_insets(image)
+    assert len(result.candidates) == 1 and result.insets == []
+    assert "unconfirmed (not masked)" in "\n".join(log_lines(result))
+    assert (
+        inset_rings(image) == []
+        or write_inset_sidecar(image, result)
+        and inset_rings(image) == []
+    )
+
+
+def test_ellenville_shaped_sheet_is_separate_keymaps_not_an_inset(tmp_path: Path):
+    """Two real key maps of small page numbers, neither dominating: nothing is masked."""
+    village = [
+        _record(str(n), 500 + (n % 4) * 300, 500 + (n // 4) * 300, size=40)
+        for n in range(2, 14)
+    ]
+    napanoch = [
+        _record(str(n), 500 + (n % 3) * 300, 3500 + (n // 3) * 300, size=40)
+        for n in range(11, 16)
+    ]
+    image = _sheet(tmp_path, village + napanoch)
+    result = detect_insets(image)
+    assert result.candidates == [] and result.insets == []
+    assert result.separate_keymaps
+    assert "separate key maps" in "\n".join(log_lines(result))
+
+
+def test_a_lone_far_read_is_never_an_inset(tmp_path: Path):
+    main = _grid(6, 6, 1500, 800, 300)
+    image = _sheet(tmp_path, main + [_record("9", 200, 4600)])
+    assert detect_insets(image).candidates == []
+
+
+def test_inset_label_reports_the_reread():
+    inset = Inset(
+        indices=[0, 1],
+        texts=["3", "4"],
+        n_small=2,
+        ring=[[0, 0], [1, 0], [1, 1]],
+        reread=(2, 2),
+    )
+    assert inset.confirmed
+    assert inset.label() == "volumes inset: 3, 4 (re-read small 2/2)"
+    unconfirmed = Inset(
+        indices=[0, 1],
+        texts=["3", "4"],
+        n_small=2,
+        ring=[[0, 0], [1, 0], [1, 1]],
+        reread=(0, 2),
+    )
+    assert not unconfirmed.confirmed and unconfirmed.label().endswith(
+        "(re-read small 0/2)"
+    )

--- a/mapsnap/keymap/pipeline.py
+++ b/mapsnap/keymap/pipeline.py
@@ -229,6 +229,11 @@ def main() -> None:
     #     the key map. Cheap: the CRAFT boxes are already cached by step 1's OCR
     #     of the same sheet on earlier runs, and the vocabulary is fifteen words.
     run_cmd([sys.executable, "-m", "mapsnap.keymap.cartouche", *image_args])
+    # 1c. Find the volume-index insets (#276): isolated clusters of small
+    #     numbers, confirmed by a no-snap re-read or a cartouche word inside.
+    #     Writes <stem>.inset.panels.json; page-number consumers drop the
+    #     reads inside those rings.
+    run_cmd([sys.executable, "-m", "mapsnap.keymap.inset", *image_args])
 
     # 2. Repair the page-number assignments against the printed adjacency graph
     #    (#213): a number misread as a shorter one (Detroit's 22 read as "2"),

--- a/scripts/inset_eval.py
+++ b/scripts/inset_eval.py
@@ -1,0 +1,121 @@
+"""Score the inset detector against the hand-labeled key-map truth points.
+
+For every truth-labeled key-map sheet (raw/truth/<stem>.labels.json), run
+detect_insets on the sheet the pipeline actually uses (the key-map panel when
+the sheet was split) and count the reads its confirmed masks cover, split
+into TRUE reads (a truth point inside the read's polygon or within one long
+side of its center) and junk. The acceptance bar for any change to the
+detector is zero true reads masked.
+
+    uv run python scripts/inset_eval.py [--reread] [--no-gpu]
+"""
+
+import argparse
+import glob
+import json
+import math
+import os
+from pathlib import Path
+
+from shapely.geometry import Point, Polygon
+
+from mapsnap.keymap.inset import detect_insets
+
+
+def sheet_for(volume: str, truth_stem: str) -> str | None:
+    """The key-map image the pipeline uses for a truth stem (its panel when split)."""
+    keys_path = f"data/{volume}/keymaps.json"
+    keys = (
+        json.loads(Path(keys_path).read_text())["keys"]
+        if os.path.exists(keys_path)
+        else []
+    )
+    stem = next((k for k in keys if k.split("__")[0] == truth_stem), truth_stem)
+    image = f"data/{volume}/raw/{stem}.jpg"
+    return image if os.path.exists(f"data/{volume}/raw/{stem}.keymap.json") else None
+
+
+def truth_points(volume: str, truth_stem: str, image: str) -> list[tuple[float, float]]:
+    """Truth points in the image's frame (shifted into a panel's crop when split)."""
+    doc = json.loads(
+        Path(f"data/{volume}/raw/truth/{truth_stem}.labels.json").read_text()
+    )
+    stem = Path(image).name.split(".")[0]
+    ox = oy = 0.0
+    if "__" in stem:
+        panels = json.loads(Path(f"data/{volume}/{truth_stem}.panels.json").read_text())
+        ring = panels["panels"][int(stem.split("__")[1]) - 1]
+        scale = doc["width"] / panels["width"]
+        ox, oy = min(p[0] for p in ring) * scale, min(p[1] for p in ring) * scale
+    return [(t["x"] - ox, t["y"] - oy) for t in doc["labels"]]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reread", action="store_true", help="Run the CRNN re-read corroboration."
+    )
+    parser.add_argument("--no-gpu", action="store_true")
+    args = parser.parse_args()
+    crnn = device = None
+    if args.reread:
+        import torch
+
+        from mapsnap.keymap.crnn_model import build_crnn
+        from mapsnap.keymap.number_model import select_device
+
+        device = torch.device("cpu") if args.no_gpu else select_device()
+        crnn = build_crnn()
+        crnn.load_state_dict(torch.load("models/number_crnn.pt", map_location=device))
+        crnn.to(device)
+
+    total_junk = total_true = 0
+    print(f"{'sheet':40s} {'masks':>5s} {'junk':>5s} {'TRUE':>5s}  masked reads")
+    for truth_path in sorted(glob.glob("data/*/raw/truth/*.labels.json")):
+        volume = truth_path.split("/")[1]
+        truth_stem = os.path.basename(truth_path).split(".")[0]
+        image = sheet_for(volume, truth_stem)
+        if image is None:
+            continue
+        result = detect_insets(image, reread=args.reread, crnn=crnn, device=device)
+        reads, _, _ = __import__(
+            "mapsnap.keymap.inset", fromlist=["load_reads"]
+        ).load_reads(image)
+        truth = truth_points(volume, truth_stem, image)
+        rings = [Polygon(inset.ring).buffer(0) for inset in result.insets]
+        masked, junk, true = [], 0, 0
+        for read in reads:
+            if not any(ring.contains(Point(read.center)) for ring in rings):
+                continue
+            poly = Polygon(read.polygon).buffer(0)
+            long_side = max(
+                math.hypot(
+                    read.polygon[1][0] - read.polygon[0][0],
+                    read.polygon[1][1] - read.polygon[0][1],
+                ),
+                math.hypot(
+                    read.polygon[2][0] - read.polygon[1][0],
+                    read.polygon[2][1] - read.polygon[1][1],
+                ),
+            )
+            is_true = any(
+                poly.contains(Point(x, y))
+                or math.hypot(x - read.center[0], y - read.center[1]) <= long_side
+                for x, y in truth
+            )
+            true += is_true
+            junk += not is_true
+            masked.append(read.text + ("*" if is_true else ""))
+        total_junk += junk
+        total_true += true
+        flag = "  <-- TRUE READ MASKED" if true else ""
+        print(
+            f"{volume + '/' + Path(image).name:40s} {len(rings):5d} {junk:5d} {true:5d}  {' '.join(masked)}{flag}"
+        )
+    print(
+        f"\ntotals: junk masked {total_junk}, TRUE masked {total_true}  (bar: TRUE == 0)"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Step 3 of the #276 plan: detect the volume-index insets on key-map sheets and write a mask.

## The rule, measured

Clustering the page-number **reads** by single linkage at 3× the sheet's median nearest-neighbour spacing, then flagging a cluster with ≥2 reads, at most ⅓ the size of the largest, and a small-number (≤15) majority. Isolation carries the rule — Richmond's inset reads `2 3 4 311` (the "1" snapped to a valid page), and miami's inset numerals 1–5 are also real pages of that volume — and one of two corroborations confirms it:

- a **no-snap re-read**: the CRNN's raw greedy decode of the cluster's numerals, no vocabulary, no repair — Richmond's "311" glyph reads as "1" (4/4 small);
- a **specific cartouche word** (GRAPHIC / VOLUMES / INDEX, never anything else on a key-map sheet) within 3 spacings of the cluster — titles sit above the inset map, 1.3–2.2 spacings out on the titled sheets.

Two or more sizeable clusters with no dominant one (Ellenville's village + Napanoch) are reported as **separate key maps** and never masked.

## Results on the truth corpus (`scripts/inset_eval.py --reread`)

| sheet | masked reads | true reads masked |
|---|---|---|
| richmond p0 | `2 3 4 311` | 0 |
| miami p0 | `5 5 4 2 5` | 0 |
| detroit p0__1 | `15 13 8 10` | 0 |
| columbus p0 | `5 1 4A 4 4 4 5 6A` | 0 |
| los_angeles pa | `4 1 3 3` | 0 |
| san_francisco p0 | `4 7 6 0 114 5` | 0 |
| washington_dc p1b | `9 213` | 0 |
| *16 other sheets* | none | 0 |

**33 junk reads masked, 0 true page numbers masked** across all 23 truth-labeled sheets — the acceptance bar. Every sheet that still carries an inset is found; kansas_city's and new_orleans_1951's were already cut away by the splitter (#383 keeps those cuts). Cincinnati p0R's two junk clusters (`5 7 7`, `5 6`) fire the rule but have neither corroboration — its re-read decodes nothing small and the sheet has no title — so they stay unconfirmed: logged, not masked. Precision over recall, by design.

Richmond's mask, drawn over the sheet: it sits on the General Index inset around its 1/2/3/4 numerals with the misread "311" inside, and touches no key-map read.

## Outputs

- `raw/<stem>.inset.panels.json` — the confirmed masks, in the **panels.json shape** the debugger renders (one labelled ring per inset, e.g. `volumes inset: 2, 3, 4, 311 (re-read small 4/4; cartouche VOLUMES, INDEX)`); `.inset.panels.json` joins `isKeymapJson`. Verified through `parseDroppedJson`: classified `panels`, 1 ring, label carried.
- an `inset` section in `raw/<stem>.keymap.txt` — every candidate cluster, its re-read count, the cartouche words near it, and the verdict.
- `mapsnap keymap-inset IMAGE…`, run by the key-map pipeline as step 1c after the cartouche pass.
- `inset_rings(image)` for consumers.

## Why not the ink moat from the issue

Tried first and worse: connected components of dilated ink find richmond/miami/detroit but the faint base street grid or the inset's own border bridges columbus and LA, while the reads stay isolated regardless. Read positions are the right signal.

## Not in this PR — step 4

Nothing consumes the mask yet. The next step drops the reads inside `inset_rings` before `centers_for`, which removes Richmond p311's third search center (4.59 km from truth) at the source; then region segmentation and key-map P(road).

Tests: the rule on Richmond-, Ellenville- and lone-read-shaped sheets, the cartouche neighbourhood, unconfirmed reporting, labels, and the sidecar round-trip through `inset_rings`. 1,127 Python tests, 249 app tests, ruff, pyright and tsc pass.

Part of #276 (step 3 of the plan there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
