### PR TITLE
Key-map underlay: opacity slider on 'k', warped by thin-plate spline

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -148,6 +148,18 @@ export interface KeymapInfo {
   hasRegions: boolean;
   /** Whether a `raw/<stem>.georef.json` sidecar exists. */
   hasGeoref: boolean;
+  /** Whether a `raw/<stem>.roadprob.png` key-map P(road) map exists (#211). */
+  hasRoadprob: boolean;
+  /**
+   * The georef's four (lon, lat) corners of the raw sheet -- top-left,
+   * top-right, bottom-right, bottom-left -- when the georef has them. They
+   * place the key-map underlay.
+   */
+  corners?: [number, number][];
+  /** Absolute IIIF image service URL of the raw sheet (`.../raw/<stem>.jpg`), when present. */
+  imageService?: string;
+  /** Absolute IIIF image service URL of the key map's P(road) PNG, when present. */
+  roadprobService?: string;
 }
 
 /**

--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -13,6 +13,7 @@
 
 import type { Endpoint, GetEndpoint } from 'crosswalk/dist/api-spec';
 import type {
+  GeorefAnnotationPage,
   RewrittenAnnotationResponse,
   VolumeListResponse,
 } from './iiifAnnotations.ts';
@@ -92,6 +93,13 @@ export interface KeymapDetectionsResponse {
 /** Query naming a volume directory. */
 export interface VolumeQuery {
   volume: string;
+}
+
+/** Query naming the underlay image of one key map: its sheet or its P(road) map. */
+export interface KeymapAnnotationQuery {
+  volume: string;
+  stem: string;
+  image: 'sheet' | 'roadprob';
 }
 
 /** Response of GET /api/adjacency-volumes. */
@@ -245,6 +253,9 @@ export interface API {
   };
   '/iiif-api/keymaps': {
     get: GetEndpoint<KeymapsResponse, VolumeQuery>;
+  };
+  '/iiif-api/keymap-annotation': {
+    get: GetEndpoint<GeorefAnnotationPage, KeymapAnnotationQuery>;
   };
   '/api/images': {
     get: GetEndpoint<KeymapImagesResponse>;

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -6,6 +6,7 @@
  * (`/iiif-api/*`) on the shared crosswalk router.
  */
 
+import { existsSync } from 'fs';
 import { readdir, readFile, stat } from 'fs/promises';
 import { createRequire } from 'module';
 import { dirname, join } from 'path';
@@ -28,6 +29,7 @@ import {
   parseMissingTruthKeys,
 } from './compareTxt.ts';
 import { findVolumes, volumePages } from './adjacencyTruth.ts';
+import { keymapAnnotation } from './keymapAnnotation.ts';
 import { keymapInfos } from './keymapInfos.ts';
 import { runArtifactDir, runArtifactStems } from './runArtifacts.ts';
 import { withTiles } from './iiifAnnotations.ts';
@@ -426,5 +428,53 @@ export function registerIiifApi(
     return {
       keymaps: await keymapInfos(join(dataDir, volume, 'raw'), serviceBaseUrl),
     };
+  });
+
+  // One key map as a georeference annotation, for the underlay: the sheet or
+  // its P(road) map, warped by a thin-plate spline through the sheet's own
+  // GCPs -- the model keymap-snap places pages in (see keymapAnnotation).
+  router.get('/iiif-api/keymap-annotation', async (_params, request) => {
+    const { volume, stem, image } = request.query;
+    if (!isSafeVolume(volume) || !isSafeSegment(stem)) {
+      throw new HTTPError(400, `invalid key map: ${volume}/${stem}`);
+    }
+    if (image !== 'sheet' && image !== 'roadprob') {
+      throw new HTTPError(400, `invalid image: ${image}`);
+    }
+    const rawDir = join(dataDir, volume, 'raw');
+    let georef: unknown;
+    try {
+      georef = JSON.parse(
+        await readFile(join(rawDir, `${stem}.georef.json`), 'utf8'),
+      );
+    } catch {
+      throw new HTTPError(404, `no georef for key map ${volume}/${stem}`);
+    }
+    // The P(road) map is rendered in the sheet's own pixel frame, so one set
+    // of GCPs places either image.
+    const candidates =
+      image === 'roadprob'
+        ? [`${stem}.roadprob.png`]
+        : [`${stem}.jpg`, `${stem}.png`];
+    const file = candidates.find((name) => existsSync(join(rawDir, name)));
+    if (!file) {
+      throw new HTTPError(
+        404,
+        `no ${image} image for key map ${volume}/${stem}`,
+      );
+    }
+    const serviceUrl = `${request.protocol}://${request.get('host')}/iiif/${volume}/raw/${file}`;
+    const page = keymapAnnotation(
+      georef,
+      serviceUrl,
+      `keymap:${volume}/${stem}/${image}`,
+    );
+    if (!page) {
+      throw new HTTPError(
+        404,
+        `key map ${volume}/${stem} has no usable georeference`,
+      );
+    }
+    return page;
   });
 }

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -28,6 +28,7 @@ import {
   parseMissingTruthKeys,
 } from './compareTxt.ts';
 import { findVolumes, volumePages } from './adjacencyTruth.ts';
+import { keymapInfos } from './keymapInfos.ts';
 import { runArtifactDir, runArtifactStems } from './runArtifacts.ts';
 import { withTiles } from './iiifAnnotations.ts';
 import { isSafeSegment, isSafeVolume } from './volumePaths.ts';
@@ -415,29 +416,15 @@ export function registerIiifApi(
   });
 
   // A volume's key-map sheets and which visualization sidecars each has, so the viewer can link
-  // to them. Key maps are `raw/<stem>.keymap.json`; siblings <stem>.regions.panels.json and
-  // <stem>.georef.json are the region and georef views. ?volume=<dir> → { keymaps: [...] }.
+  // to them and draw the key-map underlay (see keymapInfos). ?volume=<dir> → { keymaps: [...] }.
   router.get('/iiif-api/keymaps', async (_params, request) => {
     const { volume } = request.query;
     if (!isSafeVolume(volume)) {
       throw new HTTPError(400, `invalid volume: ${volume}`);
     }
-    let files: string[];
-    try {
-      files = await readdir(join(dataDir, volume, 'raw'));
-    } catch {
-      return { keymaps: [] }; // no raw/ directory: volume has no key maps
-    }
-    const present = new Set(files);
-    const keymaps = files
-      .filter((file) => file.endsWith('.keymap.json'))
-      .map((file) => file.slice(0, -'.keymap.json'.length))
-      .sort()
-      .map((stem) => ({
-        stem,
-        hasRegions: present.has(`${stem}.regions.panels.json`),
-        hasGeoref: present.has(`${stem}.georef.json`),
-      }));
-    return { keymaps };
+    const serviceBaseUrl = `${request.protocol}://${request.get('host')}/iiif/${volume}/raw`;
+    return {
+      keymaps: await keymapInfos(join(dataDir, volume, 'raw'), serviceBaseUrl),
+    };
   });
 }

--- a/app/server/keymapAnnotation.test.ts
+++ b/app/server/keymapAnnotation.test.ts
@@ -3,6 +3,7 @@ import {
   consistentGcps,
   keymapAnnotation,
   MIN_KEYMAP_GCPS,
+  smoothedTargets,
   type KeymapGcp,
 } from './keymapAnnotation.ts';
 
