### PR TITLE
Debugger shows key-map reads masked as volume-index insets

### DIFF
--- a/app/src/components/DetectionsOverlay.tsx
+++ b/app/src/components/DetectionsOverlay.tsx
@@ -49,6 +49,9 @@ export function DetectionsOverlay(props: DetectionsOverlayProps) {
         const isSelected = selectedIndices.has(i);
         const isIgnored = det.ignore === true;
         const isHint = det.hint === true;
+        // A read inside a confirmed volume-index inset (#276): masked, and drawn as
+        // a group so the inset stands out from the key map around it.
+        const isInset = det.inset === true;
         // A label on a red/blue building fill is dropped before georeferencing, so draw it
         // like the other discarded reads rather than by its confidence.
         const isOnFill = isOnBuildingFill(det);
@@ -60,24 +63,28 @@ export function DetectionsOverlay(props: DetectionsOverlayProps) {
             ? '#2563eb'
             : det.mutual === false
               ? '#d97706'
-              : isIgnored
-                ? '#999'
-                : isHint
-                  ? '#7c3aed'
-                  : isOnFill
-                    ? '#be123c'
-                    : confidenceColor(det.confidence);
+              : isInset
+                ? '#c026d3'
+                : isIgnored
+                  ? '#999'
+                  : isHint
+                    ? '#7c3aed'
+                    : isOnFill
+                      ? '#be123c'
+                      : confidenceColor(det.confidence);
         const points = det.polygon
           .map(([x, y]) => toDisplay(x, y))
           .map(([dx, dy]) => `${dx},${dy}`)
           .join(' ');
-        const dashArray = isIgnored
-          ? '4 3'
-          : isHint
-            ? '3 2'
-            : isOnFill
-              ? '5 3'
-              : undefined;
+        const dashArray = isInset
+          ? '8 4'
+          : isIgnored
+            ? '4 3'
+            : isHint
+              ? '3 2'
+              : isOnFill
+                ? '5 3'
+                : undefined;
 
         const [lx, ly] = toDisplay(det.polygon[0][0], det.polygon[0][1]);
 
@@ -86,7 +93,7 @@ export function DetectionsOverlay(props: DetectionsOverlayProps) {
             <polygon
               points={points}
               fill={color}
-              fillOpacity={isSelected ? 0.25 : 0.05}
+              fillOpacity={isSelected ? 0.25 : isInset ? 0.18 : 0.05}
               stroke={color}
               strokeWidth={isSelected ? 2.5 : 1.2}
               strokeDasharray={dashArray}

--- a/app/src/components/DetectionsTable.tsx
+++ b/app/src/components/DetectionsTable.tsx
@@ -70,6 +70,7 @@ export function DetectionsTable(props: DetectionsTableProps) {
               det.ignore ? 'ignored' : '',
               det.hint ? 'hint' : '',
               det.fallback ? 'fallback' : '',
+              det.inset ? 'inset' : '',
               onFill ? 'on-fill' : '',
               relaxed ? 'relaxed' : '',
             ]
@@ -110,6 +111,14 @@ export function DetectionsTable(props: DetectionsTableProps) {
                       title="Read by the key-map rectangle fallback vocabulary, not the tighter page-neighborhood radius vocabulary"
                     >
                       fallback
+                    </span>
+                  )}
+                  {det.inset && (
+                    <span
+                      className="inset-badge"
+                      title="Inside a confirmed volume-index inset on this key map (#276): a volume number, not a page location. Skipped by every consumer of page-number reads."
+                    >
+                      inset
                     </span>
                   )}
                   {det.background && (

--- a/app/src/detections.test.ts
+++ b/app/src/detections.test.ts
@@ -146,6 +146,25 @@ describe('filterDetections', () => {
     expect(result.map((r) => r.i)).toEqual([1, 2]);
   });
 
+  it('keeps inset-masked reads visible whatever the ignored toggle says', () => {
+    // A masked read is the thing to look at on a key map (#276); it is not `ignore`.
+    const dets = [
+      makeDetection({ text: '311', inset: true }),
+      makeDetection({ text: '310' }),
+    ];
+    const shown = filterDetections(dets, {
+      minConfidence: 0,
+      minShortSide: 0,
+      minLongSide: 0,
+      minAspectRatio: 0,
+      relaxation: false,
+      highConfidenceSizeFraction: 0.7,
+      showIgnored: false,
+      text: '',
+    });
+    expect(shown.map((r) => r.det.text)).toEqual(['311', '310']);
+  });
+
   it('hides ignored detections unless showIgnored is set', () => {
     const hidden = filterDetections(detections, {
       minConfidence: 0,

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -402,6 +402,21 @@
   vertical-align: middle;
 }
 
+#detections-table tr.inset td {
+  color: #c026d3;
+}
+
+.inset-badge {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 0 5px;
+  border-radius: 8px;
+  background: #c026d3;
+  color: #fff;
+  font-size: 0.7em;
+  vertical-align: middle;
+}
+
 .adjacency-summary {
   padding: 6px 8px;
   border-bottom: 2px solid #bbb;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -49,6 +49,12 @@ export interface Detection {
   /** Read by the key-map rectangle fallback vocab rather than the tighter radius vocab. */
   fallback?: boolean;
   /**
+   * Inside a confirmed volume-index inset on a key-map sheet (#276): the read is a
+   * volume number, not a page location. Kept in the file so it can be seen; every
+   * consumer of page-number reads skips it.
+   */
+  inset?: boolean;
+  /**
    * An ordinal underline (the rule under "10<u>TH</u>") was painted out of this
    * box before recognition, so this read comes from altered pixels (#250).
    */


### PR DESCRIPTION
The inset detector (#386) leaves flagged reads in the key map's `streets.json` with `inset: true` so they can be inspected, but the debugger drew them exactly like live reads. This makes the flag visible:

- **Overlay**: flagged reads render magenta (`#c026d3`) with a long dash and a stronger fill, so a masked inset stands out from the key map around it as a group.
- **Detections table**: an `inset` badge (tooltip explains the flag) and magenta row text, alongside the existing `fallback` badge.
- **Filtering**: flagged reads stay visible whatever the show-ignored toggle says. They are not `ignore` reads; a masked read is the thing to look at on a key map. Test added.

To view: drop a key map's `raw/<stem>.keymap.json` on the debugger. `mapsnap keymap-inset` has been run on the five inset-bearing sheets in the corpus (columbus p0, detroit p0__1, los_angeles pa, miami p0, richmond p0), so those files already carry the flag. Dropping the sibling `raw/<stem>.inset.panels.json` shows the mask rings themselves.

Part of #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)