### PR TITLE
Key-map corner-box detector cuts boxed regions the divider gate hides

### DIFF
--- a/docs/fit-pipeline.md
+++ b/docs/fit-pipeline.md
@@ -7,7 +7,9 @@ the page's `<stem>.txt` sidecar or the run's fit log for the quoted messages.
 
 Key-map sheets keep a second log, `raw/<stem>.keymap.txt`, beside their other
 key-map sidecars: one section per stage — `split` (whether the sheet's split
-stood, per-panel share and edge-flushness, stale sidecars removed),
+stood, per-panel share and edge-flushness, stale sidecars removed, and any
+corner box the key-map-only detector cut away where the divider pipeline had
+left the sheet whole: a second key map, an index inset, a legend),
 `keymap-plan` / `keymap-detect` (how the sheet was nominated and confirmed as a
 key map), `detect-numbers` (candidates, reads, valid page keys not read),
 `assignment-repair`, `cartouche` (the GRAPHIC MAP / KEY / INDEX words read and

--- a/mapsnap/corner_boxes.py
+++ b/mapsnap/corner_boxes.py
@@ -1,0 +1,391 @@
+"""Corner boxes on key-map sheets (#276, step 5).
+
+A key-map sheet gives up boxed regions in its corners: a KEY legend, a "graphic
+map of volumes" inset, or a second key map (Los Angeles 1949 vol 14's Vol-13
+continuation, Ellenville's Napanoch, Kingston's Port Ewen). The general
+splitter finds the heavy ones (Kansas City, New Orleans 1951), but a key map is
+dense with long linework: its divider candidates exceed the splitter's
+MAX_DIVIDER_CANDIDATES safety gate, so the sheet stands whole, and a box border
+drawn at 4 px sits below the divider thickness floor. This module looks for
+the one shape a legitimate cut-away always has: a chain of axis-aligned
+segments running from one sheet edge to an adjacent edge, enclosing the corner
+between them and touching no third edge. A chamfered corner (Los Angeles) is
+the one diagonal link a chain may carry; a side that Hough never vectorized
+(Ellenville) is closed by tracing a straight, border-thick ink line from the
+chain's free end to the edge.
+
+Coordinates are the splitter's cropped detection frame; the caller expands the
+resulting panels to the full sheet.
+"""
+
+from dataclasses import dataclass, field
+from math import atan2, degrees, hypot
+from statistics import median
+
+import numpy as np
+from shapely.geometry import Polygon, box
+from shapely.ops import unary_union
+
+Segment = tuple[float, float, float, float]
+Point = tuple[float, float]
+
+# A box border is drawn lighter than a sheet divider: Ellenville's Napanoch box is
+# 4.0 px at the 25% working scale (the splitter's divider floor is 5.0 px), while
+# key-map block and street lines measure 2-2.8 px.
+BOX_MIN_THICK_PX = 3.5
+# A cut-away smaller than this share of the sheet is a sliver along an edge, not
+# a boxed region; larger than the max it is the sheet itself.
+BOX_MIN_AREA_FRAC = 0.02
+BOX_MAX_AREA_FRAC = 0.5  # the same bar as split.CUT_AWAY_MAX_AREA
+# An endpoint within this fraction of the shorter sheet side counts as flush with
+# a sheet edge (split.FLUSH_EDGE_TOLERANCE).
+FLUSH_FRAC = 0.02
+# Segment endpoints this close continue one chain.
+JOIN_FRAC = 0.05
+# Two chains, one from each edge of a corner, whose free ends are this close are
+# closed with a straight link: a chamfer the detector saw both sides of.
+CHAMFER_FRAC = 0.12
+MAX_CHAIN = 6
+# A box side runs parallel to a sheet edge; a chain may carry one link that does
+# not (a chamfer). A heavy volume boundary wandering along a rotated street grid
+# (Atlanta) carries many.
+AXIS_TOLERANCE_DEG = 4.0
+# A box is a rectangle or a chamfered one: convex. A ring whose closing link
+# passes just beside one of its own vertices is a valid polygon pinched to a
+# sliver, and its convex hull is far larger than it is.
+BOX_MAX_HULL_RATIO = 1.10
+# Ink closure: a straight run from a chain's free end to the edge, sampled in a
+# strip this wide. A box side shows as one column dark along nearly the whole
+# run (Ellenville's 4 px side scores 1.00; the false closures found on the
+# corpus, straight streets and block edges, score 0.55-0.78) and border-thick
+# in the typical row: a street through dense map content can be straight, but
+# is drawn at map-line weight.
+CLOSURE_HALF_WIDTH_PX = 8
+CLOSURE_MIN_LINE = 0.8
+MAX_CHAINS_PER_EDGE = 2000
+
+CORNERS = (("left", "top"), ("top", "right"), ("right", "bottom"), ("bottom", "left"))
+# How a box was closed, best first: the chain reached the other edge on its own,
+# two chains met across a chamfer, or ink closed a side Hough never vectorized.
+RANK_FLUSH, RANK_CHAMFER, RANK_INK = 0, 1, 2
+
+
+@dataclass
+class Chain:
+    """A run of joined segments starting on a sheet edge; ``free`` is its far end."""
+
+    points: list[Point]
+    free: Point
+    used: frozenset[int] = field(default_factory=frozenset)
+
+
+@dataclass
+class BoxCandidate:
+    """A corner box with how it was closed (``rank``) and a line saying so."""
+
+    rank: int
+    polygon: Polygon
+    corner: tuple[str, str]
+    detail: str
+
+    @property
+    def area(self) -> float:
+        return self.polygon.area
+
+
+def flush_edges(point: Point, h: int, w: int) -> set[str]:
+    """The sheet edges ``point`` is flush with (within FLUSH_FRAC of the short side)."""
+    tol = FLUSH_FRAC * min(h, w)
+    x, y = point
+    edges = set()
+    if x <= tol:
+        edges.add("left")
+    if x >= w - tol:
+        edges.add("right")
+    if y <= tol:
+        edges.add("top")
+    if y >= h - tol:
+        edges.add("bottom")
+    return edges
+
+
+def project(point: Point, edge: str, h: int, w: int) -> Point:
+    """``point`` moved perpendicularly onto ``edge``."""
+    x, y = point
+    if edge == "left":
+        return (0.0, y)
+    if edge == "right":
+        return (float(w), y)
+    if edge == "top":
+        return (x, 0.0)
+    return (x, float(h))
+
+
+def corner(edge_a: str, edge_b: str, h: int, w: int) -> Point:
+    """The sheet corner where two adjacent edges meet."""
+    x = 0.0 if "left" in (edge_a, edge_b) else float(w)
+    y = 0.0 if "top" in (edge_a, edge_b) else float(h)
+    return (x, y)
+
+
+def distance(a: Point, b: Point) -> float:
+    return hypot(a[0] - b[0], a[1] - b[1])
+
+
+def endpoints(segment: Segment) -> tuple[Point, Point]:
+    return (segment[0], segment[1]), (segment[2], segment[3])
+
+
+def off_axis(a: Point, b: Point) -> bool:
+    """Whether the link a→b is neither horizontal nor vertical (a chamfer or worse)."""
+    if distance(a, b) < 2.0:
+        return False
+    angle = abs(degrees(atan2(b[1] - a[1], b[0] - a[0]))) % 90.0
+    return min(angle, 90.0 - angle) > AXIS_TOLERANCE_DEG
+
+
+def chains_from_edge(segments: list[Segment], edge: str, h: int, w: int) -> list[Chain]:
+    """Every chain of joined segments that starts flush with ``edge``.
+
+    A chain begins at a segment endpoint on the edge (moved onto it) and grows by
+    appending any unused segment whose endpoint lies within JOIN_FRAC of the
+    chain's free end; each prefix is a chain in its own right, so a box closed
+    early (by a flush end, a chamfer or ink) is found as well as the full run.
+    Joins are endpoint to endpoint only: a line crossing a box side mid-way
+    never continues the chain.
+    """
+    join = JOIN_FRAC * min(h, w)
+    chains: list[Chain] = []
+
+    def extend(chain: Chain) -> None:
+        if len(chain.used) >= MAX_CHAIN or len(chains) >= MAX_CHAINS_PER_EDGE:
+            return
+        for index, segment in enumerate(segments):
+            if index in chain.used:
+                continue
+            for near, far in (endpoints(segment), endpoints(segment)[::-1]):
+                if distance(chain.free, near) <= join:
+                    grown = Chain([*chain.points, far], far, chain.used | {index})
+                    chains.append(grown)
+                    extend(grown)
+
+    for index, segment in enumerate(segments):
+        for near, far in (endpoints(segment), endpoints(segment)[::-1]):
+            if edge in flush_edges(near, h, w):
+                chain = Chain([project(near, edge, h, w), far], far, frozenset({index}))
+                chains.append(chain)
+                extend(chain)
+    return chains
+
+
+def run_width(row: np.ndarray, column: int) -> int:
+    """Length of the dark run through ``column`` (or a neighbor) in a strip row."""
+    start = next(
+        (c for c in (column, column - 1, column + 1) if 0 <= c < len(row) and row[c]),
+        None,
+    )
+    if start is None:
+        return 0
+    left = start
+    while left > 0 and row[left - 1]:
+        left -= 1
+    right = start
+    while right < len(row) - 1 and row[right + 1]:
+        right += 1
+    return right - left + 1
+
+
+def line_profile(
+    binary: np.ndarray, point: Point, edge: str, h: int, w: int
+) -> tuple[float, float]:
+    """(coverage, width) of the best straight ink line from ``point`` to ``edge``.
+
+    Samples a strip CLOSURE_HALF_WIDTH_PX either side of the run. Coverage is
+    the share of the run along which the darkest column (allowing a pixel of
+    wander) is inked; width is the typical dark run through that column, in
+    pixels. A run shorter than the join distance reports full coverage and a
+    border width: the end is as good as on the edge.
+    """
+    x, y = point
+    half = CLOSURE_HALF_WIDTH_PX
+    if edge in ("top", "bottom"):
+        y0, y1 = (0, int(y)) if edge == "top" else (int(y), h)
+        x0, x1 = max(0, int(x) - half), min(w, int(x) + half + 1)
+        strip = binary[y0:y1, x0:x1] > 0
+    else:
+        x0, x1 = (0, int(x)) if edge == "left" else (int(x), w)
+        y0, y1 = max(0, int(y) - half), min(h, int(y) + half + 1)
+        strip = (binary[y0:y1, x0:x1] > 0).T  # rows along the run, columns across
+    if strip.shape[0] <= JOIN_FRAC * min(h, w):
+        return 1.0, float(BOX_MIN_THICK_PX)
+    if strip.shape[1] == 0:
+        return 0.0, 0.0
+    wander = strip | np.roll(strip, 1, axis=1) | np.roll(strip, -1, axis=1)
+    coverage = wander.mean(axis=0)
+    column = int(coverage.argmax())
+    widths = [run_width(row, column) for row in strip[wander[:, column]]]
+    return float(coverage[column]), float(median(widths)) if widths else 0.0
+
+
+def line_closure(binary: np.ndarray, point: Point, edge: str, h: int, w: int) -> bool:
+    """Whether a straight, border-thick ink line runs from ``point`` to ``edge``.
+
+    A box side is inked along at least CLOSURE_MIN_LINE of the run and at least
+    BOX_MIN_THICK_PX wide; map content under the strip is spread across
+    columns, and a straight street is drawn thinner than a box border.
+    """
+    coverage, width = line_profile(binary, point, edge, h, w)
+    return coverage >= CLOSURE_MIN_LINE and width >= BOX_MIN_THICK_PX
+
+
+def box_polygon(
+    ring: list[Point], edge_a: str, edge_b: str, h: int, w: int
+) -> Polygon | None:
+    """The corner box enclosed by ``ring`` (edge A end first, edge B end last).
+
+    Returns None unless the ring, closed through the corner, is a simple
+    polygon whose share of the sheet lies between BOX_MIN_AREA_FRAC and
+    BOX_MAX_AREA_FRAC, whose sides are axis-aligned but for one chamfer, which
+    is convex (BOX_MAX_HULL_RATIO), and which touches no sheet edge but its
+    corner's two: a region reaching a third edge is a strip across the sheet,
+    the general splitter's business.
+    """
+    touched: set[str] = set()
+    for point in ring:
+        touched |= flush_edges(point, h, w)
+    if touched - {edge_a, edge_b}:
+        return None
+    chamfers = 0
+    for a, b in zip(ring, ring[1:], strict=False):
+        if not off_axis(a, b):
+            continue
+        # A diagonal that reaches a sheet edge is a street or a fold cutting
+        # off a triangle, not a chamfer between two sides of a box.
+        if flush_edges(a, h, w) or flush_edges(b, h, w):
+            return None
+        chamfers += 1
+    if chamfers > 1:
+        return None
+    polygon = Polygon([corner(edge_a, edge_b, h, w), *ring])
+    if not polygon.is_valid or polygon.is_empty:
+        return None
+    share = polygon.area / (h * w)
+    if share < BOX_MIN_AREA_FRAC or share > BOX_MAX_AREA_FRAC:
+        return None
+    if polygon.convex_hull.area > BOX_MAX_HULL_RATIO * polygon.area:
+        return None
+    return polygon
+
+
+def corner_box_candidates(
+    segments: list[Segment],
+    binary: np.ndarray,
+    edges: tuple[str, str],
+    h: int,
+    w: int,
+) -> list[BoxCandidate]:
+    """Every box in the corner between two adjacent edges.
+
+    Chains from either edge close a box three ways (RANK_FLUSH, RANK_CHAMFER,
+    RANK_INK): the chain's free end is flush with the other edge; two chains'
+    free ends meet across a chamfer; a straight ink line runs from the free end
+    to the other edge.
+    """
+    edge_a, edge_b = edges
+    chamfer = CHAMFER_FRAC * min(h, w)
+    chains = {
+        edge_a: chains_from_edge(segments, edge_a, h, w),
+        edge_b: chains_from_edge(segments, edge_b, h, w),
+    }
+    candidates: list[BoxCandidate] = []
+    for start, end in ((edge_a, edge_b), (edge_b, edge_a)):
+        for chain in chains[start]:
+            if end in flush_edges(chain.free, h, w):
+                rank = RANK_FLUSH
+                detail = f"{len(chain.used)}-segment chain from {start} to {end}"
+            else:
+                coverage, width = line_profile(binary, chain.free, end, h, w)
+                if coverage < CLOSURE_MIN_LINE or width < BOX_MIN_THICK_PX:
+                    continue
+                rank = RANK_INK
+                detail = (
+                    f"{len(chain.used)}-segment chain from {start}, side to {end} "
+                    f"closed by an ink line (coverage {coverage:.2f}, {width:.0f} px)"
+                )
+            ring = [*chain.points, project(chain.free, end, h, w)]
+            polygon = box_polygon(ring, start, end, h, w)
+            if polygon is not None:
+                candidates.append(BoxCandidate(rank, polygon, edges, detail))
+    for chain_a in chains[edge_a]:
+        for chain_b in chains[edge_b]:
+            if chain_a.used & chain_b.used:
+                continue
+            gap = distance(chain_a.free, chain_b.free)
+            if gap > chamfer:
+                continue
+            ring = [*chain_a.points, *reversed(chain_b.points)]
+            polygon = box_polygon(ring, edge_a, edge_b, h, w)
+            if polygon is not None:
+                detail = (
+                    f"chains from {edge_a} ({len(chain_a.used)}) and {edge_b} "
+                    f"({len(chain_b.used)}) meet across a {gap:.0f} px chamfer"
+                )
+                candidates.append(BoxCandidate(RANK_CHAMFER, polygon, edges, detail))
+    return candidates
+
+
+def corner_box(
+    segments: list[Segment],
+    binary: np.ndarray,
+    edges: tuple[str, str],
+    h: int,
+    w: int,
+) -> BoxCandidate | None:
+    """The best box in a corner: best closure rank, then largest.
+
+    Largest so that a box with an interior rule is not cut down to the rule.
+    """
+    candidates = corner_box_candidates(segments, binary, edges, h, w)
+    if not candidates:
+        return None
+    return min(candidates, key=lambda candidate: (candidate.rank, -candidate.area))
+
+
+def corner_boxes(
+    segments: list[Segment], binary: np.ndarray, h: int, w: int
+) -> list[BoxCandidate]:
+    """Non-overlapping corner boxes on a sheet, most trusted first.
+
+    ``segments`` are the long, box-thick candidates in the cropped frame and
+    ``binary`` the ink mask of that frame (for ink closure). Where two corners'
+    boxes overlap, the one with the better closure rank stays, then the larger.
+    """
+    found: list[BoxCandidate] = []
+    for edges in CORNERS:
+        best = corner_box(segments, binary, edges, h, w)
+        if best is not None:
+            found.append(best)
+    found.sort(key=lambda candidate: (candidate.rank, -candidate.area))
+    kept: list[BoxCandidate] = []
+    for candidate in found:
+        if all(
+            candidate.polygon.intersection(other.polygon).area < 0.01 * candidate.area
+            for other in kept
+        ):
+            kept.append(candidate)
+    return kept
+
+
+def panels_with_boxes(boxes: list[Polygon], h: int, w: int) -> list[Polygon]:
+    """The sheet cut into its remainder plus each box; empty if the cut is not clean.
+
+    The remainder comes first. A remainder that is not one solid polygon (boxes
+    that meet and sever it, or leave a hole) means the boxes do not describe a
+    real layout, and no panels are returned.
+    """
+    if not boxes:
+        return []
+    remainder = box(0, 0, w, h).difference(unary_union(boxes))
+    if not isinstance(remainder, Polygon) or remainder.interiors:
+        return []
+    return [remainder, *boxes]

--- a/mapsnap/corner_boxes.py
+++ b/mapsnap/corner_boxes.py
@@ -19,6 +19,7 @@ resulting panels to the full sheet.
 """
 
 from dataclasses import dataclass, field
+from itertools import pairwise
 from math import atan2, degrees, hypot
 from statistics import median
 
@@ -256,7 +257,7 @@ def box_polygon(
     if touched - {edge_a, edge_b}:
         return None
     chamfers = 0
-    for a, b in zip(ring, ring[1:], strict=False):
+    for a, b in pairwise(ring):
         if not off_axis(a, b):
             continue
         # A diagonal that reaches a sheet edge is a street or a fold cutting

--- a/mapsnap/corner_boxes_test.py
+++ b/mapsnap/corner_boxes_test.py
@@ -1,0 +1,192 @@
+import numpy as np
+import pytest
+from shapely.geometry import Polygon
+
+from mapsnap.corner_boxes import (
+    chains_from_edge,
+    corner_boxes,
+    flush_edges,
+    line_closure,
+    panels_with_boxes,
+)
+
+H, W = 1000, 1000
+
+
+def blank() -> np.ndarray:
+    return np.zeros((H, W), dtype=np.uint8)
+
+
+def test_flush_edges_uses_the_short_side_tolerance():
+    assert flush_edges((5.0, 500.0), H, W) == {"left"}
+    assert flush_edges((995.0, 990.0), H, W) == {"right", "bottom"}
+    assert flush_edges((500.0, 500.0), H, W) == set()
+
+
+def test_chains_join_endpoint_to_endpoint_only():
+    segments = [
+        (0.0, 600.0, 400.0, 600.0),
+        (400.0, 600.0, 400.0, 1000.0),
+        # Crosses the first segment mid-way: never part of a chain.
+        (200.0, 300.0, 200.0, 900.0),
+    ]
+    chains = chains_from_edge(segments, "left", H, W)
+    longest = max(chains, key=lambda chain: len(chain.used))
+    assert longest.used == frozenset({0, 1})
+    assert longest.free == (400.0, 1000.0)
+
+
+def test_l_chain_closes_a_bottom_left_box():
+    segments = [(2.0, 600.0, 400.0, 600.0), (402.0, 605.0, 400.0, 995.0)]
+    boxes = corner_boxes(segments, blank(), H, W)
+    assert len(boxes) == 1
+    assert boxes[0].polygon.area == pytest.approx(400 * 400, rel=0.02)
+    assert boxes[0].polygon.contains(
+        Polygon([(1, 601), (399, 601), (399, 999), (1, 999)])
+    )
+
+
+def test_chamfer_is_a_diagonal_link_in_the_chain():
+    segments = [
+        (0.0, 700.0, 150.0, 700.0),
+        (150.0, 700.0, 300.0, 550.0),
+        (300.0, 550.0, 500.0, 550.0),
+        (500.0, 550.0, 500.0, 1000.0),
+    ]
+    boxes = corner_boxes(segments, blank(), H, W)
+    assert len(boxes) == 1
+    # The 500x450 rectangle less the 150x150 block above the stub and the
+    # chamfer triangle beside it.
+    assert boxes[0].area == pytest.approx(
+        500 * 450 - 150 * 150 - 150 * 150 / 2, rel=0.01
+    )
+
+
+def test_two_chains_meet_across_an_unseen_chamfer():
+    # The diagonal itself was never vectorized; the free ends are 85 px apart,
+    # beyond the join distance (50) but within the chamfer reach (120).
+    segments = [(0.0, 600.0, 350.0, 600.0), (410.0, 660.0, 410.0, 1000.0)]
+    boxes = corner_boxes(segments, blank(), H, W)
+    assert len(boxes) == 1
+    assert boxes[0].polygon.area == pytest.approx(410 * 400 - 60 * 60 / 2, rel=0.02)
+
+
+def test_ink_line_closes_a_side_hough_missed():
+    segments = [(0.0, 600.0, 400.0, 600.0)]
+    binary = blank()
+    assert corner_boxes(segments, binary, H, W) == []
+    binary[600:1000, 401:405] = 255  # the box's right side, 4 px wide
+    boxes = corner_boxes(segments, binary, H, W)
+    assert len(boxes) == 1
+    assert boxes[0].polygon.area == pytest.approx(400 * 400, rel=0.02)
+    assert "ink line" in boxes[0].detail
+
+
+def test_scattered_ink_is_not_a_line():
+    binary = blank()
+    rng = np.random.default_rng(0)
+    # Dense content: 60% of rows carry ink somewhere in the strip, in no column.
+    for y in range(600, 1000):
+        if rng.random() < 0.6:
+            x = int(rng.integers(392, 409))
+            binary[y, x] = 255
+    assert not line_closure(binary, (400.0, 600.0), "bottom", H, W)
+    binary[600:1000, 399:403] = 255
+    assert line_closure(binary, (400.0, 600.0), "bottom", H, W)
+
+
+def test_a_street_thin_straight_line_is_not_a_box_side():
+    binary = blank()
+    binary[600:1000, 400:402] = 255  # map-line weight, 2 px
+    assert not line_closure(binary, (400.0, 600.0), "bottom", H, W)
+
+
+def test_a_box_reaching_a_third_edge_is_a_strip_not_a_corner_box():
+    # A chain from the left edge that runs the full width to the right edge and
+    # down: a bottom strip, the general splitter's business.
+    strip = [(0.0, 700.0, 1000.0, 700.0), (1000.0, 700.0, 1000.0, 1000.0)]
+    assert corner_boxes(strip, blank(), H, W) == []
+
+
+def test_a_wandering_boundary_is_not_a_box():
+    # A heavy volume boundary following a rotated street grid: every link is
+    # off-axis, so however it reaches the edges it encloses no box.
+    boundary = [
+        (0.0, 500.0, 200.0, 420.0),
+        (200.0, 420.0, 350.0, 560.0),
+        (350.0, 560.0, 520.0, 700.0),
+        (520.0, 700.0, 450.0, 1000.0),
+    ]
+    assert corner_boxes(boundary, blank(), H, W) == []
+
+
+def test_a_pinched_ring_is_rejected_for_the_box_inside_it():
+    # The chain runs up from the bottom edge and back left; an ink line from
+    # its free end to the right edge passes 2 px above the chain's own side.
+    # That ring is valid but pinched to a sliver; the box is the prefix chain's.
+    segments = [(600.0, 1000.0, 600.0, 400.0), (600.0, 400.0, 300.0, 398.0)]
+    binary = blank()
+    binary[395:400, 300:1000] = 255
+    boxes = corner_boxes(segments, binary, H, W)
+    assert len(boxes) == 1
+    assert boxes[0].polygon.area == pytest.approx(400 * 600, rel=0.02)
+
+
+def test_a_flush_box_beats_an_overlapping_ink_closed_one():
+    # A legend box in the top-left corner with a double-ruled right border
+    # (Los Angeles pb): the outer rule closes the legend flush; from the inner
+    # rule an ink line runs right along the legend's bottom, closing a second
+    # box that overlaps the legend's border. The flush box stays.
+    segments = [
+        (470.0, 0.0, 470.0, 300.0),
+        (470.0, 300.0, 0.0, 300.0),
+        (455.0, 0.0, 455.0, 300.0),
+    ]
+    binary = blank()
+    binary[298:303, 455:1000] = 255
+    boxes = corner_boxes(segments, binary, H, W)
+    assert [candidate.corner for candidate in boxes] == [("left", "top")]
+    assert boxes[0].polygon.area == pytest.approx(470 * 300, rel=0.02)
+
+
+def test_a_diagonal_reaching_the_edges_cuts_a_triangle_not_a_box():
+    # A street running from the left edge to the bottom edge (Cincinnati p1R).
+    assert corner_boxes([(0.0, 700.0, 300.0, 1000.0)], blank(), H, W) == []
+
+
+def test_notch_and_sliver_are_not_boxes():
+    notch = [
+        (0.0, 300.0, 200.0, 300.0),
+        (200.0, 300.0, 200.0, 500.0),
+        (200.0, 500.0, 0.0, 500.0),
+    ]
+    assert corner_boxes(notch, blank(), H, W) == []
+    sliver = [(0.0, 990.0, 300.0, 990.0), (300.0, 990.0, 300.0, 1000.0)]
+    assert corner_boxes(sliver, blank(), H, W) == []
+
+
+def test_largest_box_wins_over_its_interior_rule():
+    segments = [
+        (0.0, 600.0, 400.0, 600.0),
+        (400.0, 600.0, 400.0, 1000.0),
+        (200.0, 600.0, 200.0, 1000.0),  # a rule inside the box
+    ]
+    boxes = corner_boxes(segments, blank(), H, W)
+    assert len(boxes) == 1
+    assert boxes[0].polygon.area == pytest.approx(400 * 400, rel=0.02)
+
+
+def test_panels_with_boxes_tile_the_sheet():
+    segments = [
+        (0.0, 600.0, 400.0, 600.0),
+        (400.0, 600.0, 400.0, 1000.0),
+        (1000.0, 200.0, 700.0, 200.0),
+        (700.0, 200.0, 700.0, 0.0),
+    ]
+    boxes = corner_boxes(segments, blank(), H, W)
+    assert len(boxes) == 2
+    panels = panels_with_boxes([candidate.polygon for candidate in boxes], H, W)
+    assert len(panels) == 3
+    assert panels[0].area == pytest.approx(H * W - 400 * 400 - 300 * 200, rel=0.01)
+    assert sum(panel.area for panel in panels) == pytest.approx(H * W, rel=1e-6)
+    assert panels_with_boxes([], H, W) == []

--- a/mapsnap/split.py
+++ b/mapsnap/split.py
@@ -1315,8 +1315,10 @@ def keymap_corner_box_panels(
     candidates = box_candidates(lines, h, w, binary)
     boxes = corner_boxes(candidates, binary, h, w)
     log_lines = [
-        f"corner boxes: {len(boxes)} found among {len(candidates)} "
-        "box-thick candidate segment(s)"
+        (
+            f"corner boxes: {len(boxes)} found among {len(candidates)} "
+            "box-thick candidate segment(s)"
+        )
     ]
     for candidate in boxes:
         share = candidate.area / (h * w)

--- a/mapsnap/split.py
+++ b/mapsnap/split.py
@@ -28,6 +28,7 @@ from shapely.geometry import LineString, Point, Polygon, box
 from shapely.ops import polygonize, unary_union
 from skimage.morphology import medial_axis
 
+from mapsnap.corner_boxes import BOX_MIN_THICK_PX, corner_boxes, panels_with_boxes
 from mapsnap.keymap.log import append_keymap_log
 from mapsnap.utils import image_stem, jpeg_dimensions
 
@@ -1268,6 +1269,67 @@ def is_keymap_sheet(stem: str) -> bool:
     return match is not None and int(match.group(1)) in (0, 1)
 
 
+def keymap_box_sheet(image_path: Path) -> bool:
+    """Whether a key-map candidate sheet is one the corner-box detector may cut.
+
+    The page-0 family and letter sheets are the key map in every volume censused
+    (mapsnap.keymap.identify.detection_plan); a page-1 sheet is only when the
+    volume has no page 0, and is otherwise an ordinary map page whose corner a
+    diagonal street or a fold could carve into a box-shaped panel.
+    """
+    stem = panel_basename(image_path)
+    if not is_keymap_sheet(stem):
+        return False
+    if re.fullmatch(r"p1[A-Za-z]{0,2}", stem):
+        return not any(image_path.parent.glob("p0*.jpg"))
+    return True
+
+
+def box_candidates(
+    lines: np.ndarray, h: int, w: int, binary: np.ndarray
+) -> list[tuple[float, float, float, float]]:
+    """Long segments at least BOX_MIN_THICK_PX thick, uncapped.
+
+    The corner-box detector's input (mapsnap.corner_boxes): the divider
+    pipeline's MAX_DIVIDER_CANDIDATES gate and its 5 px thickness floor are what
+    hide a key map's boxed regions, so this is the same merge and length filter
+    without them.
+    """
+    merged = merge_collinear(filter_segments(lines, h, w), MERGE_GAP_FRAC * min(h, w))
+    dist = cv2.distanceTransform((binary > 0).astype(np.uint8), cv2.DIST_L2, 5)
+    return [
+        seg
+        for seg in keep_long_segments(merged, h, w)
+        if segment_thickness(dist, seg) >= BOX_MIN_THICK_PX
+    ]
+
+
+def keymap_corner_box_panels(
+    lines: np.ndarray, h: int, w: int, binary: np.ndarray
+) -> tuple[list, list[str]]:
+    """Panels cut by the corner-box detector, in the full frame, with log lines.
+
+    No panels when no box is found, or when the boxes do not leave one clean
+    remainder; the log lines say what was found either way.
+    """
+    candidates = box_candidates(lines, h, w, binary)
+    boxes = corner_boxes(candidates, binary, h, w)
+    log_lines = [
+        f"corner boxes: {len(boxes)} found among {len(candidates)} "
+        "box-thick candidate segment(s)"
+    ]
+    for candidate in boxes:
+        share = candidate.area / (h * w)
+        log_lines.append(
+            f"  {'-'.join(candidate.corner)} box, {share:.1%} of the sheet: "
+            f"{candidate.detail}"
+        )
+    panels = panels_with_boxes([candidate.polygon for candidate in boxes], h, w)
+    if boxes and not panels:
+        log_lines.append("  boxes do not leave one clean remainder; sheet stands whole")
+    return expand_to_full_frame(panels, h, w, BORDER_PX), log_lines
+
+
 def keymap_split_rejection(panels: list, width: float, height: float) -> str | None:
     """Why a key-map sheet's split must be refused, or None when it may stand.
 
@@ -1373,35 +1435,51 @@ def process_image(image_path: Path, debug: bool = False) -> None:
 
     # A single panel covering the whole page means no split was found.
     is_single_full = len(panels) == 1 and panels[0].area >= 0.99 * full_h * full_w
+    # A key-map sheet only gives up boxed edge regions; anything else is a bad
+    # cut and the sheet stands whole (#276).
+    rejection = (
+        keymap_split_rejection(panels, full_w, full_h)
+        if is_keymap_sheet(base) and not is_single_full
+        else None
+    )
+    # Where the divider pipeline leaves a key-map sheet whole, look for the
+    # boxed corners its safety gates hide: a second key map, an index inset, a
+    # legend (mapsnap.corner_boxes).
+    box_lines: list[str] = []
+    if (is_single_full or rejection) and keymap_box_sheet(image_path):
+        box_panels, box_lines = keymap_corner_box_panels(lines, h, w, binary)
+        if box_panels:
+            panels, is_single_full, rejection = box_panels, False, None
+            print(f"{image_path.name}: key-map sheet, corner box(es) cut away")
     if is_single_full:
         print(f"{image_path.name}: single panel — not split")
         for index in range(1, len(previous_rings) + 1):
             remove_panel_sidecars(image_path, index)
         if is_keymap_sheet(base):
-            append_keymap_log(image_path, "split", ["single panel — not split"])
-        return
-    # A key-map sheet only gives up boxed edge regions; anything else is a bad
-    # cut and the sheet stands whole (#276). The stale panels were removed
-    # above; drop their sidecars too so nothing downstream keeps reading them.
-    if is_keymap_sheet(base):
-        rejection = keymap_split_rejection(panels, full_w, full_h)
-        if rejection:
-            print(f"{image_path.name}: key-map sheet, split rejected — {rejection}")
-            removed = []
-            for index in range(1, len(previous_rings) + 1):
-                removed += remove_panel_sidecars(image_path, index)
-            if raw_path.exists():
-                remove_split_outputs(raw_path)
             append_keymap_log(
-                image_path,
-                "split",
-                [
-                    f"split rejected — {rejection}",
-                    *panel_summary_lines(panels, full_w, full_h),
-                    f"removed {len(removed)} stale panel sidecar(s) from an earlier split",
-                ],
+                image_path, "split", ["single panel — not split", *box_lines]
             )
-            return
+        return
+    if rejection:
+        # The stale panels were removed above; drop their sidecars too so
+        # nothing downstream keeps reading them.
+        print(f"{image_path.name}: key-map sheet, split rejected — {rejection}")
+        removed = []
+        for index in range(1, len(previous_rings) + 1):
+            removed += remove_panel_sidecars(image_path, index)
+        if raw_path.exists():
+            remove_split_outputs(raw_path)
+        append_keymap_log(
+            image_path,
+            "split",
+            [
+                f"split rejected — {rejection}",
+                *panel_summary_lines(panels, full_w, full_h),
+                *box_lines,
+                f"removed {len(removed)} stale panel sidecar(s) from an earlier split",
+            ],
+        )
+        return
     ordered = order_panels(panels, full_h)  # panels are in the uncropped frame
     out_paths = write_panels(image_path, ordered, base)
     print(
@@ -1415,6 +1493,7 @@ def process_image(image_path: Path, debug: bool = False) -> None:
                 f"split accepted: {len(ordered)} panels → "
                 + ", ".join(path.name for path in out_paths),
                 *panel_summary_lines(ordered, full_w, full_h),
+                *box_lines,
             ],
         )
     changed = invalidate_changed_panels(

--- a/mapsnap/split_test.py
+++ b/mapsnap/split_test.py
@@ -5,14 +5,17 @@ from pathlib import Path
 import cv2
 import numpy as np
 import pytest
-from shapely.geometry import box
+from PIL import Image
+from shapely.geometry import Polygon, box
 
 from mapsnap.split import (
     BORDER_PX,
     assemble_panels,
+    box_candidates,
     crop_border,
     invalidate_changed_panels,
     is_keymap_sheet,
+    keymap_box_sheet,
     keymap_split_rejection,
     merge_collinear,
     order_panels,
@@ -20,6 +23,7 @@ from mapsnap.split import (
     panel_compactness,
     panel_summary_lines,
     panels_json_path,
+    process_image,
     read_panels_json,
     remove_panel_sidecars,
     remove_split_outputs,
@@ -349,3 +353,61 @@ def test_assemble_panels_glues_an_edge_strip_in_the_small_band():
     panels = assemble_panels(faces, 100, 100)
     assert len(panels) == 1
     assert panels[0].area == pytest.approx(100 * 100)
+
+
+# --- corner boxes on key-map sheets (#276, step 5) ---
+
+
+def test_keymap_box_sheet_is_the_volume_key_map_only(tmp_path):
+    for name in ("p0.jpg", "pa.jpg", "p1.jpg", "p45.jpg"):
+        (tmp_path / name).touch()
+    assert keymap_box_sheet(tmp_path / "p0.jpg")
+    assert keymap_box_sheet(tmp_path / "pa.jpg")
+    # Page 1 is an ordinary map page when the volume has a page 0.
+    assert not keymap_box_sheet(tmp_path / "p1.jpg")
+    assert not keymap_box_sheet(tmp_path / "p45.jpg")
+    assert not keymap_box_sheet(tmp_path / "p0__1.jpg")
+    alone = tmp_path / "alone"
+    alone.mkdir()
+    (alone / "p1.jpg").touch()
+    assert keymap_box_sheet(alone / "p1.jpg")
+
+
+def test_box_candidates_keep_box_thick_lines_uncapped():
+    h = w = 1000
+    binary = np.zeros((h, w), dtype=np.uint8)
+    binary[600:604, 0:400] = 255  # a 4 px box side: below the divider floor
+    binary[100:102, 500:900] = 255  # a 2 px map line
+    lines = [[0, 602, 400, 602], [500, 101, 900, 101]]
+    # More long lines than MAX_DIVIDER_CANDIDATES: the divider gate would give up.
+    for i in range(14):
+        y = 200 + 25 * i
+        binary[y : y + 6, 500:900] = 255
+        lines.append([500, y + 3, 900, y + 3])
+    kept = box_candidates(np.array(lines, dtype=float), h, w, binary)
+    assert len(kept) == 15
+    assert not any(seg[1] == 101 and seg[3] == 101 for seg in kept)
+
+
+def test_process_image_cuts_a_corner_box_the_divider_gate_hid(tmp_path):
+    # A key-map sheet: a dense grid of heavy interior rules (more than the
+    # divider pipeline's candidate cap, so it stands whole) and a boxed region
+    # in the bottom-left corner, flush with the left and bottom edges.
+    w, h = 1200, 1600
+    sheet = np.full((h, w, 3), 255, dtype=np.uint8)
+    for i in range(14):
+        x = 300 + 50 * i
+        sheet[250:1000, x : x + 7] = 0
+    sheet[1150:1157, 0:500] = 0  # box top
+    sheet[1150:1600, 500:507] = 0  # box right side
+    image_path = tmp_path / "p0.jpg"
+    Image.fromarray(sheet).save(image_path, quality=95)
+    process_image(image_path)
+    panels = read_panels_json(tmp_path / "p0.panels.json")["panels"]
+    assert len(panels) == 2
+    assert (tmp_path / "p0__1.jpg").exists() and (tmp_path / "p0__2.jpg").exists()
+    areas = sorted(Polygon(ring).area / (w * h) for ring in panels)
+    assert areas[0] == pytest.approx(500 * 450 / (w * h), abs=0.01)
+    log = (tmp_path / "raw" / "p0.keymap.txt").read_text()
+    assert "corner boxes: 1 found" in log
+    assert "bottom-left box" in log

--- a/scripts/corner_box_sweep.py
+++ b/scripts/corner_box_sweep.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Run the key-map corner-box detector over every key-map candidate sheet.
+
+For each unsplit page-0 / page-1 / letter sheet under data/ (the sheets
+split.is_keymap_sheet nominates), run the splitter's front-end, hand the
+uncapped box-thick candidates to mapsnap.corner_boxes, and print what it finds:
+the corner, share of the sheet, and how the box was closed. Pass --draw DIR to
+write a thumbnail per sheet with a box, candidates in blue and boxes in red.
+
+The precision census for #276 step 5 (2026-09-02): 9 boxes on 70 sheets, all
+real boxed regions -- Detroit's volume-index inset, Ellenville's Napanoch,
+Kingston's Port Ewen, Los Angeles pa's Vol-13 continuation, the KEY legends of
+Schenectady (both editions) and New York 1905, and the Kansas City and New
+Orleans 1951 insets the divider pipeline already cuts. Rerun after touching the
+detector's rules; a new box on any other sheet needs looking at.
+
+    uv run python scripts/corner_box_sweep.py [--draw DIR] [data/<volume>/p0.jpg ...]
+"""
+
+import argparse
+import glob
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+from mapsnap import corner_boxes as cb
+from mapsnap import split as sp
+
+
+def candidate_sheets() -> list[Path]:
+    """Every unsplit key-map candidate sheet under data/."""
+    return sorted(
+        Path(path)
+        for path in glob.glob("data/*/p*.jpg")
+        if "__" not in Path(path).stem and sp.is_keymap_sheet(Path(path).stem)
+    )
+
+
+def sweep_sheet(image_path: Path, draw_dir: Path | None) -> list[cb.BoxCandidate]:
+    """Detect corner boxes on one sheet, printing and optionally drawing them."""
+    rgb = sp.crop_border(sp.load_rgb(image_path))
+    gray = sp.crop_border(sp.load_gray(image_path))
+    h, w = gray.shape
+    binary = sp.binarize(rgb, gray)
+    candidates = sp.box_candidates(sp.detect_lines(binary), h, w, binary)
+    boxes = cb.corner_boxes(candidates, binary, h, w)
+    key = f"{image_path.parent.name}/{image_path.stem}"
+    print(f"{key:45s} candidates={len(candidates):3d} boxes={len(boxes)}")
+    for candidate in boxes:
+        share = candidate.area / (h * w)
+        print(f"    {'-'.join(candidate.corner)} {share:.1%}: {candidate.detail}")
+    if draw_dir is not None and boxes:
+        image = Image.fromarray(rgb).convert("RGB")
+        draw = ImageDraw.Draw(image)
+        for x0, y0, x1, y1 in candidates:
+            draw.line([(x0, y0), (x1, y1)], fill=(0, 0, 255), width=4)
+        for candidate in boxes:
+            ring = [(x, y) for x, y in candidate.polygon.exterior.coords]
+            draw.polygon(ring, outline=(255, 0, 0), width=8)
+        image.thumbnail((900, 900))
+        draw_dir.mkdir(parents=True, exist_ok=True)
+        image.save(draw_dir / f"{key.replace('/', '__')}.jpg", quality=75)
+    return boxes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the key-map corner-box detector over key-map candidate sheets."
+    )
+    parser.add_argument("images", nargs="*", type=Path, help="sheets (default: all)")
+    parser.add_argument("--draw", type=Path, help="write thumbnails with boxes here")
+    args = parser.parse_args()
+    sheets = args.images or candidate_sheets()
+    total = 0
+    for image_path in sheets:
+        total += len(sweep_sheet(image_path, args.draw))
+    print(f"{total} box(es) on {len(sheets)} sheet(s)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Step 5 of #276. Los Angeles pa's Vol-13 continuation and Ellenville's Napanoch are second key maps sharing a sheet with the main one, and neither was ever split: the main key map is dense with long linework, so the divider pipeline's `MAX_DIVIDER_CANDIDATES` gate leaves the sheet whole, and Napanoch's 4 px border sits below the 5 px divider floor. Their page numbers then seeded the main key map's frame with priors three miles (Napanoch pages 14, 15) or a county (1499O–R) off.

## The detector (`mapsnap/corner_boxes.py`)

Every legitimate key-map cut-away has one shape: a **chain of axis-aligned segments from one sheet edge to an adjacent edge**, enclosing the corner between them, convex, touching no third edge. Three ways to close a chain, preferred in order:

1. the chain reaches the other edge on its own (Kansas City, New Orleans 1951, Los Angeles pa: a four-segment chain whose second link is the box's chamfer);
2. two chains, one from each edge, meet across a chamfer the detector saw both sides of (Detroit's volume-index inset);
3. a straight, border-thick ink line runs from the chain's free end to the edge, for a side Hough never vectorized (Ellenville: coverage 1.00 at 4 px).

The splitter runs it as a second chance, only on key-map sheets the divider pipeline left whole (single panel, or a cut the #383 gate rejected), and only on sheets that are the volume's key map: the page-0 family, letter sheets, and page 1 when there is no page 0. Every box and how it was closed goes into the `split` section of the key-map decision log.

## Precision census

`scripts/corner_box_sweep.py` runs it over all 70 unsplit key-map candidate sheets under `data/`: **9 boxes, all real boxed regions, no false cuts**.

| Sheet | Box | Closure |
|---|---|---|
| ellenville p0 | Napanoch, bottom-left 22% | ink line, coverage 1.00, 4 px |
| los_angeles pa | Vol-13 continuation, bottom-left 25% | 4-segment chain incl. chamfer |
| kingston p0 | Port Ewen, top-left 12.5% | 2-segment chain |
| schenectady p0 (×2 editions) | KEY legend, top-left 8% | ink line, coverage 0.97, 4 px |
| detroit p0 | volume-index inset 11% | chamfer link |
| kansas_city p0, new_orleans_1951 p0, new_york_1905 p0 | inset / legend | already cut by the divider pipeline |

The first four are new splits. Getting there took six rules, each pinned by a test with the sheet that motivated it: strips reaching a third edge (Nashville, NY 1905), wandering off-axis volume boundaries (Atlanta), self-pinched rings that `buffer(0)` used to repair into a lobe (Los Angeles pa), thin straight streets under an ink closure (coverage bar 0.8: every false closure on the corpus scored 0.55–0.78), diagonals reaching both edges (Cincinnati p1R), and an ink-closed box out-ranking an overlapping flush one (Los Angeles pb).

## What happens downstream

The cut-away panels go through the key-map pipeline as today's Kansas City and New Orleans panels do: each panel is judged by page coverage. Napanoch (4 distinct pages) and the Vol-13 box (1499O–R) do not qualify as key maps, so their reads simply leave the main key map's frame. That is the win: pages 14/15 and 1499O–R lose a wrong prior rather than keep one, and pages 2/11/13 in Ellenville stop having a second search center three miles away. Georeferencing the small panels as key maps in their own right is a follow-up.

Nothing under `data/` is re-split here. The next baseline's re-split (docs/baseline.md pre-flight) picks the four sheets up; I ran the splitter on scratch copies to verify the cuts.

Part of #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)