@@ -79,6 +80,34 @@ describe('keymapAnnotation', () => {
       (item.target as unknown as { selector: { value: string } }).selector
         .value,
     ).toContain('points="0,0 6397,0 6397,7795 0,7795"');
+  });
+
+  it('hands allmaps the smoothed model targets, not the raw OSM points', () => {
+    // Noisy GCPs: the smoothed spline does not pass through them, so the
+    // annotation's targets differ from the inputs; an exact spline through
+    // the targets is then the pipeline's smoothed surface.
+    const noisy = inliers(40).map((gcp, i) => ({
+      ...gcp,
+      lat: gcp.lat + (i % 3 === 0 ? 0.0004 : 0),
+    }));
+    const page = keymapAnnotation(
+      { width: 6397, height: 7795, intersections: noisy },
+      SERVICE,
+      'id',
+    );
+    const body = page!.items[0].body as unknown as {
+      features: { geometry: { coordinates: number[] } }[];
+    };
+    const moved = body.features.filter(
+      (f, i) => Math.abs(f.geometry.coordinates[1] - noisy[i].lat) > 1e-6,
+    );
+    expect(moved.length).toBeGreaterThan(30);
+    // An affine field is left exactly alone, at any smoothing.
+    const clean = smoothedTargets(inliers(40));
+    clean.forEach(([lon, lat], i) => {
+      expect(lon).toBeCloseTo(inliers(40)[i].lon, 7);
+      expect(lat).toBeCloseTo(inliers(40)[i].lat, 7);
+    });
   });
 
   it('falls back to the affine corners when the sheet has too few GCPs', () => {

--- a/app/server/keymapAnnotation.test.ts
+++ b/app/server/keymapAnnotation.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  consistentGcps,
+  keymapAnnotation,
+  MIN_KEYMAP_GCPS,
+  type KeymapGcp,
+} from './keymapAnnotation.ts';
+
+const SERVICE = 'http://localhost:8182/iiif/new_orleans/raw/p0.jpg';
+const corners = [
+  [-90.1158, 29.9432],
+  [-90.0872, 29.9745],
+  [-90.0431, 29.9458],
+  [-90.0717, 29.9145],
+];
+
+// `count` inliers spread along a diagonal, far enough apart to stay distinct.
+function inliers(count: number): KeymapGcp[] {
+  return Array.from({ length: count }, (unused, i) => ({
+    x: 100 + i * 37,
+    y: 200 + i * 41,
+    lon: -90.1 + i * 0.001,
+    lat: 29.94 + i * 0.001,
+    inlier: true,
+  }));
+}
+
+function georefWith(count: number) {
+  return {
+    width: 6397,
+    height: 7795,
+    corners,
+    intersections: inliers(count),
+  };
+}
+
+describe('consistentGcps', () => {
+  it('keeps a pixel read once', () => {
+    expect(consistentGcps(inliers(3))).toHaveLength(3);
+  });
+
+  it('drops a whole group whose readings disagree beyond the conflict bar', () => {
+    const conflicting: KeymapGcp[] = [
+      { x: 10, y: 20, lon: -90.1, lat: 29.94 },
+      { x: 10, y: 20, lon: -90.09, lat: 29.94 }, // ~2900 ft away
+      { x: 30, y: 40, lon: -90.05, lat: 29.95 },
+    ];
+    expect(consistentGcps(conflicting).map((gcp) => gcp.x)).toEqual([30]);
+  });
+
+  it('keeps one reading of a group that agrees within the bar', () => {
+    const agreeing: KeymapGcp[] = [
+      { x: 10, y: 20, lon: -90.1, lat: 29.94 },
+      { x: 10, y: 20, lon: -90.10002, lat: 29.94001 }, // a few feet
+    ];
+    expect(consistentGcps(agreeing)).toHaveLength(1);
+  });
+});
+
+describe('keymapAnnotation', () => {
+  it('warps by thin-plate spline through the sheet own GCPs', () => {
+    const page = keymapAnnotation(georefWith(60), SERVICE, 'keymap-p0');
+    const item = page!.items[0];
+    const body = item.body as unknown as {
+      transformation: { type: string };
+      features: { properties: { resourceCoords: number[] } }[];
+    };
+    expect(body.transformation).toEqual({ type: 'thinPlateSpline' });
+    expect(body.features).toHaveLength(60);
+    expect(body.features[0].properties.resourceCoords).toEqual([100, 200]);
+    expect(item.target!.source).toEqual({
+      id: SERVICE,
+      type: 'ImageService3',
+      width: 6397,
+      height: 7795,
+    });
+    // The whole sheet is the mask: the key map is drawn margins and all.
+    expect(
+      (item.target as unknown as { selector: { value: string } }).selector
+        .value,
+    ).toContain('points="0,0 6397,0 6397,7795 0,7795"');
+  });
+
+  it('falls back to the affine corners when the sheet has too few GCPs', () => {
+    const page = keymapAnnotation(
+      georefWith(MIN_KEYMAP_GCPS - 1),
+      SERVICE,
+      'keymap-p0',
+    );
+    const body = page!.items[0].body as unknown as {
+      transformation: { type: string; options: { order: number } };
+      features: {
+        properties: { resourceCoords: number[] };
+        geometry: { coordinates: number[] };
+      }[];
+    };
+    expect(body.transformation).toEqual({
+      type: 'polynomial',
+      options: { order: 1 },
+    });
+    // Pixel corners in the georef's own order: TL, TR, BR, BL.
+    expect(body.features.map((f) => f.properties.resourceCoords)).toEqual([
+      [0, 0],
+      [6397, 0],
+      [6397, 7795],
+      [0, 7795],
+    ]);
+    expect(body.features[1].geometry.coordinates).toEqual(corners[1]);
+  });
+
+  it('is null without dimensions, or with too few GCPs and no corners', () => {
+    expect(keymapAnnotation({}, SERVICE, 'id')).toBeNull();
+    expect(
+      keymapAnnotation(
+        { width: 10, height: 10, intersections: [] },
+        SERVICE,
+        'id',
+      ),
+    ).toBeNull();
+  });
+});

--- a/app/server/keymapAnnotation.ts
+++ b/app/server/keymapAnnotation.ts
@@ -1,0 +1,180 @@
+/**
+ * A georeference annotation for a key map, warped the way keymap-snap warps it.
+ *
+ * The key map's shipped georef is a global affine, and its residuals against
+ * the sheet's own inlier intersections are large: 127 ft median on New Orleans
+ * 1896, 90 ft on Detroit. `mapsnap.keymap.snap.keymap_model` therefore models
+ * the sheet as a thin-plate spline through those same intersections, and that
+ * model -- not the affine -- is the frame every keymap-snap placement is
+ * measured in (#211). Drawing the sheet at its four affine corners would show
+ * the viewer something the pipeline does not use.
+ *
+ * So the underlay is served as a georeference annotation carrying the sheet's
+ * own GCPs with `transformation: thinPlateSpline`, which allmaps renders
+ * directly. The one difference from the pipeline is smoothing: allmaps
+ * interpolates the GCPs exactly while `keymap_model` smooths them
+ * (TPS_SMOOTHING). On the corpus that moves the median by ~2 ft.
+ */
+import type { GeorefAnnotationPage } from './iiifAnnotations.ts';
+
+/** One inlier intersection of a key-map georef: sheet pixel and its world point. */
+export interface KeymapGcp {
+  x: number;
+  y: number;
+  lon: number;
+  lat: number;
+  inlier?: boolean;
+}
+
+const M_PER_DEG_LAT = 110_540.0;
+const M_PER_DEG_LON_EQUATOR = 111_320.0;
+const FEET_PER_METRE = 3.28084;
+
+/**
+ * Two readings of one pixel further apart than this are a contradiction.
+ * Mirrors `mapsnap.keymap.snap.GCP_CONFLICT_FT`.
+ */
+export const GCP_CONFLICT_FT = 50.0;
+
+/**
+ * Fewest consistent GCPs that can constrain a warp; below it the sheet is
+ * drawn by its affine corners. Mirrors `road_prob.MIN_KEYMAP_INLIERS`.
+ */
+export const MIN_KEYMAP_GCPS = 25;
+
+/**
+ * Drop GCPs that put one key-map pixel in two different places.
+ *
+ * A port of `mapsnap.keymap.snap.consistent_gcps`: a pixel matched to two OSM
+ * intersections more than GCP_CONFLICT_FT apart is a contradiction the spline
+ * cannot resolve, and there is no evidence here for which reading is right, so
+ * the whole group goes.
+ */
+export function consistentGcps(inliers: KeymapGcp[]): KeymapGcp[] {
+  const groups = new Map<string, KeymapGcp[]>();
+  for (const gcp of inliers) {
+    const key = `${gcp.x.toFixed(1)},${gcp.y.toFixed(1)}`;
+    const group = groups.get(key);
+    if (group) group.push(gcp);
+    else groups.set(key, [gcp]);
+  }
+  const kept: KeymapGcp[] = [];
+  for (const readings of groups.values()) {
+    if (readings.length === 1) {
+      kept.push(readings[0]);
+      continue;
+    }
+    const lons = readings.map((r) => r.lon);
+    const lats = readings.map((r) => r.lat);
+    const lonScale =
+      M_PER_DEG_LON_EQUATOR * Math.cos((lats[0] * Math.PI) / 180);
+    const spread =
+      Math.hypot(
+        (Math.max(...lons) - Math.min(...lons)) * lonScale,
+        (Math.max(...lats) - Math.min(...lats)) * M_PER_DEG_LAT,
+      ) * FEET_PER_METRE;
+    if (spread <= GCP_CONFLICT_FT) kept.push(readings[0]);
+  }
+  return kept;
+}
+
+/** A georef document's four (lon, lat) corners, when it has them. */
+function corners(georef: unknown): [number, number][] | undefined {
+  const value = (georef as { corners?: unknown })?.corners;
+  if (!Array.isArray(value) || value.length !== 4) return undefined;
+  const points = value.map((corner) =>
+    Array.isArray(corner) &&
+    typeof corner[0] === 'number' &&
+    typeof corner[1] === 'number'
+      ? ([corner[0], corner[1]] as [number, number])
+      : null,
+  );
+  return points.every((point) => point !== null)
+    ? (points as [number, number][])
+    : undefined;
+}
+
+function feature(pixel: [number, number], world: [number, number]) {
+  return {
+    type: 'Feature' as const,
+    properties: { resourceCoords: pixel },
+    geometry: { type: 'Point' as const, coordinates: world },
+  };
+}
+
+/**
+ * A one-item georeference AnnotationPage placing a key-map image on the world.
+ *
+ * `serviceUrl` is the IIIF image service for the image to draw (the sheet or
+ * its P(road) map, which share the sheet's pixel frame, so the same GCPs place
+ * either). Uses a thin-plate spline through the sheet's consistent inlier
+ * intersections when there are enough of them, and the affine corners
+ * otherwise; the returned `transformation` says which.
+ */
+export function keymapAnnotation(
+  georef: unknown,
+  serviceUrl: string,
+  annotationId: string,
+): GeorefAnnotationPage | null {
+  const document = georef as {
+    width?: number;
+    height?: number;
+    intersections?: KeymapGcp[];
+  };
+  const width = document?.width;
+  const height = document?.height;
+  if (!width || !height) return null;
+
+  const gcps = consistentGcps(
+    (document.intersections ?? []).filter((point) => point.inlier),
+  );
+  let transformation: { type: string; options?: { order: number } };
+  let features: ReturnType<typeof feature>[];
+  if (gcps.length >= MIN_KEYMAP_GCPS) {
+    transformation = { type: 'thinPlateSpline' };
+    features = gcps.map((gcp) => feature([gcp.x, gcp.y], [gcp.lon, gcp.lat]));
+  } else {
+    const ring = corners(georef);
+    if (!ring) return null;
+    transformation = { type: 'polynomial', options: { order: 1 } };
+    const pixels: [number, number][] = [
+      [0, 0],
+      [width, 0],
+      [width, height],
+      [0, height],
+    ];
+    features = pixels.map((pixel, index) => feature(pixel, ring[index]));
+  }
+
+  return {
+    '@context': 'http://iiif.io/api/extension/georeference/1/context.json',
+    type: 'AnnotationPage',
+    items: [
+      {
+        id: annotationId,
+        type: 'Annotation',
+        motivation: 'georeferencing',
+        target: {
+          type: 'SpecificResource',
+          source: {
+            id: serviceUrl,
+            type: 'ImageService3',
+            width,
+            height,
+          },
+          // Required by the georeference-annotation schema, and the mask
+          // allmaps clips the image to: the whole sheet, margins included.
+          selector: {
+            type: 'SvgSelector',
+            value: `<svg width="${width}" height="${height}"><polygon points="0,0 ${width},0 ${width},${height} 0,${height}" /></svg>`,
+          },
+        },
+        body: {
+          type: 'FeatureCollection',
+          transformation,
+          features,
+        },
+      },
+    ],
+  } as unknown as GeorefAnnotationPage;
+}

--- a/app/server/keymapAnnotation.ts
+++ b/app/server/keymapAnnotation.ts
@@ -11,11 +11,19 @@
  *
  * So the underlay is served as a georeference annotation carrying the sheet's
  * own GCPs with `transformation: thinPlateSpline`, which allmaps renders
- * directly. The one difference from the pipeline is smoothing: allmaps
- * interpolates the GCPs exactly while `keymap_model` smooths them
- * (TPS_SMOOTHING). On the corpus that moves the median by ~2 ft.
+ * directly. allmaps interpolates exactly, while `keymap_model` smooths
+ * (TPS_SMOOTHING), and that smoothing is what keeps straight streets straight
+ * between GCPs (see thinPlateSpline.ts). So the annotation's targets are not
+ * the raw OSM points but the smoothed spline's prediction at each GCP pixel:
+ * the exact spline allmaps fits through those reproduces the pipeline's
+ * surface (measured 0.0 ft apart on New Orleans 1896).
  */
 import type { GeorefAnnotationPage } from './iiifAnnotations.ts';
+import {
+  thinPlateSpline,
+  TPS_SMOOTHING,
+  type Point2,
+} from './thinPlateSpline.ts';
 
 /** One inlier intersection of a key-map georef: sheet pixel and its world point. */
 export interface KeymapGcp {
@@ -94,6 +102,33 @@ function corners(georef: unknown): [number, number][] | undefined {
     : undefined;
 }
 
+/**
+ * The smoothed key-map model's world point at each GCP pixel, in the frame
+ * `keymap_model` uses: metres from the first GCP, with the longitude scale at
+ * the GCPs' mean latitude.
+ */
+export function smoothedTargets(
+  gcps: KeymapGcp[],
+  smoothing: number = TPS_SMOOTHING,
+): [number, number][] {
+  const origin = [gcps[0].lon, gcps[0].lat];
+  const meanLat = gcps.reduce((sum, gcp) => sum + gcp.lat, 0) / gcps.length;
+  const lonScale = M_PER_DEG_LON_EQUATOR * Math.cos((meanLat * Math.PI) / 180);
+  const pixels: Point2[] = gcps.map((gcp) => [gcp.x, gcp.y]);
+  const metres: Point2[] = gcps.map((gcp) => [
+    (gcp.lon - origin[0]) * lonScale,
+    (gcp.lat - origin[1]) * M_PER_DEG_LAT,
+  ]);
+  return thinPlateSpline(
+    pixels,
+    metres,
+    smoothing,
+  )(pixels).map(([x, y]) => [
+    x / lonScale + origin[0],
+    y / M_PER_DEG_LAT + origin[1],
+  ]);
+}
+
 function feature(pixel: [number, number], world: [number, number]) {
   return {
     type: 'Feature' as const,
@@ -132,7 +167,8 @@ export function keymapAnnotation(
   let features: ReturnType<typeof feature>[];
   if (gcps.length >= MIN_KEYMAP_GCPS) {
     transformation = { type: 'thinPlateSpline' };
-    features = gcps.map((gcp) => feature([gcp.x, gcp.y], [gcp.lon, gcp.lat]));
+    const targets = smoothedTargets(gcps);
+    features = gcps.map((gcp, i) => feature([gcp.x, gcp.y], targets[i]));
   } else {
     const ring = corners(georef);
     if (!ring) return null;

--- a/app/server/keymapInfos.test.ts
+++ b/app/server/keymapInfos.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, mkdtemp, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { georefCorners, keymapInfos } from './keymapInfos.ts';
+
+const corners = [
+  [-90.1158, 29.9432],
+  [-90.0872, 29.9745],
+  [-90.0431, 29.9458],
+  [-90.0717, 29.9145],
+];
+
+let rawDir: string;
+const SERVICE = 'http://localhost:8182/iiif/new_orleans/raw';
+
+// A raw/ directory shaped like New Orleans 1896's: one key map with every
+// sidecar, a second (Los Angeles-style pb) with a georef but no P(road) map,
+// and a third with a georef whose corners are malformed.
+beforeAll(async () => {
+  rawDir = await mkdtemp(join(tmpdir(), 'keymap-infos-'));
+  const write = (name: string, contents = '{}') =>
+    writeFile(join(rawDir, name), contents);
+  await write('p0.jpg', 'jpeg');
+  await write('p0.keymap.json');
+  await write('p0.regions.panels.json');
+  await write('p0.georef.json', JSON.stringify({ corners, width: 6397 }));
+  await write('p0.roadprob.png', 'png');
+  await write('pb.png', 'png');
+  await write('pb.keymap.json');
+  await write('pb.georef.json', JSON.stringify({ corners }));
+  await write('pz.keymap.json');
+  await write(
+    'pz.georef.json',
+    JSON.stringify({ corners: corners.slice(0, 3) }),
+  );
+  await write('p7.georef.json', JSON.stringify({ corners })); // not a key map
+  await mkdir(join(rawDir, 'truth'));
+});
+
+describe('keymapInfos', () => {
+  it('lists key maps with their sidecars and georef corners', async () => {
+    const infos = await keymapInfos(rawDir, SERVICE);
+    expect(infos.map((info) => info.stem)).toEqual(['p0', 'pb', 'pz']);
+    expect(infos[0]).toEqual({
+      stem: 'p0',
+      hasRegions: true,
+      hasGeoref: true,
+      hasRoadprob: true,
+      corners,
+      imageService: `${SERVICE}/p0.jpg`,
+      roadprobService: `${SERVICE}/p0.roadprob.png`,
+    });
+    // A PNG key map (Queens) is addressed as one; no P(road) map, no service.
+    expect(infos[1]).toEqual({
+      stem: 'pb',
+      hasRegions: false,
+      hasGeoref: true,
+      hasRoadprob: false,
+      corners,
+      imageService: `${SERVICE}/pb.png`,
+    });
+  });
+
+  it('omits corners from a georef that lacks four points', async () => {
+    const infos = await keymapInfos(rawDir, SERVICE);
+    expect(infos[2].hasGeoref).toBe(true);
+    expect(infos[2].corners).toBeUndefined();
+  });
+
+  it('is empty for a volume without a raw directory', async () => {
+    expect(await keymapInfos(join(rawDir, 'missing'), SERVICE)).toEqual([]);
+  });
+});
+
+describe('georefCorners', () => {
+  it('accepts four finite lon/lat pairs and nothing else', () => {
+    expect(georefCorners({ corners })).toEqual(corners);
+    expect(
+      georefCorners({
+        corners: [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+        ],
+      }),
+    ).toBeUndefined();
+    expect(
+      georefCorners({ corners: [[1, 2], [3, 4], [5, 6], [7]] }),
+    ).toBeUndefined();
+    expect(
+      georefCorners({
+        corners: [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+          ['7', 8],
+        ],
+      }),
+    ).toBeUndefined();
+    expect(georefCorners({})).toBeUndefined();
+    expect(georefCorners(null)).toBeUndefined();
+  });
+});

--- a/app/server/keymapInfos.ts
+++ b/app/server/keymapInfos.ts
@@ -1,0 +1,88 @@
+/**
+ * A volume's key-map sheets and the sidecars the viewer can use for each.
+ *
+ * Key maps are `raw/<stem>.keymap.json`. Siblings: `<stem>.regions.panels.json`
+ * (region view), `<stem>.georef.json` (the key map's own georeference, whose
+ * `corners` place the sheet on the map) and `<stem>.roadprob.png` (the key
+ * map's P(road) map, #211). The corners are what the key-map underlay draws
+ * the sheet, or its P(road) map, with.
+ */
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+import type { KeymapInfo } from './api.ts';
+
+/** The four (lon, lat) corners of a georef document, or undefined if malformed. */
+export function georefCorners(doc: unknown): [number, number][] | undefined {
+  const corners = (doc as { corners?: unknown })?.corners;
+  if (!Array.isArray(corners) || corners.length !== 4) return undefined;
+  const points: [number, number][] = [];
+  for (const corner of corners) {
+    if (
+      !Array.isArray(corner) ||
+      corner.length < 2 ||
+      typeof corner[0] !== 'number' ||
+      typeof corner[1] !== 'number' ||
+      !Number.isFinite(corner[0]) ||
+      !Number.isFinite(corner[1])
+    ) {
+      return undefined;
+    }
+    points.push([corner[0], corner[1]]);
+  }
+  return points;
+}
+
+/**
+ * Key-map sheets under `rawDir`, sorted by stem, with their sidecars.
+ *
+ * `serviceBaseUrl` is the IIIF image service root for the raw directory
+ * (`.../iiif/<volume>/raw`); each key map's sheet and P(road) map are
+ * addressed under it as absolute URLs, the way the annotation rewrite
+ * addresses page tiles, so the viewer reaches the API server directly in
+ * development too (the Vite proxy does not forward `/iiif`).
+ *
+ * Empty when there is no raw/ directory: the volume has no key maps.
+ */
+export async function keymapInfos(
+  rawDir: string,
+  serviceBaseUrl: string,
+): Promise<KeymapInfo[]> {
+  let files: string[];
+  try {
+    files = await readdir(rawDir);
+  } catch {
+    return [];
+  }
+  const present = new Set(files);
+  const infos: KeymapInfo[] = [];
+  for (const file of files.filter((f) => f.endsWith('.keymap.json')).sort()) {
+    const stem = file.slice(0, -'.keymap.json'.length);
+    const hasGeoref = present.has(`${stem}.georef.json`);
+    let corners: [number, number][] | undefined;
+    if (hasGeoref) {
+      try {
+        corners = georefCorners(
+          JSON.parse(
+            await readFile(join(rawDir, `${stem}.georef.json`), 'utf8'),
+          ),
+        );
+      } catch {
+        corners = undefined;
+      }
+    }
+    const image = ['jpg', 'png'].find((ext) => present.has(`${stem}.${ext}`));
+    const hasRoadprob = present.has(`${stem}.roadprob.png`);
+    infos.push({
+      stem,
+      hasRegions: present.has(`${stem}.regions.panels.json`),
+      hasGeoref,
+      hasRoadprob,
+      ...(corners ? { corners } : {}),
+      ...(image ? { imageService: `${serviceBaseUrl}/${stem}.${image}` } : {}),
+      ...(hasRoadprob
+        ? { roadprobService: `${serviceBaseUrl}/${stem}.roadprob.png` }
+        : {}),
+    });
+  }
+  return infos;
+}

--- a/app/server/thinPlateSpline.test.ts
+++ b/app/server/thinPlateSpline.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  solveLinear,
+  thinPlateSpline,
+  type Point2,
+} from './thinPlateSpline.ts';
+
+// Eight noisy GCPs and three query points, with the Python
+// mapsnap.keymap.snap.thin_plate_spline evaluated on them (rng seed 7).
+const SRC: Point2[] = [
+  [3125.5, 4486.1],
+  [3878.4, 1126.0],
+  [1500.8, 4367.8],
+  [26.3, 4106.1],
+  [3985.3, 2339.7],
+  [1515.2, 1392.1],
+  [1274.3, 2225.4],
+  [2522.7, 2767.5],
+];
+const DST: Point2[] = [
+  [1927.75, -2921.73],
+  [2555.77, -649.13],
+  [765.34, -2909.17],
+  [-221.88, -2774.56],
+  [2705.53, -1402.95],
+  [853.95, -903.19],
+  [800.08, -1442.76],
+  [1563.38, -1784.43],
+];
+const Q: Point2[] = [
+  [1200.0, 2500.0],
+  [4000.0, 800.0],
+  [2600.0, 4100.0],
+];
+
+function close(actual: Point2[], expected: number[][], digits: number) {
+  actual.forEach((point, i) => {
+    expect(point[0]).toBeCloseTo(expected[i][0], digits);
+    expect(point[1]).toBeCloseTo(expected[i][1], digits);
+  });
+}
+
+// The spline system is badly scaled (kernel entries ~1e8 against a [1, x, y]
+// block), so numpy reports it as numerically singular (cond ~1e17). The
+// pipeline solves it with lstsq, which truncates the near-null direction;
+// this port solves it exactly, matching numpy.linalg.solve to every digit.
+// The two agree at the source points and differ elsewhere by up to ~2.3
+// units on this eight-point toy (numpy's own solve-vs-lstsq gap); on New
+// Orleans 1896's 485 GCPs the route's targets sit 0.65 ft median / 19 ft max
+// from the pipeline's model, against a ~50 ft model error.
+const LSTSQ_TOLERANCE = 3.0;
+function near(actual: Point2[], expected: number[][]) {
+  actual.forEach((point, i) => {
+    expect(Math.abs(point[0] - expected[i][0])).toBeLessThan(LSTSQ_TOLERANCE);
+    expect(Math.abs(point[1] - expected[i][1])).toBeLessThan(LSTSQ_TOLERANCE);
+  });
+}
+
+describe('thinPlateSpline', () => {
+  it('matches numpy.linalg.solve when barely smoothed, and interpolates', () => {
+    const spline = thinPlateSpline(SRC, DST, 1e-9);
+    close(
+      spline(Q),
+      [
+        [746.79303, -1629.39961],
+        [2632.83709, -435.08416],
+        [1559.90509, -2684.59378],
+      ],
+      2,
+    );
+    // The pipeline's lstsq answer is within the truncation tolerance.
+    near(spline(Q), [
+      [747.1522, -1629.1677],
+      [2630.566, -436.5506],
+      [1561.2887, -2683.7004],
+    ]);
+    // Interpolates its own points.
+    close(spline(SRC), DST, 3);
+  });
+
+  it('matches numpy.linalg.solve at the pipeline smoothing', () => {
+    const spline = thinPlateSpline(SRC, DST, 1e6);
+    close(
+      spline(Q),
+      [
+        [703.86394, -1638.28134],
+        [2647.63965, -425.65723],
+        [1569.485, -2680.94141],
+      ],
+      2,
+    );
+    near(spline(Q), [
+      [704.6595, -1637.6081],
+      [2645.4303, -427.5268],
+      [1570.5464, -2680.0432],
+    ]);
+    // Smoothing trades interpolation for a flatter surface: the GCPs no
+    // longer pass through exactly.
+    const [x] = spline([SRC[0]])[0];
+    expect(Math.abs(x - DST[0][0])).toBeGreaterThan(1);
+  });
+
+  it('reproduces an affine at any smoothing (it is in the bending null space)', () => {
+    const affine = (p: Point2): Point2 => [
+      3 + 0.7 * p[0] - 0.1 * p[1],
+      -8 - 0.05 * p[0] - 0.6 * p[1],
+    ];
+    for (const smoothing of [0, 1e6]) {
+      const spline = thinPlateSpline(SRC, SRC.map(affine), smoothing);
+      close(spline(Q), Q.map(affine), 4);
+    }
+  });
+});
+
+describe('solveLinear', () => {
+  it('solves a small system with pivoting', () => {
+    const x = solveLinear(
+      [
+        [0, 2, 1],
+        [1, 1, 1],
+        [2, 0, 3],
+      ],
+      [[5], [6], [13]],
+    );
+    // x = [2, 1, 3]
+    expect(x.map((row) => row[0])).toEqual(
+      [2, 1, 3].map((v) => expect.closeTo(v, 9)),
+    );
+  });
+});

--- a/app/server/thinPlateSpline.ts
+++ b/app/server/thinPlateSpline.ts
@@ -1,0 +1,109 @@
+/**
+ * Smoothed thin-plate spline, a port of `mapsnap.keymap.snap.thin_plate_spline`.
+ *
+ * The key-map model keymap-snap places pages in is a spline through the
+ * sheet's inlier intersections with a large smoothing term (TPS_SMOOTHING),
+ * which is what keeps straight streets straight between GCPs: on New Orleans
+ * 1896 the exactly-interpolating spline bends a street's midpoint 9 ft off its
+ * chord (median; 53 ft at p90) while the smoothed one bends it 1.3 ft (6.7 at
+ * p90) at the same held-out accuracy. allmaps only interpolates exactly, so to
+ * draw the pipeline's surface the debugger evaluates this spline at the GCP
+ * pixels and hands allmaps the smoothed targets; the exact spline through
+ * those reproduces the smoothed surface (measured: 0.0 ft apart).
+ *
+ * Same kernel, system and smoothing as the Python: U(r²) = ½ r² ln r², the
+ * smoothing added to the kernel's diagonal, an affine part [1, x, y].
+ */
+
+export type Point2 = [number, number];
+
+/** Mirrors `mapsnap.keymap.snap.TPS_SMOOTHING`. */
+export const TPS_SMOOTHING = 1e6;
+
+// ½ r² ln r² for r² > 0, and 0 at r = 0 (the kernel's removable singularity).
+function kernel(squared: number): number {
+  return squared > 0 ? squared * 0.5 * Math.log(squared) : 0;
+}
+
+/**
+ * Solve A x = B for a square A by Gaussian elimination with partial pivoting.
+ * B may have several columns; both are overwritten. Sized for a few hundred
+ * GCPs (a 500x500 system is a few milliseconds).
+ */
+export function solveLinear(a: number[][], b: number[][]): number[][] {
+  const n = a.length;
+  const width = b[0]?.length ?? 0;
+  for (let col = 0; col < n; col++) {
+    let pivot = col;
+    for (let row = col + 1; row < n; row++) {
+      if (Math.abs(a[row][col]) > Math.abs(a[pivot][col])) pivot = row;
+    }
+    if (a[pivot][col] === 0) throw new Error('singular spline system');
+    if (pivot !== col) {
+      [a[col], a[pivot]] = [a[pivot], a[col]];
+      [b[col], b[pivot]] = [b[pivot], b[col]];
+    }
+    for (let row = col + 1; row < n; row++) {
+      const factor = a[row][col] / a[col][col];
+      if (factor === 0) continue;
+      for (let k = col; k < n; k++) a[row][k] -= factor * a[col][k];
+      for (let k = 0; k < width; k++) b[row][k] -= factor * b[col][k];
+    }
+  }
+  const x: number[][] = Array.from({ length: n }, () => Array(width).fill(0));
+  for (let row = n - 1; row >= 0; row--) {
+    for (let k = 0; k < width; k++) {
+      let sum = b[row][k];
+      for (let col = row + 1; col < n; col++) sum -= a[row][col] * x[col][k];
+      x[row][k] = sum / a[row][row];
+    }
+  }
+  return x;
+}
+
+/**
+ * The smoothed spline mapping `source` points onto `destination`, as a
+ * function of query points. With smoothing 0 it interpolates exactly.
+ */
+export function thinPlateSpline(
+  source: Point2[],
+  destination: Point2[],
+  smoothing: number = TPS_SMOOTHING,
+): (queries: Point2[]) => Point2[] {
+  const count = source.length;
+  const size = count + 3;
+  const system: number[][] = Array.from({ length: size }, () =>
+    Array(size).fill(0),
+  );
+  for (let i = 0; i < count; i++) {
+    for (let j = 0; j < count; j++) {
+      const dx = source[i][0] - source[j][0];
+      const dy = source[i][1] - source[j][1];
+      system[i][j] = kernel(dx * dx + dy * dy) + (i === j ? smoothing : 0);
+    }
+    const poly = [1, source[i][0], source[i][1]];
+    for (let k = 0; k < 3; k++) {
+      system[i][count + k] = poly[k];
+      system[count + k][i] = poly[k];
+    }
+  }
+  const rhs: number[][] = Array.from({ length: size }, (unused, i) =>
+    i < count ? [destination[i][0], destination[i][1]] : [0, 0],
+  );
+  const solution = solveLinear(system, rhs);
+  const weights = solution.slice(0, count);
+  const affine = solution.slice(count);
+  return (queries) =>
+    queries.map(([x, y]) => {
+      let outX = affine[0][0] + affine[1][0] * x + affine[2][0] * y;
+      let outY = affine[0][1] + affine[1][1] * x + affine[2][1] * y;
+      for (let i = 0; i < count; i++) {
+        const dx = x - source[i][0];
+        const dy = y - source[i][1];
+        const value = kernel(dx * dx + dy * dy);
+        outX += value * weights[i][0];
+        outY += value * weights[i][1];
+      }
+      return [outX, outY];
+    });
+}

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -48,6 +48,8 @@ interface VolumeMapProps {
    * beneath the pages, as the sheet or as its P(road) map. Empty removes them.
    */
   keymapUnderlays: KeymapUnderlay[];
+  /** Key-map underlay opacity in [0, 1], independent of the pages'. */
+  keymapOpacity: number;
   /**
    * Show only the selected page's warped image, hiding every other sheet.
    * No-op while nothing is selected -- isolating "nothing" would blank the map.
@@ -146,6 +148,7 @@ export function VolumeMap(props: VolumeMapProps) {
     showMissing,
     snapOverlay,
     keymapUnderlays,
+    keymapOpacity,
     isolateSelected,
     selectedItemIndex,
     onSelectPage,
@@ -157,6 +160,9 @@ export function VolumeMap(props: VolumeMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const layerRef = useRef<WarpedMapLayer | null>(null);
+  const keymapLayerRef = useRef<WarpedMapLayer | null>(null);
+  // Read inside the underlay effect without making it depend on the value.
+  const keymapOpacityRef = useRef(0);
 
   // Panel polygons per parent stem, from the volume's pN.panels.json (25%-jpg
   // frame). null = fetched and absent. The SvgSelector is split INTERSECT
@@ -267,6 +273,13 @@ export function VolumeMap(props: VolumeMapProps) {
       'top-left',
     );
     map.on('load', () => {
+      // Added first, so it sits beneath the pages layer: the key map is the
+      // ground the pages are read against, never over them.
+      const keymapLayer = new WarpedMapLayer({
+        layerId: 'keymap-underlay-layer',
+      });
+      map.addLayer(keymapLayer);
+      keymapLayerRef.current = keymapLayer;
       const layer = new WarpedMapLayer();
       map.addLayer(layer);
       map.addSource('rmse-fills', {
@@ -486,57 +499,55 @@ export function VolumeMap(props: VolumeMapProps) {
       map.remove();
       mapRef.current = null;
       layerRef.current = null;
+      keymapLayerRef.current = null;
       setMapReady(false);
     };
   }, []);
 
-  // The key-map underlay (#211): each georeferenced key map as an image
-  // source at its corner coordinates, inserted BENEATH the pages layer so the
-  // pages (dimmed with the opacity slider) can be read against it. Reconciled
-  // against the previous set: a mode switch swaps the image in place.
-  const underlayIdsRef = useRef<Set<string>>(new Set());
+  // The key-map underlay (#211): each key map as its own georeference
+  // annotation on a second WarpedMapLayer, so allmaps applies the thin-plate
+  // spline through the sheet's GCPs -- the model keymap-snap places pages in.
+  // The layer sits BENEATH the pages layer, so the pages (dimmed with their
+  // own opacity slider) can be read against it.
   useEffect(() => {
-    const map = mapRef.current;
-    const pagesLayer = layerRef.current;
-    if (!map || !pagesLayer || !mapReady) return;
-    const wanted = new Map(
-      keymapUnderlays.map((underlay) => [
-        `keymap-underlay-${underlay.id}`,
-        underlay,
-      ]),
-    );
-    for (const id of [...underlayIdsRef.current]) {
-      if (wanted.has(id)) continue;
-      if (map.getLayer(id)) map.removeLayer(id);
-      if (map.getSource(id)) map.removeSource(id);
-      underlayIdsRef.current.delete(id);
-    }
-    for (const [id, underlay] of wanted) {
-      const existing = map.getSource(id) as maplibregl.ImageSource | undefined;
-      if (existing) {
-        existing.updateImage({
-          url: underlay.url,
-          coordinates: underlay.corners,
+    const layer = keymapLayerRef.current;
+    if (!layer || !mapReady) return;
+    layer.clear();
+    let cancelled = false;
+    for (const underlay of keymapUnderlays) {
+      layer
+        .addGeoreferenceAnnotationByUrl(underlay.annotationUrl)
+        .then((results) => {
+          if (cancelled) return;
+          for (const result of results) {
+            if (result instanceof Error) {
+              console.error(`key-map underlay ${underlay.id}`, result);
+            }
+          }
+          // A newly added map starts at full opacity, so reapply the current
+          // value rather than waiting for the next slider move.
+          layer.setLayerOptions(
+            { opacity: keymapOpacityRef.current },
+            { animate: false },
+          );
+        })
+        .catch((error: unknown) => {
+          if (!cancelled)
+            console.error(`key-map underlay ${underlay.id}`, error);
         });
-        continue;
-      }
-      map.addSource(id, {
-        type: 'image',
-        url: underlay.url,
-        coordinates: underlay.corners,
-      });
-      map.addLayer(
-        {
-          id,
-          type: 'raster',
-          source: id,
-          paint: { 'raster-opacity': 1, 'raster-fade-duration': 0 },
-        },
-        pagesLayer.id,
-      );
-      underlayIdsRef.current.add(id);
     }
+    return () => {
+      cancelled = true;
+    };
   }, [mapReady, keymapUnderlays]);
+
+  // Key-map opacity, independent of the pages'.
+  useEffect(() => {
+    keymapOpacityRef.current = keymapOpacity;
+    const layer = keymapLayerRef.current;
+    if (!layer || !mapReady) return;
+    layer.setLayerOptions({ opacity: keymapOpacity }, { animate: false });
+  }, [keymapOpacity, mapReady]);
 
   // The snap-debugger pose overlay (#325): the selected candidate's P(road)
   // map as an image source at the pose's corner coordinates. Added/updated/

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { WarpedMapLayer } from '@allmaps/maplibre';
+import type { KeymapUnderlay } from '../iiif/underlay';
 import type { FeatureCollection } from 'geojson';
 import { pointInPolygon } from '../geometry';
 import { hasFootprint, type PageGeo } from '../iiif/pages';
@@ -42,6 +43,11 @@ interface VolumeMapProps {
       [number, number],
     ];
   } | null;
+  /**
+   * The key-map underlay (#211): the volume's georeferenced key map(s) drawn
+   * beneath the pages, as the sheet or as its P(road) map. Empty removes them.
+   */
+  keymapUnderlays: KeymapUnderlay[];
   /**
    * Show only the selected page's warped image, hiding every other sheet.
    * No-op while nothing is selected -- isolating "nothing" would blank the map.
@@ -139,6 +145,7 @@ export function VolumeMap(props: VolumeMapProps) {
     truthPages,
     showMissing,
     snapOverlay,
+    keymapUnderlays,
     isolateSelected,
     selectedItemIndex,
     onSelectPage,
@@ -482,6 +489,54 @@ export function VolumeMap(props: VolumeMapProps) {
       setMapReady(false);
     };
   }, []);
+
+  // The key-map underlay (#211): each georeferenced key map as an image
+  // source at its corner coordinates, inserted BENEATH the pages layer so the
+  // pages (dimmed with the opacity slider) can be read against it. Reconciled
+  // against the previous set: a mode switch swaps the image in place.
+  const underlayIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const map = mapRef.current;
+    const pagesLayer = layerRef.current;
+    if (!map || !pagesLayer || !mapReady) return;
+    const wanted = new Map(
+      keymapUnderlays.map((underlay) => [
+        `keymap-underlay-${underlay.id}`,
+        underlay,
+      ]),
+    );
+    for (const id of [...underlayIdsRef.current]) {
+      if (wanted.has(id)) continue;
+      if (map.getLayer(id)) map.removeLayer(id);
+      if (map.getSource(id)) map.removeSource(id);
+      underlayIdsRef.current.delete(id);
+    }
+    for (const [id, underlay] of wanted) {
+      const existing = map.getSource(id) as maplibregl.ImageSource | undefined;
+      if (existing) {
+        existing.updateImage({
+          url: underlay.url,
+          coordinates: underlay.corners,
+        });
+        continue;
+      }
+      map.addSource(id, {
+        type: 'image',
+        url: underlay.url,
+        coordinates: underlay.corners,
+      });
+      map.addLayer(
+        {
+          id,
+          type: 'raster',
+          source: id,
+          paint: { 'raster-opacity': 1, 'raster-fade-duration': 0 },
+        },
+        pagesLayer.id,
+      );
+      underlayIdsRef.current.add(id);
+    }
+  }, [mapReady, keymapUnderlays]);
 
   // The snap-debugger pose overlay (#325): the selected candidate's P(road)
   // map as an image source at the pose's corner coordinates. Added/updated/

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -1,4 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
+import {
+  keymapUnderlays,
+  underlayFromParam,
+  underlayParam,
+  type KeymapUnderlayMode,
+} from '../iiif/underlay';
 import type {
   GeorefAnnotationPage,
   SkippedItem,
@@ -101,6 +107,10 @@ export function VolumeViewer() {
   );
   const [isolateSelected, setIsolateSelected] = useState(
     () => initialParams.get('only') === '1',
+  );
+  // The key-map underlay (#211): off, the sheet, or its P(road) map.
+  const [underlayMode, setUnderlayMode] = useState<KeymapUnderlayMode>(() =>
+    underlayFromParam(initialParams.get('underlay')),
   );
   const [error, setError] = useState<string | null>(null);
   // Selection is tracked by page stem (stable across annotation files, unlike the item index).
@@ -408,6 +418,10 @@ export function VolumeViewer() {
       ),
     };
   }, [snapOpen, snapRecord, snapSelected, volumeName]);
+  const underlays = useMemo(
+    () => keymapUnderlays(keymaps, underlayMode),
+    [keymaps, underlayMode],
+  );
   const selectedIsMissing =
     selectedPage !== null &&
     selectedItemIndex !== null &&
@@ -434,6 +448,7 @@ export function VolumeViewer() {
       adj: showAdjacency ? '1' : null,
       osm: showOsmRelation ? null : '0',
       only: isolateSelected ? '1' : null,
+      underlay: underlayParam(underlayMode),
     });
   }, [
     selectedStem,
@@ -442,6 +457,7 @@ export function VolumeViewer() {
     showAdjacency,
     showOsmRelation,
     isolateSelected,
+    underlayMode,
   ]);
 
   function selectVolume(name: string): void {
@@ -565,6 +581,37 @@ export function VolumeViewer() {
               : 'OSM boundary'}
           </label>
         )}
+        {keymaps.some((keymap) => keymap.corners) && (
+          <label
+            className="rmse-color-control"
+            title="Draw the volume's georeferenced key map beneath the pages (#211). Dim the pages with the opacity slider to read them against it."
+          >
+            <input
+              type="checkbox"
+              checked={underlayMode !== 'off'}
+              onChange={(e) =>
+                setUnderlayMode(e.target.checked ? 'image' : 'off')
+              }
+            />
+            Key map
+          </label>
+        )}
+        {keymaps.some((keymap) => keymap.corners && keymap.hasRoadprob) && (
+          <label
+            className="rmse-color-control"
+            title="Show the key map's P(road) map (raw/<stem>.roadprob.png) in place of the sheet: what a key-map snap would match against."
+          >
+            <input
+              type="checkbox"
+              checked={underlayMode === 'roadprob'}
+              disabled={underlayMode === 'off'}
+              onChange={(e) =>
+                setUnderlayMode(e.target.checked ? 'roadprob' : 'image')
+              }
+            />
+            as P(road)
+          </label>
+        )}
         <div className="opacity-control">
           <label htmlFor="iiif-opacity-slider">Opacity</label>
           <input
@@ -595,6 +642,7 @@ export function VolumeViewer() {
         <div className="volume-map-slot" aria-hidden={debugView !== null}>
           <VolumeMap
             snapOverlay={snapOverlay}
+            keymapUnderlays={underlays}
             annotation={annotation}
             pages={pages}
             missingPages={missingPages}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -274,6 +274,9 @@ export function VolumeViewer() {
       .catch(() => {
         if (!cancelled) setOsmRelation(null);
       });
+    // Drop the previous volume's key maps now, or the underlay briefly asks
+    // for the new volume's key map by the old volume's stem.
+    setKeymaps([]);
     fetchKeymaps(volumeName)
       .then((list) => {
         if (!cancelled) setKeymaps(list);
@@ -440,19 +443,20 @@ export function VolumeViewer() {
   // stays loaded and opacity is only opacity. Clearing the allmaps layer at 0
   // and re-adding the same map at 50 left it blank until a zoom: the clear
   // aborts the in-flight tile fetches the re-add immediately repeats.
-  const [underlayArmed, setUnderlayArmed] = useState(false);
+  // The volume the underlay is armed for: the slider was above 0 while that
+  // volume was selected. Keyed by volume, so switching volumes with the
+  // slider already up arms the new one at once, and a slider parked at 0
+  // does not.
+  const [armedVolume, setArmedVolume] = useState<string | undefined>();
   useEffect(() => {
-    setUnderlayArmed(false);
-  }, [volumeName]);
-  useEffect(() => {
-    if (keymapOpacity > 0) setUnderlayArmed(true);
-  }, [keymapOpacity]);
+    if (keymapOpacity > 0 && volumeName) setArmedVolume(volumeName);
+  }, [keymapOpacity, volumeName]);
   const underlays = useMemo(
     () =>
-      volumeName && underlayArmed
+      volumeName && armedVolume === volumeName
         ? keymapUnderlays(volumeName, keymaps, underlayImage)
         : [],
-    [volumeName, keymaps, underlayImage, underlayArmed],
+    [volumeName, keymaps, underlayImage, armedVolume],
   );
   const selectedIsMissing =
     selectedPage !== null &&

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -436,13 +436,23 @@ export function VolumeViewer() {
       ),
     };
   }, [snapOpen, snapRecord, snapSelected, volumeName]);
-  // Nothing is fetched until the underlay is actually turned up.
+  // Nothing is fetched until the underlay is first turned up; after that it
+  // stays loaded and opacity is only opacity. Clearing the allmaps layer at 0
+  // and re-adding the same map at 50 left it blank until a zoom: the clear
+  // aborts the in-flight tile fetches the re-add immediately repeats.
+  const [underlayArmed, setUnderlayArmed] = useState(false);
+  useEffect(() => {
+    setUnderlayArmed(false);
+  }, [volumeName]);
+  useEffect(() => {
+    if (keymapOpacity > 0) setUnderlayArmed(true);
+  }, [keymapOpacity]);
   const underlays = useMemo(
     () =>
-      volumeName && keymapOpacity > 0
+      volumeName && underlayArmed
         ? keymapUnderlays(volumeName, keymaps, underlayImage)
         : [],
-    [volumeName, keymaps, underlayImage, keymapOpacity],
+    [volumeName, keymaps, underlayImage, underlayArmed],
   );
   const selectedIsMissing =
     selectedPage !== null &&

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
   keymapUnderlays,
-  underlayFromParam,
-  underlayParam,
-  type KeymapUnderlayMode,
+  underlayImageFromParam,
+  underlayImageParam,
+  type KeymapUnderlayImage,
 } from '../iiif/underlay';
 import type {
   GeorefAnnotationPage,
@@ -108,10 +108,15 @@ export function VolumeViewer() {
   const [isolateSelected, setIsolateSelected] = useState(
     () => initialParams.get('only') === '1',
   );
-  // The key-map underlay (#211): off, the sheet, or its P(road) map.
-  const [underlayMode, setUnderlayMode] = useState<KeymapUnderlayMode>(() =>
-    underlayFromParam(initialParams.get('underlay')),
+  // The key-map underlay (#211): which image, and how strongly it shows. The
+  // opacity is independent of the pages' so the two can be cross-faded.
+  const [underlayImage, setUnderlayImage] = useState<KeymapUnderlayImage>(() =>
+    underlayImageFromParam(initialParams.get('underlay')),
   );
+  const [keymapOpacity, setKeymapOpacity] = useState(() => {
+    const value = Number(initialParams.get('keymap'));
+    return Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : 0;
+  });
   const [error, setError] = useState<string | null>(null);
   // Selection is tracked by page stem (stable across annotation files, unlike the item index).
   const [selectedStem, setSelectedStem] = useState<string | null>(() =>
@@ -335,6 +340,19 @@ export function VolumeViewer() {
     return () => window.removeEventListener('keydown', onKeydown);
   }, []);
 
+  // The same 0/50/100% cycle for the key-map underlay, on 'k'.
+  useEffect(() => {
+    function onKeydown(e: KeyboardEvent): void {
+      if (e.key !== 'k' || isTypingTarget(e.target)) return;
+      const steps = [0, 50, 100];
+      setKeymapOpacity(
+        (prev) => steps[(steps.indexOf(prev) + 1) % steps.length] ?? 0,
+      );
+    }
+    window.addEventListener('keydown', onKeydown);
+    return () => window.removeEventListener('keydown', onKeydown);
+  }, []);
+
   const pages = useMemo(
     () =>
       annotation ? pagesFromAnnotation(annotation as GeorefAnnotationPage) : [],
@@ -418,9 +436,13 @@ export function VolumeViewer() {
       ),
     };
   }, [snapOpen, snapRecord, snapSelected, volumeName]);
+  // Nothing is fetched until the underlay is actually turned up.
   const underlays = useMemo(
-    () => keymapUnderlays(keymaps, underlayMode),
-    [keymaps, underlayMode],
+    () =>
+      volumeName && keymapOpacity > 0
+        ? keymapUnderlays(volumeName, keymaps, underlayImage)
+        : [],
+    [volumeName, keymaps, underlayImage, keymapOpacity],
   );
   const selectedIsMissing =
     selectedPage !== null &&
@@ -448,7 +470,8 @@ export function VolumeViewer() {
       adj: showAdjacency ? '1' : null,
       osm: showOsmRelation ? null : '0',
       only: isolateSelected ? '1' : null,
-      underlay: underlayParam(underlayMode),
+      underlay: underlayImageParam(underlayImage),
+      keymap: keymapOpacity > 0 ? String(keymapOpacity) : null,
     });
   }, [
     selectedStem,
@@ -457,7 +480,8 @@ export function VolumeViewer() {
     showAdjacency,
     showOsmRelation,
     isolateSelected,
-    underlayMode,
+    underlayImage,
+    keymapOpacity,
   ]);
 
   function selectVolume(name: string): void {
@@ -581,38 +605,41 @@ export function VolumeViewer() {
               : 'OSM boundary'}
           </label>
         )}
-        {keymaps.some((keymap) => keymap.corners) && (
-          <label
-            className="rmse-color-control"
-            title="Draw the volume's georeferenced key map beneath the pages (#211). Dim the pages with the opacity slider to read them against it."
-          >
-            <input
-              type="checkbox"
-              checked={underlayMode !== 'off'}
-              onChange={(e) =>
-                setUnderlayMode(e.target.checked ? 'image' : 'off')
-              }
-            />
-            Key map
-          </label>
-        )}
-        {keymaps.some((keymap) => keymap.corners && keymap.hasRoadprob) && (
+        {keymaps.some((keymap) => keymap.hasGeoref && keymap.hasRoadprob) && (
           <label
             className="rmse-color-control"
             title="Show the key map's P(road) map (raw/<stem>.roadprob.png) in place of the sheet: what a key-map snap would match against."
           >
             <input
               type="checkbox"
-              checked={underlayMode === 'roadprob'}
-              disabled={underlayMode === 'off'}
+              checked={underlayImage === 'roadprob'}
               onChange={(e) =>
-                setUnderlayMode(e.target.checked ? 'roadprob' : 'image')
+                setUnderlayImage(e.target.checked ? 'roadprob' : 'sheet')
               }
             />
             as P(road)
           </label>
         )}
-        <div className="opacity-control">
+        {keymaps.some((keymap) => keymap.hasGeoref) && (
+          <div
+            className="opacity-control"
+            title="Key-map underlay opacity, independent of the pages' (#211). Press k to cycle 0/50/100%."
+          >
+            <label htmlFor="iiif-keymap-opacity-slider">Key map</label>
+            <input
+              type="range"
+              id="iiif-keymap-opacity-slider"
+              min={0}
+              max={100}
+              value={keymapOpacity}
+              onChange={(e) => setKeymapOpacity(Number(e.target.value))}
+            />
+          </div>
+        )}
+        <div
+          className="opacity-control"
+          title="Page opacity. Press p to cycle 0/50/100%."
+        >
           <label htmlFor="iiif-opacity-slider">Opacity</label>
           <input
             type="range"
@@ -643,6 +670,7 @@ export function VolumeViewer() {
           <VolumeMap
             snapOverlay={snapOverlay}
             keymapUnderlays={underlays}
+            keymapOpacity={keymapOpacity / 100}
             annotation={annotation}
             pages={pages}
             missingPages={missingPages}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -629,16 +629,27 @@ export function VolumeViewer() {
               {keymaps.some(
                 (keymap) => keymap.hasGeoref && keymap.hasRoadprob,
               ) && (
-                <label title="Show the key map's P(road) map (raw/<stem>.roadprob.png) in place of the sheet: what a key-map snap would match against.">
-                  <input
-                    type="checkbox"
-                    checked={underlayImage === 'roadprob'}
-                    onChange={(e) =>
-                      setUnderlayImage(e.target.checked ? 'roadprob' : 'sheet')
-                    }
-                  />
-                  P(road)
-                </label>
+                <div
+                  className="segmented"
+                  role="group"
+                  aria-label="Key-map underlay image"
+                  title="Show the key map's sheet, or its P(road) map (raw/<stem>.roadprob.png): what a key-map snap would match against."
+                >
+                  <button
+                    type="button"
+                    aria-pressed={underlayImage === 'sheet'}
+                    onClick={() => setUnderlayImage('sheet')}
+                  >
+                    Key map
+                  </button>
+                  <button
+                    type="button"
+                    aria-pressed={underlayImage === 'roadprob'}
+                    onClick={() => setUnderlayImage('roadprob')}
+                  >
+                    P(road)
+                  </button>
+                </div>
               )}
             </div>
             <label htmlFor="iiif-keymap-opacity-slider">Key map (k)</label>

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -565,7 +565,7 @@ export function VolumeViewer() {
                   checked={showMissing}
                   onChange={(e) => setShowMissing(e.target.checked)}
                 />
-                Show missing pages
+                Show missing
               </label>
             )}
           </div>

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -102,9 +102,6 @@ export function VolumeViewer() {
   );
   // Default ON: a page outside the downloaded relation cannot be fit at all,
   // and that is invisible without the ring.
-  const [showOsmRelation, setShowOsmRelation] = useState(
-    () => initialParams.get('osm') !== '0',
-  );
   const [isolateSelected, setIsolateSelected] = useState(
     () => initialParams.get('only') === '1',
   );
@@ -482,7 +479,6 @@ export function VolumeViewer() {
       rmse: colorByRmse ? '1' : null,
       missing: showMissing ? '1' : null,
       adj: showAdjacency ? '1' : null,
-      osm: showOsmRelation ? null : '0',
       only: isolateSelected ? '1' : null,
       underlay: underlayImageParam(underlayImage),
       keymap: keymapOpacity > 0 ? String(keymapOpacity) : null,
@@ -492,7 +488,6 @@ export function VolumeViewer() {
     colorByRmse,
     showMissing,
     showAdjacency,
-    showOsmRelation,
     isolateSelected,
     underlayImage,
     keymapOpacity,
@@ -508,8 +503,8 @@ export function VolumeViewer() {
   if (error) {
     status = error;
   } else if (loadResult) {
-    const parts = [`${loadResult.loaded} pages shown`];
-    if (loadResult.failed > 0) parts.push(`${loadResult.failed} failed`);
+    const parts: string[] = [];
+    if (loadResult.failed > 0) parts.push(`${loadResult.failed} pages failed`);
     if (skipped.length > 0) parts.push(`${skipped.length} skipped`);
     status = parts.join(', ');
   } else if (selectedPath) {
@@ -520,141 +515,93 @@ export function VolumeViewer() {
 
   return (
     <div className="volume-viewer">
+      {/* Two rows tall by design: each stack holds two related controls, so
+          the bar never wraps on a laptop-width window (#211). */}
       <div className="iiif-controls">
-        <a href=".">← debugger</a>
-        <select
-          value={selection?.volume ?? ''}
-          onChange={(e) => selectVolume(e.target.value)}
-        >
-          <option value="" disabled>
-            Select a volume…
-          </option>
-          {(volumes ?? []).map((volume) => (
-            <option key={volume.name} value={volume.name}>
-              {volume.name} ({volume.pageCount} pages)
+        <div className="control-stack">
+          <select
+            value={selection?.volume ?? ''}
+            onChange={(e) => selectVolume(e.target.value)}
+          >
+            <option value="" disabled>
+              Select a volume…
             </option>
-          ))}
-        </select>
-        <select
-          value={selection?.file ?? ''}
-          onChange={(e) =>
-            setSelectedPath(`data/${selection?.volume}/${e.target.value}`)
-          }
-          disabled={!selectedVolume}
-        >
-          {(selectedVolume?.annotations ?? []).map((file) => (
-            <option key={file.name} value={file.name}>
-              {file.name} ({file.itemCount})
-            </option>
-          ))}
-        </select>
-        {truthStats && (
-          <label className="rmse-color-control">
-            <input
-              type="checkbox"
-              checked={colorByRmse}
-              onChange={(e) => setColorByRmse(e.target.checked)}
-            />
-            Color by RMSE
-          </label>
-        )}
-        {missingPages.length > 0 && (
-          <label className="rmse-color-control">
-            <input
-              type="checkbox"
-              checked={showMissing}
-              onChange={(e) => setShowMissing(e.target.checked)}
-            />
-            Show missing pages
-          </label>
-        )}
-        <label
-          className="rmse-color-control"
-          title={
-            selectedStem
-              ? `Show only ${selectedStem}`
-              : 'Select a page to isolate it'
-          }
-        >
-          <input
-            type="checkbox"
-            checked={isolateSelected}
-            disabled={!selectedStem}
-            onChange={(e) => setIsolateSelected(e.target.checked)}
-          />
-          Isolate selected
-        </label>
-        {adjacencyData && (
-          <label className="rmse-color-control">
-            <input
-              type="checkbox"
-              checked={showAdjacency}
-              onChange={(e) => setShowAdjacency(e.target.checked)}
-            />
-            Show adjacency
-          </label>
-        )}
-        {osmRelation && (
-          <label
-            className="rmse-color-control"
-            title={`Streets were downloaded from OSM ${osmRelation.id}${
-              osmRelation.name ? ` (${osmRelation.name})` : ''
-            }${
-              osmRelation.bufferM
-                ? `, buffered by ${osmRelation.bufferM} m — the ring is the area actually downloaded, not the administrative line`
-                : ' (no buffer — the ring is the administrative boundary itself)'
-            }. Pages crossing this ring cover ground whose streets are missing from the vocabulary.`}
+            {(volumes ?? []).map((volume) => (
+              <option key={volume.name} value={volume.name}>
+                {volume.name} ({volume.pageCount} pages)
+              </option>
+            ))}
+          </select>
+          <select
+            value={selection?.file ?? ''}
+            onChange={(e) =>
+              setSelectedPath(`data/${selection?.volume}/${e.target.value}`)
+            }
+            disabled={!selectedVolume}
           >
-            <input
-              type="checkbox"
-              checked={showOsmRelation}
-              onChange={(e) => setShowOsmRelation(e.target.checked)}
-            />
-            {osmRelation.bufferM
-              ? `OSM boundary +${
-                  osmRelation.bufferM >= 1000
-                    ? `${osmRelation.bufferM / 1000} km`
-                    : `${osmRelation.bufferM} m`
-                }`
-              : 'OSM boundary'}
-          </label>
-        )}
-        {keymaps.some((keymap) => keymap.hasGeoref && keymap.hasRoadprob) && (
-          <label
-            className="rmse-color-control"
-            title="Show the key map's P(road) map (raw/<stem>.roadprob.png) in place of the sheet: what a key-map snap would match against."
-          >
-            <input
-              type="checkbox"
-              checked={underlayImage === 'roadprob'}
-              onChange={(e) =>
-                setUnderlayImage(e.target.checked ? 'roadprob' : 'sheet')
-              }
-            />
-            as P(road)
-          </label>
-        )}
-        {keymaps.some((keymap) => keymap.hasGeoref) && (
-          <div
-            className="opacity-control"
-            title="Key-map underlay opacity, independent of the pages' (#211). Press k to cycle 0/50/100%."
-          >
-            <label htmlFor="iiif-keymap-opacity-slider">Key map</label>
-            <input
-              type="range"
-              id="iiif-keymap-opacity-slider"
-              min={0}
-              max={100}
-              value={keymapOpacity}
-              onChange={(e) => setKeymapOpacity(Number(e.target.value))}
-            />
+            {(selectedVolume?.annotations ?? []).map((file) => (
+              <option key={file.name} value={file.name}>
+                {file.name} ({file.itemCount})
+              </option>
+            ))}
+          </select>
+        </div>
+        {(truthStats || missingPages.length > 0) && (
+          <div className="control-stack">
+            {truthStats && (
+              <label>
+                <input
+                  type="checkbox"
+                  checked={colorByRmse}
+                  onChange={(e) => setColorByRmse(e.target.checked)}
+                />
+                Color by RMSE
+              </label>
+            )}
+            {missingPages.length > 0 && (
+              <label>
+                <input
+                  type="checkbox"
+                  checked={showMissing}
+                  onChange={(e) => setShowMissing(e.target.checked)}
+                />
+                Show missing pages
+              </label>
+            )}
           </div>
         )}
+        <div className="control-stack">
+          <label
+            title={
+              selectedStem
+                ? `Show only ${selectedStem}`
+                : 'Select a page to isolate it'
+            }
+          >
+            <input
+              type="checkbox"
+              checked={isolateSelected}
+              disabled={!selectedStem}
+              onChange={(e) => setIsolateSelected(e.target.checked)}
+            />
+            Isolate selected
+          </label>
+          {adjacencyData && (
+            <label>
+              <input
+                type="checkbox"
+                checked={showAdjacency}
+                onChange={(e) => setShowAdjacency(e.target.checked)}
+              />
+              Show adjacency
+            </label>
+          )}
+        </div>
+        {status && <span className="iiif-status">{status}</span>}
         <div
-          className="opacity-control"
+          className="slider-stack"
           title="Page opacity. Press p to cycle 0/50/100%."
         >
-          <label htmlFor="iiif-opacity-slider">Opacity</label>
           <input
             type="range"
             id="iiif-opacity-slider"
@@ -663,8 +610,40 @@ export function VolumeViewer() {
             value={opacity}
             onChange={(e) => setOpacity(Number(e.target.value))}
           />
+          <label htmlFor="iiif-opacity-slider">Opacity (p)</label>
         </div>
-        <span className="iiif-status">{status}</span>
+        {keymaps.some((keymap) => keymap.hasGeoref) && (
+          <div
+            className="slider-stack keymap-stack"
+            title="Key-map underlay opacity, independent of the pages' (#211). Press k to cycle 0/50/100%."
+          >
+            <div className="slider-row">
+              <input
+                type="range"
+                id="iiif-keymap-opacity-slider"
+                min={0}
+                max={100}
+                value={keymapOpacity}
+                onChange={(e) => setKeymapOpacity(Number(e.target.value))}
+              />
+              {keymaps.some(
+                (keymap) => keymap.hasGeoref && keymap.hasRoadprob,
+              ) && (
+                <label title="Show the key map's P(road) map (raw/<stem>.roadprob.png) in place of the sheet: what a key-map snap would match against.">
+                  <input
+                    type="checkbox"
+                    checked={underlayImage === 'roadprob'}
+                    onChange={(e) =>
+                      setUnderlayImage(e.target.checked ? 'roadprob' : 'sheet')
+                    }
+                  />
+                  P(road)
+                </label>
+              )}
+            </div>
+            <label htmlFor="iiif-keymap-opacity-slider">Key map (k)</label>
+          </div>
+        )}
       </div>
       <div className="volume-viewer-body">
         <PageList
@@ -697,9 +676,7 @@ export function VolumeViewer() {
             awaitingView={!!selectedPath && !error}
             pageColors={pageColors}
             adjacencyClaims={showAdjacency ? adjacencyClaims : []}
-            osmRelationWays={
-              showOsmRelation && osmRelation ? osmRelation.ways : null
-            }
+            osmRelationWays={osmRelation ? osmRelation.ways : null}
             selectedStem={selectedPage?.stem ?? null}
             initialViewport={initialViewport}
             fitVolumeKey={volumeName ?? null}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -617,42 +617,44 @@ export function VolumeViewer() {
             className="slider-stack keymap-stack"
             title="Key-map underlay opacity, independent of the pages' (#211). Press k to cycle 0/50/100%."
           >
-            <div className="slider-row">
-              <input
-                type="range"
-                id="iiif-keymap-opacity-slider"
-                min={0}
-                max={100}
-                value={keymapOpacity}
-                onChange={(e) => setKeymapOpacity(Number(e.target.value))}
-              />
-              {keymaps.some(
-                (keymap) => keymap.hasGeoref && keymap.hasRoadprob,
-              ) && (
-                <div
-                  className="segmented"
-                  role="group"
-                  aria-label="Key-map underlay image"
-                  title="Show the key map's sheet, or its P(road) map (raw/<stem>.roadprob.png): what a key-map snap would match against."
-                >
-                  <button
-                    type="button"
-                    aria-pressed={underlayImage === 'sheet'}
-                    onClick={() => setUnderlayImage('sheet')}
-                  >
-                    Key map
-                  </button>
-                  <button
-                    type="button"
-                    aria-pressed={underlayImage === 'roadprob'}
-                    onClick={() => setUnderlayImage('roadprob')}
-                  >
-                    P(road)
-                  </button>
-                </div>
-              )}
+            <input
+              type="range"
+              id="iiif-keymap-opacity-slider"
+              min={0}
+              max={100}
+              value={keymapOpacity}
+              onChange={(e) => setKeymapOpacity(Number(e.target.value))}
+            />
+            {/* Disabled while the underlay is hidden, so the pressed side's fill
+                is not noise in the default state. */}
+            <div
+              className="segmented"
+              role="group"
+              aria-label="Key-map underlay image"
+              title="Show the key map's sheet, or its P(road) map (raw/<stem>.roadprob.png): what a key-map snap would match against."
+            >
+              <button
+                type="button"
+                aria-pressed={underlayImage === 'sheet'}
+                disabled={keymapOpacity === 0}
+                onClick={() => setUnderlayImage('sheet')}
+              >
+                Key map
+              </button>
+              <button
+                type="button"
+                aria-pressed={underlayImage === 'roadprob'}
+                disabled={
+                  keymapOpacity === 0 ||
+                  !keymaps.some(
+                    (keymap) => keymap.hasGeoref && keymap.hasRoadprob,
+                  )
+                }
+                onClick={() => setUnderlayImage('roadprob')}
+              >
+                P(road)
+              </button>
             </div>
-            <label htmlFor="iiif-keymap-opacity-slider">Key map (k)</label>
           </div>
         )}
       </div>

--- a/app/src/iiif/underlay.test.ts
+++ b/app/src/iiif/underlay.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { keymapUnderlays, underlayFromParam, underlayParam } from './underlay';
+import {
+  keymapUnderlays,
+  underlayImageFromParam,
+  underlayImageParam,
+} from './underlay';
 import type { KeymapInfo } from '../../server/api';
 
 const corners: [number, number][] = [
@@ -9,65 +13,48 @@ const corners: [number, number][] = [
   [-90.0717, 29.9145],
 ];
 
-const service = 'http://localhost:8182/iiif/new_orleans_la_1896_vol_2/raw';
 const keymaps: KeymapInfo[] = [
-  {
-    stem: 'p0',
-    hasRegions: true,
-    hasGeoref: true,
-    hasRoadprob: true,
-    corners,
-    imageService: `${service}/p0.jpg`,
-    roadprobService: `${service}/p0.roadprob.png`,
-  },
+  { stem: 'p0', hasRegions: true, hasGeoref: true, hasRoadprob: true, corners },
   {
     stem: 'pb',
     hasRegions: false,
     hasGeoref: true,
     hasRoadprob: false,
     corners,
-    imageService: `${service}/pb.png`,
   },
-  {
-    stem: 'pz',
-    hasRegions: false,
-    hasGeoref: false,
-    hasRoadprob: true,
-    imageService: `${service}/pz.jpg`,
-    roadprobService: `${service}/pz.roadprob.png`,
-  },
+  // No georef: nothing to warp it by, in either mode.
+  { stem: 'pz', hasRegions: false, hasGeoref: false, hasRoadprob: true },
 ];
 
 describe('keymapUnderlays', () => {
-  it('draws every georeferenced key map as its sheet through the IIIF service', () => {
-    const underlays = keymapUnderlays(keymaps, 'image');
-    expect(underlays.map((u) => u.id)).toEqual(['p0', 'pb']);
-    expect(underlays[0].url).toBe(
-      `${service}/p0.jpg/full/!2400,2400/0/default.jpg`,
+  it('draws every georeferenced key map from its annotation', () => {
+    const underlays = keymapUnderlays(
+      'new_orleans_la_1896_vol_2',
+      keymaps,
+      'sheet',
     );
-    expect(underlays[0].corners).toEqual(corners);
+    expect(underlays.map((u) => u.id)).toEqual(['p0', 'pb']);
+    expect(underlays[0].annotationUrl).toBe(
+      '/iiif-api/keymap-annotation?volume=new_orleans_la_1896_vol_2&stem=p0&image=sheet',
+    );
   });
 
   it('draws only key maps with a P(road) map in roadprob mode', () => {
-    const underlays = keymapUnderlays(keymaps, 'roadprob');
+    const underlays = keymapUnderlays('queens_1950/vol2', keymaps, 'roadprob');
     expect(underlays.map((u) => u.id)).toEqual(['p0']);
-    expect(underlays[0].url).toBe(
-      `${service}/p0.roadprob.png/full/!2400,2400/0/default.png`,
+    expect(underlays[0].annotationUrl).toBe(
+      '/iiif-api/keymap-annotation?volume=queens_1950%2Fvol2&stem=p0&image=roadprob',
     );
-  });
-
-  it('draws nothing when off', () => {
-    expect(keymapUnderlays(keymaps, 'off')).toEqual([]);
   });
 });
 
-describe('underlay URL parameter', () => {
-  it('round-trips the two on modes and treats anything else as off', () => {
-    expect(underlayFromParam('image')).toBe('image');
-    expect(underlayFromParam('roadprob')).toBe('roadprob');
-    expect(underlayFromParam(null)).toBe('off');
-    expect(underlayFromParam('yes')).toBe('off');
-    expect(underlayParam('off')).toBeNull();
-    expect(underlayParam('roadprob')).toBe('roadprob');
+describe('underlay image URL parameter', () => {
+  it('round-trips roadprob and treats anything else as the sheet', () => {
+    expect(underlayImageFromParam('roadprob')).toBe('roadprob');
+    expect(underlayImageFromParam('sheet')).toBe('sheet');
+    expect(underlayImageFromParam(null)).toBe('sheet');
+    expect(underlayImageFromParam('yes')).toBe('sheet');
+    expect(underlayImageParam('sheet')).toBeNull();
+    expect(underlayImageParam('roadprob')).toBe('roadprob');
   });
 });

--- a/app/src/iiif/underlay.test.ts
+++ b/app/src/iiif/underlay.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { keymapUnderlays, underlayFromParam, underlayParam } from './underlay';
+import type { KeymapInfo } from '../../server/api';
+
+const corners: [number, number][] = [
+  [-90.1158, 29.9432],
+  [-90.0872, 29.9745],
+  [-90.0431, 29.9458],
+  [-90.0717, 29.9145],
+];
+
+const service = 'http://localhost:8182/iiif/new_orleans_la_1896_vol_2/raw';
+const keymaps: KeymapInfo[] = [
+  {
+    stem: 'p0',
+    hasRegions: true,
+    hasGeoref: true,
+    hasRoadprob: true,
+    corners,
+    imageService: `${service}/p0.jpg`,
+    roadprobService: `${service}/p0.roadprob.png`,
+  },
+  {
+    stem: 'pb',
+    hasRegions: false,
+    hasGeoref: true,
+    hasRoadprob: false,
+    corners,
+    imageService: `${service}/pb.png`,
+  },
+  {
+    stem: 'pz',
+    hasRegions: false,
+    hasGeoref: false,
+    hasRoadprob: true,
+    imageService: `${service}/pz.jpg`,
+    roadprobService: `${service}/pz.roadprob.png`,
+  },
+];
+
+describe('keymapUnderlays', () => {
+  it('draws every georeferenced key map as its sheet through the IIIF service', () => {
+    const underlays = keymapUnderlays(keymaps, 'image');
+    expect(underlays.map((u) => u.id)).toEqual(['p0', 'pb']);
+    expect(underlays[0].url).toBe(
+      `${service}/p0.jpg/full/!2400,2400/0/default.jpg`,
+    );
+    expect(underlays[0].corners).toEqual(corners);
+  });
+
+  it('draws only key maps with a P(road) map in roadprob mode', () => {
+    const underlays = keymapUnderlays(keymaps, 'roadprob');
+    expect(underlays.map((u) => u.id)).toEqual(['p0']);
+    expect(underlays[0].url).toBe(
+      `${service}/p0.roadprob.png/full/!2400,2400/0/default.png`,
+    );
+  });
+
+  it('draws nothing when off', () => {
+    expect(keymapUnderlays(keymaps, 'off')).toEqual([]);
+  });
+});
+
+describe('underlay URL parameter', () => {
+  it('round-trips the two on modes and treats anything else as off', () => {
+    expect(underlayFromParam('image')).toBe('image');
+    expect(underlayFromParam('roadprob')).toBe('roadprob');
+    expect(underlayFromParam(null)).toBe('off');
+    expect(underlayFromParam('yes')).toBe('off');
+    expect(underlayParam('off')).toBeNull();
+    expect(underlayParam('roadprob')).toBe('roadprob');
+  });
+});

--- a/app/src/iiif/underlay.ts
+++ b/app/src/iiif/underlay.ts
@@ -1,0 +1,82 @@
+/**
+ * The key-map underlay (#211): a volume's georeferenced key map drawn beneath
+ * its pages, either as the sheet itself or as its P(road) map.
+ *
+ * Where the street grid has changed since the Sanborn survey there is nothing
+ * on OSM for snap to lock onto, and the page lands on an alias. The key map is
+ * a Sanborn-era drawing of the same streets, so a page that fails to snap onto
+ * the modern grid might snap onto the key map's P(road) map instead. This
+ * underlay is the first look at that: does the page's own P(road) map line up
+ * with the key map's?
+ *
+ * The key map's georef is an affine, given by its four corners, so the sheet is
+ * placed the way the snap pose overlay is: a maplibre image source at the
+ * corner coordinates. The image is fetched through the key map's IIIF image
+ * service (an absolute URL from the API, like the pages' tiles) at a bounded
+ * size, since a full-resolution sheet is too large for one texture.
+ */
+import type { KeymapInfo } from '../../server/api';
+
+export type KeymapUnderlayMode = 'off' | 'image' | 'roadprob';
+
+export type Corners = [
+  [number, number],
+  [number, number],
+  [number, number],
+  [number, number],
+];
+
+/** One key map to draw: an image URL and the corner coordinates to pin it to. */
+export interface KeymapUnderlay {
+  /** The key map's stem, e.g. "p0"; the layer id derives from it. */
+  id: string;
+  url: string;
+  /** Top-left, top-right, bottom-right, bottom-left, as maplibre wants them. */
+  corners: Corners;
+}
+
+/** Longest side, in pixels, of the image fetched for the underlay. */
+export const UNDERLAY_MAX_PX = 2400;
+
+/** The underlay mode a URL parameter names; anything unknown is off. */
+export function underlayFromParam(value: string | null): KeymapUnderlayMode {
+  return value === 'image' || value === 'roadprob' ? value : 'off';
+}
+
+/** The URL parameter value for a mode; null (remove the parameter) when off. */
+export function underlayParam(mode: KeymapUnderlayMode): string | null {
+  return mode === 'off' ? null : mode;
+}
+
+/** The IIIF request for a service's image, best-fit inside UNDERLAY_MAX_PX square. */
+export function underlayImageUrl(
+  service: string,
+  format: 'jpg' | 'png',
+): string {
+  return `${service}/full/!${UNDERLAY_MAX_PX},${UNDERLAY_MAX_PX}/0/default.${format}`;
+}
+
+/**
+ * The underlays to draw in a mode: every key map with a georef and an image
+ * service, as its sheet, or in P(road) mode only those with a road-probability
+ * map. Nothing when off.
+ */
+export function keymapUnderlays(
+  keymaps: KeymapInfo[],
+  mode: KeymapUnderlayMode,
+): KeymapUnderlay[] {
+  if (mode === 'off') return [];
+  const underlays: KeymapUnderlay[] = [];
+  for (const keymap of keymaps) {
+    if (!keymap.corners || keymap.corners.length !== 4) continue;
+    const service =
+      mode === 'roadprob' ? keymap.roadprobService : keymap.imageService;
+    if (!service) continue;
+    underlays.push({
+      id: keymap.stem,
+      url: underlayImageUrl(service, mode === 'roadprob' ? 'png' : 'jpg'),
+      corners: keymap.corners as Corners,
+    });
+  }
+  return underlays;
+}

--- a/app/src/iiif/underlay.ts
+++ b/app/src/iiif/underlay.ts
@@ -9,73 +9,59 @@
  * underlay is the first look at that: does the page's own P(road) map line up
  * with the key map's?
  *
- * The key map's georef is an affine, given by its four corners, so the sheet is
- * placed the way the snap pose overlay is: a maplibre image source at the
- * corner coordinates. The image is fetched through the key map's IIIF image
- * service (an absolute URL from the API, like the pages' tiles) at a bounded
- * size, since a full-resolution sheet is too large for one texture.
+ * Each key map is drawn from a georeference annotation the server builds
+ * (`/iiif-api/keymap-annotation`), warped by a thin-plate spline through the
+ * sheet's own GCPs -- the model keymap-snap places pages in, whose residuals
+ * are about half the shipped affine's. Rendering it with allmaps, the way the
+ * pages are rendered, is what makes the spline visible: a four-corner image
+ * would show the affine placement the pipeline does not use.
  */
 import type { KeymapInfo } from '../../server/api';
 
-export type KeymapUnderlayMode = 'off' | 'image' | 'roadprob';
+/** Which image to draw for a key map: the sheet, or its road-probability map. */
+export type KeymapUnderlayImage = 'sheet' | 'roadprob';
 
-export type Corners = [
-  [number, number],
-  [number, number],
-  [number, number],
-  [number, number],
-];
-
-/** One key map to draw: an image URL and the corner coordinates to pin it to. */
+/** One key map to draw, as the annotation URL that places it. */
 export interface KeymapUnderlay {
-  /** The key map's stem, e.g. "p0"; the layer id derives from it. */
+  /** The key map's stem, e.g. "p0". */
   id: string;
-  url: string;
-  /** Top-left, top-right, bottom-right, bottom-left, as maplibre wants them. */
-  corners: Corners;
+  /** Georeference annotation URL; allmaps fetches and warps it. */
+  annotationUrl: string;
 }
 
-/** Longest side, in pixels, of the image fetched for the underlay. */
-export const UNDERLAY_MAX_PX = 2400;
-
-/** The underlay mode a URL parameter names; anything unknown is off. */
-export function underlayFromParam(value: string | null): KeymapUnderlayMode {
-  return value === 'image' || value === 'roadprob' ? value : 'off';
+/** The image a URL parameter names; anything unknown is the sheet. */
+export function underlayImageFromParam(
+  value: string | null,
+): KeymapUnderlayImage {
+  return value === 'roadprob' ? 'roadprob' : 'sheet';
 }
 
-/** The URL parameter value for a mode; null (remove the parameter) when off. */
-export function underlayParam(mode: KeymapUnderlayMode): string | null {
-  return mode === 'off' ? null : mode;
-}
-
-/** The IIIF request for a service's image, best-fit inside UNDERLAY_MAX_PX square. */
-export function underlayImageUrl(
-  service: string,
-  format: 'jpg' | 'png',
-): string {
-  return `${service}/full/!${UNDERLAY_MAX_PX},${UNDERLAY_MAX_PX}/0/default.${format}`;
+/** The URL parameter value for an image; null (omit) for the default sheet. */
+export function underlayImageParam(image: KeymapUnderlayImage): string | null {
+  return image === 'roadprob' ? 'roadprob' : null;
 }
 
 /**
- * The underlays to draw in a mode: every key map with a georef and an image
- * service, as its sheet, or in P(road) mode only those with a road-probability
- * map. Nothing when off.
+ * The underlays to draw for a volume: every key map that has a georeference,
+ * or in P(road) mode only those that also have a road-probability map.
  */
 export function keymapUnderlays(
+  volume: string,
   keymaps: KeymapInfo[],
-  mode: KeymapUnderlayMode,
+  image: KeymapUnderlayImage,
 ): KeymapUnderlay[] {
-  if (mode === 'off') return [];
   const underlays: KeymapUnderlay[] = [];
   for (const keymap of keymaps) {
-    if (!keymap.corners || keymap.corners.length !== 4) continue;
-    const service =
-      mode === 'roadprob' ? keymap.roadprobService : keymap.imageService;
-    if (!service) continue;
+    if (!keymap.hasGeoref) continue;
+    if (image === 'roadprob' && !keymap.hasRoadprob) continue;
+    const query = new URLSearchParams({
+      volume,
+      stem: keymap.stem,
+      image,
+    });
     underlays.push({
       id: keymap.stem,
-      url: underlayImageUrl(service, mode === 'roadprob' ? 'png' : 'jpg'),
-      corners: keymap.corners as Corners,
+      annotationUrl: `/iiif-api/keymap-annotation?${query}`,
     });
   }
   return underlays;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -192,22 +192,13 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
-  width: 100px;
+  width: 126px; /* the Key map / P(road) toggle's natural width; both sliders match it */
   flex-shrink: 0;
 }
 
 .iiif-controls .slider-stack input[type='range'] {
   width: 100%;
   margin: 4px 0;
-}
-
-/* The key-map stack: its slider over the sheet / P(road) toggle. */
-.iiif-controls .keymap-stack {
-  width: 130px;
-}
-
-.iiif-controls .keymap-stack input[type='range'] {
-  width: 100px;
 }
 
 /* A two-way toggle drawn as one control: the pressed side is filled. */

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -162,21 +162,66 @@
   gap: 8px;
 }
 
+/* Two rows tall by design: every child is a two-item vertical stack, so the
+   bar's height is fixed and nothing wraps on a laptop-width window. */
 .iiif-controls {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  align-items: flex-start;
+  gap: 18px;
   font-family: sans-serif;
   font-size: 14px;
 }
 
-.iiif-controls .opacity-control {
+.iiif-controls .control-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.iiif-controls .control-stack select {
+  width: 100%;
+}
+
+.iiif-controls label {
+  white-space: nowrap;
+}
+
+/* A slider with its caption underneath; the caption names the keyboard shortcut. */
+.iiif-controls .slider-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
   width: 200px;
   flex-shrink: 0;
 }
 
+.iiif-controls .slider-stack input[type='range'] {
+  width: 100%;
+  margin: 4px 0;
+}
+
+.iiif-controls .slider-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.iiif-controls .slider-row input[type='range'] {
+  flex: 1;
+  min-width: 120px;
+}
+
+/* The key-map controls sit at the right edge. */
+.iiif-controls .keymap-stack {
+  margin-left: auto;
+  width: 280px;
+}
+
 .iiif-status {
   color: #555;
+  align-self: center;
 }
 
 .volume-viewer-body {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -192,7 +192,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
-  width: 200px;
+  width: 100px;
   flex-shrink: 0;
 }
 
@@ -210,13 +210,13 @@
 
 .iiif-controls .slider-row input[type='range'] {
   flex: 1;
-  min-width: 120px;
+  min-width: 80px;
 }
 
-/* The key-map controls sit at the right edge. */
+/* The key-map controls follow the page-opacity ones; the checkbox shares
+   the slider's row. */
 .iiif-controls .keymap-stack {
-  margin-left: auto;
-  width: 280px;
+  width: 180px;
 }
 
 .iiif-status {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -201,22 +201,13 @@
   margin: 4px 0;
 }
 
-.iiif-controls .slider-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-}
-
-.iiif-controls .slider-row input[type='range'] {
-  flex: 1;
-  min-width: 80px;
-}
-
-/* The key-map controls follow the page-opacity ones; the checkbox shares
-   the slider's row. */
+/* The key-map stack: its slider over the sheet / P(road) toggle. */
 .iiif-controls .keymap-stack {
-  width: 240px;
+  width: 130px;
+}
+
+.iiif-controls .keymap-stack input[type='range'] {
+  width: 100px;
 }
 
 /* A two-way toggle drawn as one control: the pressed side is filled. */
@@ -245,6 +236,12 @@
 .iiif-controls .segmented button[aria-pressed='true'] {
   background: #1a73e8;
   color: #fff;
+}
+
+.iiif-controls .segmented button:disabled {
+  background: #f4f4f4;
+  color: #999;
+  cursor: default;
 }
 
 .iiif-status {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -216,7 +216,35 @@
 /* The key-map controls follow the page-opacity ones; the checkbox shares
    the slider's row. */
 .iiif-controls .keymap-stack {
-  width: 180px;
+  width: 240px;
+}
+
+/* A two-way toggle drawn as one control: the pressed side is filled. */
+.iiif-controls .segmented {
+  display: inline-flex;
+  border: 1px solid #888;
+  border-radius: 4px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.iiif-controls .segmented button {
+  border: 0;
+  background: #fff;
+  color: #222;
+  padding: 1px 7px;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.iiif-controls .segmented button + button {
+  border-left: 1px solid #888;
+}
+
+.iiif-controls .segmented button[aria-pressed='true'] {
+  background: #1a73e8;
+  color: #fff;
 }
 
 .iiif-status {


### PR DESCRIPTION
Where the street grid has changed since the Sanborn survey there is nothing on OSM for snap to lock onto, and the page lands on an alias: New Orleans 1896 p119 fits 704 ft off, one block row from its truth. The key map is a Sanborn-era drawing of the same streets, so a page that fails to snap onto the modern grid might snap onto the key map's P(road) map instead (#211). This is the first look at that.

This also includes a reworking of the control bar so that it fits better on laptop screens:
<img width="1362" height="399" alt="image" src="https://github.com/user-attachments/assets/d4aaf5ae-f5cb-48d9-96a3-0c5d7c351558" />

It looks a little scrunched on a big monitor, but this gives me space to add more controls in the future if I like.

## Controls

- **Key map** opacity slider, independent of the pages'. `k` cycles it through 0/50/100% exactly as `p` cycles the pages, so the two can be cross-faded, which is the whole point: reading a page's P(road) map against the key map's.
- **as P(road)** swaps `raw/<stem>.roadprob.png` in for the sheet: what a key-map snap would match against.

Both persist in the URL (`?keymap=100&underlay=roadprob`). Try: `?view=iiif&iiif=data/new_orleans_la_1896_vol_2/2026-08-28.iiif.json&page=p119&only=1&underlay=roadprob&keymap=100`. Nothing is fetched until the slider leaves 0.

## Warped by thin-plate spline, not by the affine corners

Drawing the sheet at its georef's four corners would show a frame the pipeline does not use. `mapsnap.keymap.snap.keymap_model` models the key map as a **thin-plate spline through the sheet's own inlier intersections**, and that model is what every keymap-snap placement is measured in. The affine's residuals against those same points are large. Cross-validated 10-fold over each sheet's consistent GCPs, median error in feet:

| key map | GCPs | shipped affine | refit affine | TPS |
|---|---|---|---|---|
| new_orleans_1896 p0 | 485 | 126.7 | 124.6 | **53.0** |
| detroit p0__1 | 248 | 90.2 | 89.6 | **23.1** |
| richmond p0 | 353 | 71.2 | 78.2 | **53.0** |
| columbus p0 | 343 | 59.3 | 70.0 | 59.6 |

So the underlay is served as a georeference annotation carrying those GCPs with `transformation: thinPlateSpline`, rendered by a second allmaps `WarpedMapLayer` inserted beneath the pages. Sheets with fewer than 25 consistent GCPs fall back to the affine corners, and the annotation records which was used. `consistentGcps` is a port of the Python rule that drops a pixel read in two places more than 50 ft apart; it has its own tests.

## Smoothed, so straight streets stay straight

allmaps interpolates GCPs exactly; `keymap_model` smooths them (`TPS_SMOOTHING` 1e6), and that smoothing is what keeps straight streets straight between GCPs. Measured on the same 485 GCPs, whose pixels sit on the street label's axis and are collinear by construction, so any bend between adjacent GCPs is the model's own (sagitta = mapped midpoint's distance from the chord, ft):

| model | CV median | sagitta median | p90 | max |
|---|---|---|---|---|
| exact TPS (what allmaps fits) | 55.2 | 9.3 | 53 | 363 |
| smoothed TPS (the pipeline) | 53.0 | 1.3 | 6.7 | 97 |

So the annotation's targets are the smoothed spline's predictions at the GCP pixels rather than the raw OSM points; the exact spline allmaps fits through them reproduces the pipeline's surface. `thinPlateSpline.ts` ports the pipeline's spline. The system is badly scaled and numpy treats it as singular, so the pipeline's `lstsq` and this exact solve differ slightly: 0.65 ft median, 19 ft max on this sheet, documented in the test's tolerance.

## Notes

`/iiif-api/keymaps` now returns each key map's georef corners, whether it has a P(road) map, and absolute image-service URLs built from the request host, the way the annotation rewrite addresses page tiles. That matters in development: the Vite dev proxy does not forward `/iiif`, so a relative image URL 404s there while the pages' tiles work.

Verified live on New Orleans 1896 p119: the spline-warped P(road) key map renders, the annotation parses as one map with 485 GCPs, `k` cycles the underlay independently of `p`, and clicking still selects pages (the hit test works off page footprints, not the allmaps layers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

