### PR TITLE
Snap panel shows how select and verif are built, on hover

### DIFF
--- a/app/src/components/SnapPanel.test.tsx
+++ b/app/src/components/SnapPanel.test.tsx
@@ -127,6 +127,23 @@ describe('SnapPanel phase-2 records', () => {
     );
   });
 
+  it('carries each score breakdown in a hover popover, not in the row', () => {
+    const html = render(record);
+    // Every row's select and verif cells carry a breakdown tooltip.
+    expect(
+      (html.match(/class="snap-breakdown" role="tooltip"/g) ?? []).length,
+    ).toBe(8);
+    // The truth row's name term, from its recorded alignment block.
+    expect(html).toContain('5/9 labels hit');
+    expect(html).toContain('record predates the signed term');
+    expect(html).toContain('no key-map region for this page');
+    // The fixture records no containment or prior, so the terms fall short
+    // of the recorded select and the popover says so.
+    expect(html).toContain('terms sum to 0.544, recorded 0.678');
+    // The incumbent has no recorded select score.
+    expect(html).toContain('not recorded for this pose');
+  });
+
   it('says when truth exists but was never scored', () => {
     const { truth_pose: _omit, ...unscored } = record;
     const html = render(unscored);

--- a/app/src/components/SnapPanel.tsx
+++ b/app/src/components/SnapPanel.tsx
@@ -1,11 +1,15 @@
+import { useState } from 'react';
 import {
   groupRotationPriors,
   posePxPerFoot,
   poseRotationDeg,
   rankedCandidates,
+  selectBreakdown,
   truthVerdict,
+  verificationBreakdown,
 } from '../snap';
 import type {
+  ScoreBreakdown,
   SnapCandidate,
   SnapDecisionBar,
   SnapRecord,
@@ -29,6 +33,82 @@ interface SnapPanelProps {
   onClose: () => void;
 }
 
+// Room a popover needs below a cell before it is placed above it instead.
+const POPOVER_HEIGHT_PX = 160;
+
+// A score cell whose breakdown pops over the table on hover. The popover is
+// fixed-positioned from the cell's viewport rectangle, so it escapes the
+// panel's scroll clipping and showing it never reflows the rows (selecting a
+// row must not make the table jump). It is always in the markup, hidden
+// until hovered, so a static render carries the breakdown too.
+function ScoreCell({ breakdown }: { breakdown: ScoreBreakdown }) {
+  const shown = breakdown.recorded ?? breakdown.total;
+  const [anchor, setAnchor] = useState<React.CSSProperties | null>(null);
+  const show = (event: React.MouseEvent<HTMLTableCellElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const below = rect.bottom + POPOVER_HEIGHT_PX <= window.innerHeight;
+    setAnchor(
+      below
+        ? { left: rect.left, top: rect.bottom }
+        : { left: rect.left, bottom: window.innerHeight - rect.top },
+    );
+  };
+  return (
+    <td
+      className="num snap-score"
+      onMouseEnter={show}
+      onMouseLeave={() => setAnchor(null)}
+    >
+      <span>{shown != null ? shown.toFixed(2) : '—'}</span>
+      <div
+        className={'snap-breakdown' + (anchor ? ' open' : '')}
+        style={anchor ?? undefined}
+        role="tooltip"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <table>
+          <tbody>
+            {breakdown.terms.map((term, i) => (
+              <tr
+                key={term.label}
+                className={term.value === null ? 'snap-breakdown-missing' : ''}
+              >
+                <td>
+                  {i === 0
+                    ? ''
+                    : term.value !== null && term.value < 0
+                      ? '−'
+                      : '+'}
+                </td>
+                <td>{term.label}</td>
+                <td className="num">
+                  {term.value !== null ? Math.abs(term.value).toFixed(3) : '—'}
+                </td>
+                <td>{term.detail}</td>
+              </tr>
+            ))}
+            <tr className="snap-breakdown-total">
+              <td>=</td>
+              <td>{breakdown.label}</td>
+              <td className="num">
+                {breakdown.total !== null ? breakdown.total.toFixed(3) : '—'}
+              </td>
+              <td>
+                {breakdown.recorded !== null
+                  ? `recorded ${breakdown.recorded.toFixed(4)}`
+                  : 'not recorded for this pose'}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        {breakdown.note && (
+          <p className="snap-breakdown-note">{breakdown.note}</p>
+        )}
+      </div>
+    </td>
+  );
+}
+
 function CandidateRow({
   label,
   candidate,
@@ -50,8 +130,8 @@ function CandidateRow({
       style={{ cursor: 'pointer' }}
     >
       <td>{label}</td>
-      <td className="num">{c.select_score?.toFixed(2) ?? '—'}</td>
-      <td className="num">{c.verification?.toFixed(2) ?? '—'}</td>
+      <ScoreCell breakdown={selectBreakdown(c)} />
+      <ScoreCell breakdown={verificationBreakdown(c)} />
       <td className="num">{c.inlier_frac?.toFixed(2) ?? '—'}</td>
       <td className="num">{c.ncc_fine?.toFixed(2) ?? '—'}</td>
       <td className="num">
@@ -147,10 +227,12 @@ export function SnapPanel({
         <thead>
           <tr>
             <th>pose</th>
-            <th title="the ranking score gates compare against (rescue bar 1.25)">
+            <th title="the ranking score gates compare against (rescue bar 1.25); hover a cell for its breakdown">
               select
             </th>
-            <th title="inlier_frac + ncc_fine − chamfer penalty">verif</th>
+            <th title="inlier_frac + ncc_fine − chamfer penalty; hover a cell for its breakdown">
+              verif
+            </th>
             <th title="share of P(road) pixels within the chamfer inlier distance of OSM">
               inlier
             </th>

--- a/app/src/snap.test.ts
+++ b/app/src/snap.test.ts
@@ -5,7 +5,9 @@ import {
   posePxPerFoot,
   poseRotationDeg,
   rankedCandidates,
+  selectBreakdown,
   truthVerdict,
+  verificationBreakdown,
 } from './snap';
 
 const affine: [number, number, number][] = [
@@ -193,5 +195,90 @@ describe('pose rotation and scale', () => {
       [-c * Math.sin(theta), -c * Math.cos(theta), 40],
     ];
     expect(poseRotationDeg(rotated)).toBeCloseTo(30, 6);
+  });
+});
+
+describe('selectBreakdown', () => {
+  // A candidate with every term recorded: select = verif + 1.0·name
+  // + 0.3·containment + 0.1·(1 − σ).
+  const full = {
+    verification: 0.17,
+    select_score: 0.825,
+    name: { score: 0.31, evidence: 0.31, n_labels: 15, n_hits: 6 },
+    region_containment: 0.95,
+    prior_theta_residual_sigma: 0.4,
+  };
+
+  it('adds the four terms back up to the recorded score', () => {
+    const b = selectBreakdown(full);
+    expect(b.terms.map((t) => t.label)).toEqual([
+      'verif',
+      'name',
+      'containment',
+      'prior',
+    ]);
+    expect(b.terms.map((t) => t.value)).toEqual([0.17, 0.31, 0.285, 0.06]);
+    expect(b.total).toBeCloseTo(0.825, 6);
+    expect(b.recorded).toBe(0.825);
+    expect(b.note).toBeUndefined();
+    expect(b.terms[1].detail).toContain('6/15 labels hit');
+    expect(b.terms[3].detail).toContain('0.40σ');
+  });
+
+  it('charges a gross prior disagreement at most the full weight', () => {
+    const b = selectBreakdown({ ...full, prior_theta_residual_sigma: 40 });
+    expect(b.terms[3].value).toBeCloseTo(-0.1, 6);
+  });
+
+  it('shows missing terms as missing and skips them, like the pipeline', () => {
+    const b = selectBreakdown({ verification: 0.5, select_score: 0.5 });
+    expect(b.terms.slice(1).map((t) => t.value)).toEqual([null, null, null]);
+    expect(b.terms[2].detail).toBe('no key-map region for this page');
+    expect(b.total).toBe(0.5);
+    expect(b.note).toBeUndefined();
+  });
+
+  it('falls back to the reward-only name score on a pre-#375 record', () => {
+    const b = selectBreakdown({
+      verification: 0.1,
+      select_score: 0.4,
+      name: { score: 0.3, n_labels: 4, n_hits: 2 },
+    });
+    expect(b.terms[1].value).toBeCloseTo(0.3, 6);
+    expect(b.terms[1].detail).toContain('predates the signed term');
+  });
+
+  it('flags a recorded score the terms no longer add up to', () => {
+    const b = selectBreakdown({ ...full, select_score: 0.9 });
+    expect(b.note).toContain('terms sum to 0.825, recorded 0.900');
+  });
+
+  it('has no total for an implausible pose', () => {
+    const b = selectBreakdown({ name: full.name });
+    expect(b.total).toBeNull();
+    expect(b.recorded).toBeNull();
+    expect(b.terms[0].detail).toContain('−∞');
+  });
+});
+
+describe('verificationBreakdown', () => {
+  it('is inlier + ncc − chamfer / 30 m', () => {
+    const b = verificationBreakdown({
+      inlier_frac: 0.52,
+      ncc_fine: 0.31,
+      chamfer_mean_m: 20.1,
+      verification: 0.16,
+    });
+    expect(b.terms.map((t) => t.label)).toEqual(['inlier', 'ncc', 'chamfer']);
+    expect(b.terms[2].value).toBeCloseTo(-0.67, 6);
+    expect(b.terms[2].detail).toBe('−20.1 m / 30 m');
+    expect(b.total).toBeCloseTo(0.16, 6);
+    expect(b.note).toBeUndefined();
+  });
+
+  it('has no total when a constituent was not recorded', () => {
+    const b = verificationBreakdown({ inlier_frac: 0.5, verification: 0.5 });
+    expect(b.total).toBeNull();
+    expect(b.terms[1].detail).toBe('not recorded');
   });
 });

--- a/app/src/snap.ts
+++ b/app/src/snap.ts
@@ -11,9 +11,12 @@
 
 /** OCR street-name agreement with a pose (a boost, never a gate). */
 export interface SnapNameAlignment {
+  /** Reward-only alignment: Σ exp(−d/25 m) over hits, / (n_labels + 2). */
   score: number;
   n_labels: number;
   n_hits: number;
+  /** The signed term the ranking uses (#375); absent on older records. */
+  evidence?: number;
   hits?: { text: string; dist_m: number; angle_deg: number }[];
 }
 
@@ -34,6 +37,8 @@ export interface SnapCandidate {
   n_points?: number;
   overlap_frac?: number;
   region_containment?: number;
+  /** Sigmas from the nearest directed rotation prior; absent without one. */
+  prior_theta_residual_sigma?: number;
   refine_shift_m?: number;
   select_score?: number;
   verification?: number;
@@ -272,5 +277,186 @@ export function truthVerdict(record: SnapRecord): TruthVerdict | null {
   return {
     kind: 'agrees',
     detail: `top candidate is ${rmse === undefined ? 'near' : `${Math.round(rmse)} ft from`} truth and outscores it (${topScore} vs ${truthScore})`,
+  };
+}
+
+// The ranking weights and the chamfer clamp, mirrored from the pipeline
+// (mapsnap/osm_snap.py W_NAME / W_CONTAIN / W_PRIOR, mapsnap/edge_join.py
+// CHAMFER_CLAMP_M). Records carry the terms and the totals but not the
+// weights; selectBreakdown flags a total that no longer adds up, which is how
+// a weight change upstream shows itself here.
+export const W_NAME = 1.0;
+export const W_CONTAIN = 0.3;
+export const W_PRIOR = 0.1;
+export const CHAMFER_CLAMP_M = 30.0;
+/** Records round scores to 4 decimals; a larger gap means the weights moved. */
+const BREAKDOWN_TOLERANCE = 0.01;
+
+/** One additive term of a score: its label, the product it contributes, how it was formed. */
+export interface ScoreTerm {
+  label: string;
+  /** The signed contribution to the total; null when the record lacks the input. */
+  value: number | null;
+  /** How the value was formed, or why it is missing. */
+  detail: string;
+}
+
+/** A score decomposed into the terms recorded for the pose. */
+export interface ScoreBreakdown {
+  /** The score name: "select" or "verif". */
+  label: string;
+  terms: ScoreTerm[];
+  /** Sum of the present terms; null when the base term is missing. */
+  total: number | null;
+  /** The score as the pipeline recorded it; null when not recorded. */
+  recorded: number | null;
+  /** Set when the terms do not add up to the recorded score. */
+  note?: string;
+}
+
+type Scored = {
+  verification?: number;
+  select_score?: number;
+  inlier_frac?: number;
+  ncc_fine?: number;
+  chamfer_mean_m?: number;
+  name?: SnapNameAlignment;
+  region_containment?: number;
+  prior_theta_residual_sigma?: number;
+};
+
+// Sum the present terms; null when the first (base) term is missing.
+function sumTerms(terms: ScoreTerm[]): number | null {
+  if (terms[0].value === null) return null;
+  return terms.reduce((acc, term) => acc + (term.value ?? 0), 0);
+}
+
+// The mismatch note, when the terms and the recorded total disagree.
+function mismatchNote(
+  total: number | null,
+  recorded: number | null,
+): string | undefined {
+  if (total === null || recorded === null) return undefined;
+  if (Math.abs(total - recorded) <= BREAKDOWN_TOLERANCE) return undefined;
+  return `terms sum to ${total.toFixed(3)}, recorded ${recorded.toFixed(3)}: the pipeline's weights differ from this view's`;
+}
+
+/**
+ * The matcher's verification score decomposed: inlier_frac + ncc_fine −
+ * chamfer_mean_m / CHAMFER_CLAMP_M (edge_join.JoinCandidate.verification_score).
+ */
+export function verificationBreakdown(pose: Scored): ScoreBreakdown {
+  const terms: ScoreTerm[] = [
+    {
+      label: 'inlier',
+      value: pose.inlier_frac ?? null,
+      detail:
+        pose.inlier_frac != null
+          ? 'share of P(road) pixels within the inlier distance of OSM'
+          : 'not recorded',
+    },
+    {
+      label: 'ncc',
+      value: pose.ncc_fine ?? null,
+      detail:
+        pose.ncc_fine != null
+          ? 'fine-scale correlation, P(road) vs OSM'
+          : 'not recorded',
+    },
+    {
+      label: 'chamfer',
+      value:
+        pose.chamfer_mean_m != null
+          ? -pose.chamfer_mean_m / CHAMFER_CLAMP_M
+          : null,
+      detail:
+        pose.chamfer_mean_m != null
+          ? `−${pose.chamfer_mean_m.toFixed(1)} m / ${CHAMFER_CLAMP_M} m`
+          : 'not recorded',
+    },
+  ];
+  const total = terms.every((term) => term.value !== null)
+    ? sumTerms(terms)
+    : null;
+  const recorded = pose.verification ?? null;
+  return {
+    label: 'verif',
+    terms,
+    total,
+    recorded,
+    note: mismatchNote(total, recorded),
+  };
+}
+
+/**
+ * The ranking score decomposed: verification plus the three soft-evidence
+ * terms (osm_snap.selection_score). A term the record lacks is shown as
+ * missing and contributes nothing, exactly as the pipeline skips a None term.
+ */
+export function selectBreakdown(pose: Scored): ScoreBreakdown {
+  const name = pose.name;
+  let nameTerm: ScoreTerm;
+  if (!name) {
+    nameTerm = {
+      label: 'name',
+      value: null,
+      detail: 'no street labels matched to OSM',
+    };
+  } else {
+    const evidence = name.evidence ?? name.score;
+    const hits = `${name.n_hits}/${name.n_labels} labels hit`;
+    const basis =
+      name.evidence != null
+        ? `signed evidence ${evidence.toFixed(3)}`
+        : `reward-only score ${evidence.toFixed(3)} (record predates the signed term)`;
+    nameTerm = {
+      label: 'name',
+      value: W_NAME * evidence,
+      detail: `${W_NAME} × ${basis}; ${hits}`,
+    };
+  }
+  const containment = pose.region_containment;
+  const containTerm: ScoreTerm =
+    containment != null
+      ? {
+          label: 'containment',
+          value: W_CONTAIN * containment,
+          detail: `${W_CONTAIN} × ${(containment * 100).toFixed(0)}% of the footprint inside the key-map region`,
+        }
+      : {
+          label: 'containment',
+          value: null,
+          detail: 'no key-map region for this page',
+        };
+  const sigma = pose.prior_theta_residual_sigma;
+  const priorTerm: ScoreTerm =
+    sigma != null
+      ? {
+          label: 'prior',
+          value: W_PRIOR * Math.max(-1, 1 - sigma),
+          detail: `${W_PRIOR} × max(−1, 1 − ${sigma.toFixed(2)}σ from the nearest directed rotation prior)`,
+        }
+      : { label: 'prior', value: null, detail: 'no directed rotation prior' };
+  const terms: ScoreTerm[] = [
+    {
+      label: 'verif',
+      value: pose.verification ?? null,
+      detail:
+        pose.verification != null
+          ? 'matcher verification (see its own breakdown)'
+          : 'not recorded (implausible pose scores −∞)',
+    },
+    nameTerm,
+    containTerm,
+    priorTerm,
+  ];
+  const total = sumTerms(terms);
+  const recorded = pose.select_score ?? null;
+  return {
+    label: 'select',
+    terms,
+    total,
+    recorded,
+    note: mismatchNote(total, recorded),
   };
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -982,6 +982,56 @@ tr.relaxed {
 .snap-table tr.selected {
   background: #dbeafe;
 }
+/* Score cells carry a hover popover with the score's breakdown. The popover
+   is fixed-positioned from the cell's viewport rectangle (see ScoreCell), so
+   it escapes the panel's scroll clipping and overlays the rows below without
+   reflowing the table (selecting a row must not make it jump). */
+.snap-table td.snap-score {
+  cursor: help;
+}
+.snap-table td.snap-score > span {
+  text-decoration: underline dotted #9ca3af;
+  text-underline-offset: 2px;
+}
+.snap-breakdown {
+  display: none;
+  position: fixed;
+  z-index: 20;
+  padding: 6px 8px;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 12px;
+  text-align: left;
+  white-space: nowrap;
+  cursor: default;
+}
+.snap-breakdown.open {
+  display: block;
+}
+.snap-breakdown table {
+  border-collapse: collapse;
+}
+.snap-breakdown td {
+  padding: 1px 6px 1px 0;
+  border: none;
+}
+.snap-breakdown td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.snap-breakdown-total td {
+  border-top: 1px solid #d1d5db;
+  font-weight: 600;
+}
+.snap-breakdown-missing {
+  color: #6b7280;
+}
+.snap-breakdown-note {
+  margin: 4px 0 0;
+  color: #b45309;
+}
 .snap-table tr.snap-best td:first-child {
   font-weight: 600;
 }


### PR DESCRIPTION
The snap explorer showed the `select` and `verif` scores but not what goes into them, so the street-name term from #375 (and containment, and the rotation-prior residual) were invisible even though every candidate record carries them.

<img width="740" height="287" alt="image" src="https://github.com/user-attachments/assets/601c56a7-a0fe-4dc3-8c56-540d17f095c2" />

Hovering a `select` or `verif` cell now pops a breakdown over the table: each term, its weight and input, and the sum against the recorded value.

```
select = verif + 1.0 × name.evidence + 0.3 × containment + 0.1 × max(−1, 1 − prior residual σ)
verif  = inlier_frac + ncc_fine − chamfer_mean_m / 30 m
```

- A term the record lacks is listed as missing and contributes nothing, as the pipeline skips a `None` term.
- A name block without the signed evidence (records before #375) falls back to the reward-only score and says so. Richmond p365's `ab-incumbent-rung` record is one such.
- When the terms do not add up to the recorded score, an amber note says by how much. The weights live in the pipeline (`osm_snap.W_NAME` / `W_CONTAIN` / `W_PRIOR`, `edge_join.CHAMFER_CLAMP_M`) and are mirrored in `snap.ts`; this note is how a change there shows itself in the debugger.

**UI care.** The popover is fixed-positioned from the cell's viewport rectangle and opened by hover state, so it escapes the snap panel's `overflow: auto` clipping and never reflows the rows: selecting a row does not make the table jump. It flips above the cell when there is no room below. Verified live on Richmond p365 in the running debugger: the panel's scroll height is unchanged with the popover open, and the four terms add back to the recorded 2.2823.

The breakdown helpers (`selectBreakdown`, `verificationBreakdown`) are pure and unit-tested; the panel test checks every row carries both tooltips and that the mismatch note fires on a record with missing terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

