### PR TITLE
Consumers of key-map reads skip the ones inside a volume-index inset

### DIFF
--- a/docs/fit-pipeline.md
+++ b/docs/fit-pipeline.md
@@ -13,7 +13,9 @@ key map), `detect-numbers` (candidates, reads, valid page keys not read),
 `assignment-repair`, `cartouche` (the GRAPHIC MAP / KEY / INDEX words read and
 where), and `inset` (each isolated small-number cluster, its no-snap re-read,
 the cartouche words near it, and the verdict; the confirmed masks are written
-to `raw/<stem>.inset.panels.json`). A rerun replaces a stage's section in
+to `raw/<stem>.inset.panels.json`, and the reads inside them are flagged
+`inset: true` in `<stem>.keymap.json` — kept for the debugger, skipped by every
+consumer of page-number reads). A rerun replaces a stage's section in
 place, each header carries a UTC timestamp, and `archive_run` copies the logs
 into `<run>/raw/`.
 

--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -58,6 +58,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from mapsnap.keymap.fit_keymap import collapse_skeleton_keys
+from mapsnap.keymap.records import is_inset
 
 PROXIMITY_FACTOR = 1.5
 """How many page-pitches apart two printed numbers may be and still count as
@@ -514,6 +515,29 @@ def split_multiplicity(volume: Path) -> dict[str, int]:
     return counts
 
 
+def planner_inputs(
+    streets: list[dict],
+) -> tuple[list[str], list[tuple[float, float] | None]]:
+    """(labels, centers) for the repair planner, one entry per record.
+
+    Positions matter: apply_repairs indexes into the same list, so a read the
+    inset detector masked (#276) is neutralized in place -- an empty label and
+    no center -- rather than dropped. It then cites nothing, is cited by
+    nothing, and can never be relabelled.
+    """
+    labels = [
+        ""
+        if is_inset(street)
+        else (page_key_of(street.get("text", "")) or str(street.get("text", "")))
+        for street in streets
+    ]
+    centers = [
+        None if is_inset(street) else center
+        for street, center in zip(streets, detection_centers(streets))
+    ]
+    return labels, centers
+
+
 def detection_centers(streets: list[dict]) -> list[tuple[float, float] | None]:
     """Each page-number detection's centre, from its CRNN polygon."""
     centers: list[tuple[float, float] | None] = []
@@ -682,11 +706,7 @@ def plan_volume_repairs(
     geometry: dict[str, tuple[list[tuple[float, float] | None], float]] = {}
     for stem, doc in load_sheets(volume):
         streets = doc.get("streets", [])
-        labels = [
-            page_key_of(street.get("text", "")) or str(street.get("text", ""))
-            for street in streets
-        ]
-        centers = detection_centers(streets)
+        labels, centers = planner_inputs(streets)
         sheet_panels.append(SheetNumbers(stem, labels, proximity_graph(centers)))
         geometry[stem] = (centers, page_pitch(centers))
 

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -572,3 +572,16 @@ def test_keymap_sidecar_mtime_tracks_the_newest_sidecar(tmp_path):
     truth.write_text("{}")
     os.utime(truth, (9_000_000, 9_000_000))
     assert keymap_sidecar_mtime(tmp_path) == 2_000_000
+
+
+def test_planner_inputs_neutralize_masked_reads_in_place():
+    from mapsnap.keymap.adjacency_assign import planner_inputs
+
+    streets = [
+        {"text": "4", "inset": True, "polygon": [[0, 0], [2, 0], [2, 2], [0, 2]]},
+        {"text": "310", "polygon": [[4, 4], [6, 4], [6, 6], [4, 6]]},
+    ]
+    labels, centers = planner_inputs(streets)
+    # Same length as the records, so apply_repairs' indices still line up.
+    assert labels == ["", "310"]
+    assert centers[0] is None and centers[1] == (5.0, 5.0)

--- a/mapsnap/keymap/fit_keymap.py
+++ b/mapsnap/keymap/fit_keymap.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 import numpy as np
 
+from mapsnap.keymap.records import live_detections
 from mapsnap.keymap.score_keymap_labels import point_in_polygon
 
 # Metres per degree of latitude (and of longitude after the cos(lat) correction).
@@ -202,12 +203,14 @@ def load_detections(keymap_path: Path) -> list[Detection]:
     """Load key-map page-number detections (page-key texts) with pixel centroids.
 
     A text must be a page key — digits with an optional letter suffix (``51``,
-    ``35F``) — anything else (a stray street-name read) is skipped. ``number``
-    holds the digit stem for numeric consumers; ``key`` the full canonical key.
+    ``35F``) — anything else (a stray street-name read) is skipped, and so is a
+    read the inset detector masked (records.is_inset): a volume-index inset's
+    numerals are not page locations. ``number`` holds the digit stem for
+    numeric consumers; ``key`` the full canonical key.
     """
     streets = json.loads(keymap_path.read_text())["streets"]
     detections: list[Detection] = []
-    for street in streets:
+    for street in live_detections(streets):
         text = str(street["text"])
         if not re.fullmatch(r"\d+[A-Za-z]{0,2}", text):
             continue

--- a/mapsnap/keymap/fit_keymap_test.py
+++ b/mapsnap/keymap/fit_keymap_test.py
@@ -162,6 +162,18 @@ def test_load_detections_keeps_lettered_keys(tmp_path):
     assert [(d.key, d.number) for d in detections] == [("35A", 35), ("51", 51)]
 
 
+def test_load_detections_skips_reads_masked_as_inset(tmp_path):
+    doc = {
+        "streets": [
+            {"text": "311", "inset": True, "polygon": [[0, 0], [2, 0], [2, 2], [0, 2]]},
+            {"text": "310", "polygon": [[4, 4], [6, 4], [6, 6], [4, 6]]},
+        ]
+    }
+    path = tmp_path / "p0.keymap.json"
+    path.write_text(json.dumps(doc))
+    assert [d.key for d in load_detections(path)] == ["310"]
+
+
 # --- skeleton collapse ---
 
 

--- a/mapsnap/keymap/inset.py
+++ b/mapsnap/keymap/inset.py
@@ -44,7 +44,7 @@ from shapely.geometry import MultiPoint, Point, Polygon, box
 
 from mapsnap.keymap.cartouche import cartouche_sidecar_path, is_specific
 from mapsnap.keymap.log import append_keymap_log
-from mapsnap.keymap.records import keymap_path, page_key_sort
+from mapsnap.keymap.records import INSET_FLAG, keymap_path, page_key_sort
 from mapsnap.utils import image_stem
 
 SMALL_MAX = 15  # a "small number": plausible volume index, 1..15
@@ -297,6 +297,32 @@ def detect_insets(
     )
 
 
+def annotate_keymap_reads(image_path: str | Path, result: InsetResult) -> int:
+    """Flag the reads inside the confirmed masks in <stem>.keymap.json; return how many.
+
+    The flag is recomputed from scratch on every run -- set on reads inside a
+    confirmed ring, removed from every other read -- so the file always says
+    what the current masks say. Consumers skip flagged reads through
+    records.is_inset; the reads themselves stay, so the debugger can show what
+    was masked and the detector can re-judge them next time.
+    """
+    path = Path(keymap_path(str(image_path)))
+    doc = json.loads(path.read_text())
+    rings = [Polygon(inset.ring).buffer(0) for inset in result.insets]
+    flagged = 0
+    for record in doc.get("streets", []):
+        inside = bool(rings) and any(
+            ring.contains(Point(polygon_center(record["polygon"]))) for ring in rings
+        )
+        if inside:
+            record[INSET_FLAG] = True
+            flagged += 1
+        else:
+            record.pop(INSET_FLAG, None)
+    path.write_text(json.dumps(doc, indent=2))
+    return flagged
+
+
 def inset_sidecar_path(image_path: str | Path) -> Path:
     """``<dir>/<stem>.inset.panels.json`` beside the key-map image."""
     image_path = Path(image_path)
@@ -397,7 +423,15 @@ def main() -> None:
             image, reread=not args.no_reread, crnn=crnn, device=device
         )
         path = write_inset_sidecar(image, result)
-        append_keymap_log(image, "inset", log_lines(result))
+        flagged = annotate_keymap_reads(image, result)
+        append_keymap_log(
+            image,
+            "inset",
+            [
+                *log_lines(result),
+                f"{flagged} read(s) flagged inset in the key-map reads file",
+            ],
+        )
         summary = "; ".join(inset.label() for inset in result.insets) or "none"
         print(
             f"{Path(image).name}: {len(result.insets)} inset(s) -> {path.name}: {summary}",

--- a/mapsnap/keymap/inset_test.py
+++ b/mapsnap/keymap/inset_test.py
@@ -7,6 +7,7 @@ from shapely.geometry import Point
 
 from mapsnap.keymap.inset import (
     Inset,
+    annotate_keymap_reads,
     cluster_reads,
     detect_insets,
     inset_rings,
@@ -197,3 +198,39 @@ def test_inset_label_reports_the_reread():
     assert not unconfirmed.confirmed and unconfirmed.label().endswith(
         "(re-read small 0/2)"
     )
+
+
+def test_annotate_keymap_reads_flags_masked_reads_and_clears_stale_flags(
+    tmp_path: Path,
+):
+    main = _grid(6, 6, 1500, 800, 300)
+    inset = [
+        _record("2", 300, 4300),
+        _record("3", 450, 4200),
+        _record("4", 250, 4450),
+        _record("311", 400, 4500),
+    ]
+    cartouche = [
+        {
+            "text": "VOLUMES",
+            "confidence": 0.9,
+            "polygon": [[300, 3950], [500, 3950], [500, 4000], [300, 4000]],
+        }
+    ]
+    image = _sheet(tmp_path, main + inset, cartouche)
+    result = detect_insets(image)
+    assert annotate_keymap_reads(image, result) == 4
+    doc = json.loads((image.parent / "p0.keymap.json").read_text())
+    flagged = sorted(r["text"] for r in doc["streets"] if r.get("inset"))
+    assert flagged == ["2", "3", "311", "4"]
+    assert all(
+        "inset" not in r
+        for r in doc["streets"]
+        if r["text"].isdigit() and int(r["text"]) >= 300 and r["text"] != "311"
+    )
+    # The detector re-judges from ALL reads, so a run that confirms nothing clears the flags.
+    (image.parent / "p0.cartouche.json").unlink()
+    result = detect_insets(image)
+    assert result.insets == [] and annotate_keymap_reads(image, result) == 0
+    doc = json.loads((image.parent / "p0.keymap.json").read_text())
+    assert not any(r.get("inset") for r in doc["streets"])

--- a/mapsnap/keymap/page_regions.py
+++ b/mapsnap/keymap/page_regions.py
@@ -38,6 +38,8 @@ from scipy import ndimage as ndi
 from skimage.color import lab2rgb, rgb2lab
 from skimage.segmentation import watershed
 
+from mapsnap.keymap.records import live_detections
+
 Point = tuple[float, float]
 Box = tuple[float, float, float, float]  # x0, y0, x1, y1 (full-res pixels)
 ScaledBox = tuple[int, int, int, int]  # col0, row0, col1, row1 in label-image pixels
@@ -61,7 +63,7 @@ def load_seeds(keymap_path: Path) -> tuple[list[Box], list[str]]:
     streets = json.loads(keymap_path.read_text()).get("streets", [])
     boxes: list[Box] = []
     texts: list[str] = []
-    for street in streets:
+    for street in live_detections(streets):  # an inset's numerals seed nothing
         boxes.append(polygon_bounds(street["polygon"]))
         texts.append(str(street.get("text", "")))
     return boxes, texts

--- a/mapsnap/keymap/page_regions_test.py
+++ b/mapsnap/keymap/page_regions_test.py
@@ -339,3 +339,27 @@ def test_pick_ladder_scale_prefers_the_finest_within_margin():
     assert pick_ladder_scale({3000: 1.6, 2250: 1.2, 1500: 0.4, 1000: 0.5}) == 1500
     # Infinite scores (no regions at all) never win.
     assert pick_ladder_scale({3000: float("inf"), 1500: 0.9}) == 1500
+
+
+def test_load_seeds_skips_reads_masked_as_inset(tmp_path):
+    import json
+
+    from mapsnap.keymap.page_regions import load_seeds
+
+    path = tmp_path / "p0.keymap.json"
+    path.write_text(
+        json.dumps(
+            {
+                "streets": [
+                    {
+                        "text": "4",
+                        "inset": True,
+                        "polygon": [[0, 0], [2, 0], [2, 2], [0, 2]],
+                    },
+                    {"text": "310", "polygon": [[4, 4], [6, 4], [6, 6], [4, 6]]},
+                ]
+            }
+        )
+    )
+    boxes, texts = load_seeds(path)
+    assert texts == ["310"] and len(boxes) == 1

--- a/mapsnap/keymap/records.py
+++ b/mapsnap/keymap/records.py
@@ -79,6 +79,23 @@ def detection_record(bbox: list[list[float]], text: str, confidence: float) -> d
     }
 
 
+# Set on a <stem>.keymap.json record by the inset detector (#276) when the read
+# sits inside a confirmed volume-index inset. The record stays in the file --
+# the debugger shows it, and the detector re-judges it on every run -- but
+# every consumer of page-number reads skips it through is_inset().
+INSET_FLAG = "inset"
+
+
+def is_inset(record: dict) -> bool:
+    """Whether a key-map read was masked as part of a volume-index inset."""
+    return bool(record.get(INSET_FLAG))
+
+
+def live_detections(streets: list[dict]) -> list[dict]:
+    """The reads a consumer should act on: everything not masked as an inset."""
+    return [record for record in streets if not is_inset(record)]
+
+
 KEYMAPS_FILENAME = "keymaps.json"
 
 

--- a/mapsnap/keymap/records_test.py
+++ b/mapsnap/keymap/records_test.py
@@ -3,6 +3,8 @@ import math
 from mapsnap.keymap.records import (
     detection_record,
     filter_args,
+    is_inset,
+    live_detections,
     parse_page_spec,
 )
 
@@ -61,3 +63,13 @@ def test_detection_record_dir_pix_in_unit_range():
 def test_filter_args_keeps_only_the_named_image():
     argv = ["detect", "--min-size", "60", "a.jpg", "b.jpg", "c.jpg"]
     assert filter_args(argv, "b.jpg") == ["detect", "--min-size", "60", "b.jpg"]
+
+
+def test_inset_flag_hides_a_read_from_consumers_without_deleting_it():
+    reads = [
+        {"text": "311", "inset": True},
+        {"text": "310"},
+        {"text": "5", "inset": False},
+    ]
+    assert [is_inset(r) for r in reads] == [True, False, False]
+    assert [r["text"] for r in live_detections(reads)] == ["310", "5"]

--- a/mapsnap/keymap/road_prob.py
+++ b/mapsnap/keymap/road_prob.py
@@ -44,6 +44,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
+from mapsnap.keymap.inset import inset_rings
 from mapsnap.road_model import (
     invert_affine,
     page_scale_m_per_px,
@@ -285,10 +286,19 @@ def mapped_extent_mask(
     grown = within_px(mask, margin_px).astype(np.uint8)
     count, components = cv2.connectedComponents(grown)
     if count <= 2:
-        return grown
-    sizes = np.bincount(components.ravel())
-    sizes[0] = 0  # background
-    return (components == int(sizes.argmax())).astype(np.uint8)
+        extent = grown
+    else:
+        sizes = np.bincount(components.ravel())
+        sizes[0] = 0  # background
+        extent = (components == int(sizes.argmax())).astype(np.uint8)
+    # A confirmed volume-index inset (#276) is furniture whatever the regions
+    # say: its roads are real but drawn at another scale, so the affine's OSM
+    # label is wrong there. Cut it out of the supervised extent.
+    for ring in inset_rings(sheet.image_path):
+        cv2.fillPoly(
+            extent, [np.asarray(ring.exterior.coords, dtype=np.int32)], color=0
+        )
+    return extent
 
 
 def sheet_label(


### PR DESCRIPTION
Step 4 of the #276 plan: the masks from #386 are now consumed.

## Mechanism

`mapsnap keymap-inset` flags every read inside a confirmed inset mask with **`inset: true`** in the sheet's `<stem>.keymap.json`. The flag is recomputed from scratch each run (a mask that goes away clears its flags), and the reads stay in the file so the debugger shows what was masked. Every consumer of page-number reads then skips flagged records through one predicate, `records.is_inset`:

| consumer | effect |
|---|---|
| `fit_keymap.load_detections` — the loader behind `KeymapLocator` | no location, no search center (`centers_for`), no radius contribution, no key-map GeoJSON entry |
| `page_regions.load_seeds` | an inset's numerals seed no page region |
| assignment-repair planner (`planner_inputs`) | neutralized **in place** — empty label, no center — because `apply_repairs` indexes into the same list; it cites nothing, is cited by nothing, is never relabelled |
| `road_prob.mapped_extent_mask` | the inset is cut out of the supervised extent: its roads are real but drawn at another scale |

The key-map pipeline order already puts the inset step before repairs and georef, so the flags are in place when they are read.

## Richmond p311, end to end

The case that started #276. Georeferenced in a scratch volume against the key map with the flags stripped, then with them in place:

| | key-map search centers | distance from truth | radius | GCPs |
|---|---|---|---|---|
| before | **3** | 0.0, 1.1, **4.9 km** | 569 m | 2 |
| after | **2** | 0.0, 1.1 km | 561 m | 2 |

The inset's "1" — snapped to "311" by the vocabulary repair — no longer seeds a snap search 4.9 km away. The real centers and the GCPs are untouched.

On the seven inset-bearing sheets the flags land on exactly the reads the detector reported: richmond `2 3 4 311`, miami `5 5 4 2 5`, detroit `15 13 8 10`, columbus `5 1 4A 4 4 4 5 6A`, los_angeles `4 1 3 3`; kansas_city and new_orleans_1951 have none to flag.

## Not here

Masking the inset at P(road) *inference* (zeroing the prediction inside the rings) — the training extent is handled; the prediction consumer in the key-map snap path is a separate, small follow-up.

Tests: the predicate, the annotation round-trip (flags set, then cleared when nothing confirms), and each consumer's skip. 1,132 tests, ruff and pyright pass.

Part of #276 (step 4 of the plan there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
