### PR TITLE
Snap can match a page against the key map's P(road) map instead of OSM

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -148,6 +148,18 @@ export interface KeymapInfo {
   hasRegions: boolean;
   /** Whether a `raw/<stem>.georef.json` sidecar exists. */
   hasGeoref: boolean;
+  /** Whether a `raw/<stem>.roadprob.png` key-map P(road) map exists (#211). */
+  hasRoadprob: boolean;
+  /**
+   * The georef's four (lon, lat) corners of the raw sheet -- top-left,
+   * top-right, bottom-right, bottom-left -- when the georef has them. They
+   * place the key-map underlay.
+   */
+  corners?: [number, number][];
+  /** Absolute IIIF image service URL of the raw sheet (`.../raw/<stem>.jpg`), when present. */
+  imageService?: string;
+  /** Absolute IIIF image service URL of the key map's P(road) PNG, when present. */
+  roadprobService?: string;
 }
 
 /**

--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -13,6 +13,7 @@
 
 import type { Endpoint, GetEndpoint } from 'crosswalk/dist/api-spec';
 import type {
+  GeorefAnnotationPage,
   RewrittenAnnotationResponse,
   VolumeListResponse,
 } from './iiifAnnotations.ts';
@@ -92,6 +93,13 @@ export interface KeymapDetectionsResponse {
 /** Query naming a volume directory. */
 export interface VolumeQuery {
   volume: string;
+}
+
+/** Query naming the underlay image of one key map: its sheet or its P(road) map. */
+export interface KeymapAnnotationQuery {
+  volume: string;
+  stem: string;
+  image: 'sheet' | 'roadprob';
 }
 
 /** Response of GET /api/adjacency-volumes. */
@@ -245,6 +253,9 @@ export interface API {
   };
   '/iiif-api/keymaps': {
     get: GetEndpoint<KeymapsResponse, VolumeQuery>;
+  };
+  '/iiif-api/keymap-annotation': {
+    get: GetEndpoint<GeorefAnnotationPage, KeymapAnnotationQuery>;
   };
   '/api/images': {
     get: GetEndpoint<KeymapImagesResponse>;

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -6,6 +6,7 @@
  * (`/iiif-api/*`) on the shared crosswalk router.
  */
 
+import { existsSync } from 'fs';
 import { readdir, readFile, stat } from 'fs/promises';
 import { createRequire } from 'module';
 import { dirname, join } from 'path';
@@ -28,6 +29,7 @@ import {
   parseMissingTruthKeys,
 } from './compareTxt.ts';
 import { findVolumes, volumePages } from './adjacencyTruth.ts';
+import { keymapAnnotation } from './keymapAnnotation.ts';
 import { keymapInfos } from './keymapInfos.ts';
 import { runArtifactDir, runArtifactStems } from './runArtifacts.ts';
 import { withTiles } from './iiifAnnotations.ts';
@@ -426,5 +428,53 @@ export function registerIiifApi(
     return {
       keymaps: await keymapInfos(join(dataDir, volume, 'raw'), serviceBaseUrl),
     };
+  });
+
+  // One key map as a georeference annotation, for the underlay: the sheet or
+  // its P(road) map, warped by a thin-plate spline through the sheet's own
+  // GCPs -- the model keymap-snap places pages in (see keymapAnnotation).
+  router.get('/iiif-api/keymap-annotation', async (_params, request) => {
+    const { volume, stem, image } = request.query;
+    if (!isSafeVolume(volume) || !isSafeSegment(stem)) {
+      throw new HTTPError(400, `invalid key map: ${volume}/${stem}`);
+    }
+    if (image !== 'sheet' && image !== 'roadprob') {
+      throw new HTTPError(400, `invalid image: ${image}`);
+    }
+    const rawDir = join(dataDir, volume, 'raw');
+    let georef: unknown;
+    try {
+      georef = JSON.parse(
+        await readFile(join(rawDir, `${stem}.georef.json`), 'utf8'),
+      );
+    } catch {
+      throw new HTTPError(404, `no georef for key map ${volume}/${stem}`);
+    }
+    // The P(road) map is rendered in the sheet's own pixel frame, so one set
+    // of GCPs places either image.
+    const candidates =
+      image === 'roadprob'
+        ? [`${stem}.roadprob.png`]
+        : [`${stem}.jpg`, `${stem}.png`];
+    const file = candidates.find((name) => existsSync(join(rawDir, name)));
+    if (!file) {
+      throw new HTTPError(
+        404,
+        `no ${image} image for key map ${volume}/${stem}`,
+      );
+    }
+    const serviceUrl = `${request.protocol}://${request.get('host')}/iiif/${volume}/raw/${file}`;
+    const page = keymapAnnotation(
+      georef,
+      serviceUrl,
+      `keymap:${volume}/${stem}/${image}`,
+    );
+    if (!page) {
+      throw new HTTPError(
+        404,
+        `key map ${volume}/${stem} has no usable georeference`,
+      );
+    }
+    return page;
   });
 }

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -28,6 +28,7 @@ import {
   parseMissingTruthKeys,
 } from './compareTxt.ts';
 import { findVolumes, volumePages } from './adjacencyTruth.ts';
+import { keymapInfos } from './keymapInfos.ts';
 import { runArtifactDir, runArtifactStems } from './runArtifacts.ts';
 import { withTiles } from './iiifAnnotations.ts';
 import { isSafeSegment, isSafeVolume } from './volumePaths.ts';
@@ -415,29 +416,15 @@ export function registerIiifApi(
   });
 
   // A volume's key-map sheets and which visualization sidecars each has, so the viewer can link
-  // to them. Key maps are `raw/<stem>.keymap.json`; siblings <stem>.regions.panels.json and
-  // <stem>.georef.json are the region and georef views. ?volume=<dir> → { keymaps: [...] }.
+  // to them and draw the key-map underlay (see keymapInfos). ?volume=<dir> → { keymaps: [...] }.
   router.get('/iiif-api/keymaps', async (_params, request) => {
     const { volume } = request.query;
     if (!isSafeVolume(volume)) {
       throw new HTTPError(400, `invalid volume: ${volume}`);
     }
-    let files: string[];
-    try {
-      files = await readdir(join(dataDir, volume, 'raw'));
-    } catch {
-      return { keymaps: [] }; // no raw/ directory: volume has no key maps
-    }
-    const present = new Set(files);
-    const keymaps = files
-      .filter((file) => file.endsWith('.keymap.json'))
-      .map((file) => file.slice(0, -'.keymap.json'.length))
-      .sort()
-      .map((stem) => ({
-        stem,
-        hasRegions: present.has(`${stem}.regions.panels.json`),
-        hasGeoref: present.has(`${stem}.georef.json`),
-      }));
-    return { keymaps };
+    const serviceBaseUrl = `${request.protocol}://${request.get('host')}/iiif/${volume}/raw`;
+    return {
+      keymaps: await keymapInfos(join(dataDir, volume, 'raw'), serviceBaseUrl),
+    };
   });
 }

--- a/app/server/keymapAnnotation.test.ts
+++ b/app/server/keymapAnnotation.test.ts
@@ -3,6 +3,7 @@ import {
   consistentGcps,
   keymapAnnotation,
   MIN_KEYMAP_GCPS,
+  smoothedTargets,
   type KeymapGcp,
 } from './keymapAnnotation.ts';
 
@@ -79,6 +80,34 @@ describe('keymapAnnotation', () => {
       (item.target as unknown as { selector: { value: string } }).selector
         .value,
     ).toContain('points="0,0 6397,0 6397,7795 0,7795"');
+  });
+
+  it('hands allmaps the smoothed model targets, not the raw OSM points', () => {
+    // Noisy GCPs: the smoothed spline does not pass through them, so the
+    // annotation's targets differ from the inputs; an exact spline through
+    // the targets is then the pipeline's smoothed surface.
+    const noisy = inliers(40).map((gcp, i) => ({
+      ...gcp,
+      lat: gcp.lat + (i % 3 === 0 ? 0.0004 : 0),
+    }));
+    const page = keymapAnnotation(
+      { width: 6397, height: 7795, intersections: noisy },
+      SERVICE,
+      'id',
+    );
+    const body = page!.items[0].body as unknown as {
+      features: { geometry: { coordinates: number[] } }[];
+    };
+    const moved = body.features.filter(
+      (f, i) => Math.abs(f.geometry.coordinates[1] - noisy[i].lat) > 1e-6,
+    );
+    expect(moved.length).toBeGreaterThan(30);
+    // An affine field is left exactly alone, at any smoothing.
+    const clean = smoothedTargets(inliers(40));
+    clean.forEach(([lon, lat], i) => {
+      expect(lon).toBeCloseTo(inliers(40)[i].lon, 7);
+      expect(lat).toBeCloseTo(inliers(40)[i].lat, 7);
+    });
   });
 
   it('falls back to the affine corners when the sheet has too few GCPs', () => {

--- a/app/server/keymapAnnotation.test.ts
+++ b/app/server/keymapAnnotation.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  consistentGcps,
+  keymapAnnotation,
+  MIN_KEYMAP_GCPS,
+  type KeymapGcp,
+} from './keymapAnnotation.ts';
+
+const SERVICE = 'http://localhost:8182/iiif/new_orleans/raw/p0.jpg';
+const corners = [
+  [-90.1158, 29.9432],
+  [-90.0872, 29.9745],
+  [-90.0431, 29.9458],
+  [-90.0717, 29.9145],
+];
+
+// `count` inliers spread along a diagonal, far enough apart to stay distinct.
+function inliers(count: number): KeymapGcp[] {
+  return Array.from({ length: count }, (unused, i) => ({
+    x: 100 + i * 37,
+    y: 200 + i * 41,
+    lon: -90.1 + i * 0.001,
+    lat: 29.94 + i * 0.001,
+    inlier: true,
+  }));
+}
+
+function georefWith(count: number) {
+  return {
+    width: 6397,
+    height: 7795,
+    corners,
+    intersections: inliers(count),
+  };
+}
+
+describe('consistentGcps', () => {
+  it('keeps a pixel read once', () => {
+    expect(consistentGcps(inliers(3))).toHaveLength(3);
+  });
+
+  it('drops a whole group whose readings disagree beyond the conflict bar', () => {
+    const conflicting: KeymapGcp[] = [
+      { x: 10, y: 20, lon: -90.1, lat: 29.94 },
+      { x: 10, y: 20, lon: -90.09, lat: 29.94 }, // ~2900 ft away
+      { x: 30, y: 40, lon: -90.05, lat: 29.95 },
+    ];
+    expect(consistentGcps(conflicting).map((gcp) => gcp.x)).toEqual([30]);
+  });
+
+  it('keeps one reading of a group that agrees within the bar', () => {
+    const agreeing: KeymapGcp[] = [
+      { x: 10, y: 20, lon: -90.1, lat: 29.94 },
+      { x: 10, y: 20, lon: -90.10002, lat: 29.94001 }, // a few feet
+    ];
+    expect(consistentGcps(agreeing)).toHaveLength(1);
+  });
+});
+
+describe('keymapAnnotation', () => {
+  it('warps by thin-plate spline through the sheet own GCPs', () => {
+    const page = keymapAnnotation(georefWith(60), SERVICE, 'keymap-p0');
+    const item = page!.items[0];
+    const body = item.body as unknown as {
+      transformation: { type: string };
+      features: { properties: { resourceCoords: number[] } }[];
+    };
+    expect(body.transformation).toEqual({ type: 'thinPlateSpline' });
+    expect(body.features).toHaveLength(60);
+    expect(body.features[0].properties.resourceCoords).toEqual([100, 200]);
+    expect(item.target!.source).toEqual({
+      id: SERVICE,
+      type: 'ImageService3',
+      width: 6397,
+      height: 7795,
+    });
+    // The whole sheet is the mask: the key map is drawn margins and all.
+    expect(
+      (item.target as unknown as { selector: { value: string } }).selector
+        .value,
+    ).toContain('points="0,0 6397,0 6397,7795 0,7795"');
+  });
+
+  it('falls back to the affine corners when the sheet has too few GCPs', () => {
+    const page = keymapAnnotation(
+      georefWith(MIN_KEYMAP_GCPS - 1),
+      SERVICE,
+      'keymap-p0',
+    );
+    const body = page!.items[0].body as unknown as {
+      transformation: { type: string; options: { order: number } };
+      features: {
+        properties: { resourceCoords: number[] };
+        geometry: { coordinates: number[] };
+      }[];
+    };
+    expect(body.transformation).toEqual({
+      type: 'polynomial',
+      options: { order: 1 },
+    });
+    // Pixel corners in the georef's own order: TL, TR, BR, BL.
+    expect(body.features.map((f) => f.properties.resourceCoords)).toEqual([
+      [0, 0],
+      [6397, 0],
+      [6397, 7795],
+      [0, 7795],
+    ]);
+    expect(body.features[1].geometry.coordinates).toEqual(corners[1]);
+  });
+
+  it('is null without dimensions, or with too few GCPs and no corners', () => {
+    expect(keymapAnnotation({}, SERVICE, 'id')).toBeNull();
+    expect(
+      keymapAnnotation(
+        { width: 10, height: 10, intersections: [] },
+        SERVICE,
+        'id',
+      ),
+    ).toBeNull();
+  });
+});

--- a/app/server/keymapAnnotation.ts
+++ b/app/server/keymapAnnotation.ts
@@ -1,0 +1,180 @@
+/**
+ * A georeference annotation for a key map, warped the way keymap-snap warps it.
+ *
+ * The key map's shipped georef is a global affine, and its residuals against
+ * the sheet's own inlier intersections are large: 127 ft median on New Orleans
+ * 1896, 90 ft on Detroit. `mapsnap.keymap.snap.keymap_model` therefore models
+ * the sheet as a thin-plate spline through those same intersections, and that
+ * model -- not the affine -- is the frame every keymap-snap placement is
+ * measured in (#211). Drawing the sheet at its four affine corners would show
+ * the viewer something the pipeline does not use.
+ *
+ * So the underlay is served as a georeference annotation carrying the sheet's
+ * own GCPs with `transformation: thinPlateSpline`, which allmaps renders
+ * directly. The one difference from the pipeline is smoothing: allmaps
+ * interpolates the GCPs exactly while `keymap_model` smooths them
+ * (TPS_SMOOTHING). On the corpus that moves the median by ~2 ft.
+ */
+import type { GeorefAnnotationPage } from './iiifAnnotations.ts';
+
+/** One inlier intersection of a key-map georef: sheet pixel and its world point. */
+export interface KeymapGcp {
+  x: number;
+  y: number;
+  lon: number;
+  lat: number;
+  inlier?: boolean;
+}
+
+const M_PER_DEG_LAT = 110_540.0;
+const M_PER_DEG_LON_EQUATOR = 111_320.0;
+const FEET_PER_METRE = 3.28084;
+
+/**
+ * Two readings of one pixel further apart than this are a contradiction.
+ * Mirrors `mapsnap.keymap.snap.GCP_CONFLICT_FT`.
+ */
+export const GCP_CONFLICT_FT = 50.0;
+
+/**
+ * Fewest consistent GCPs that can constrain a warp; below it the sheet is
+ * drawn by its affine corners. Mirrors `road_prob.MIN_KEYMAP_INLIERS`.
+ */
+export const MIN_KEYMAP_GCPS = 25;
+
+/**
+ * Drop GCPs that put one key-map pixel in two different places.
+ *
+ * A port of `mapsnap.keymap.snap.consistent_gcps`: a pixel matched to two OSM
+ * intersections more than GCP_CONFLICT_FT apart is a contradiction the spline
+ * cannot resolve, and there is no evidence here for which reading is right, so
+ * the whole group goes.
+ */
+export function consistentGcps(inliers: KeymapGcp[]): KeymapGcp[] {
+  const groups = new Map<string, KeymapGcp[]>();
+  for (const gcp of inliers) {
+    const key = `${gcp.x.toFixed(1)},${gcp.y.toFixed(1)}`;
+    const group = groups.get(key);
+    if (group) group.push(gcp);
+    else groups.set(key, [gcp]);
+  }
+  const kept: KeymapGcp[] = [];
+  for (const readings of groups.values()) {
+    if (readings.length === 1) {
+      kept.push(readings[0]);
+      continue;
+    }
+    const lons = readings.map((r) => r.lon);
+    const lats = readings.map((r) => r.lat);
+    const lonScale =
+      M_PER_DEG_LON_EQUATOR * Math.cos((lats[0] * Math.PI) / 180);
+    const spread =
+      Math.hypot(
+        (Math.max(...lons) - Math.min(...lons)) * lonScale,
+        (Math.max(...lats) - Math.min(...lats)) * M_PER_DEG_LAT,
+      ) * FEET_PER_METRE;
+    if (spread <= GCP_CONFLICT_FT) kept.push(readings[0]);
+  }
+  return kept;
+}
+
+/** A georef document's four (lon, lat) corners, when it has them. */
+function corners(georef: unknown): [number, number][] | undefined {
+  const value = (georef as { corners?: unknown })?.corners;
+  if (!Array.isArray(value) || value.length !== 4) return undefined;
+  const points = value.map((corner) =>
+    Array.isArray(corner) &&
+    typeof corner[0] === 'number' &&
+    typeof corner[1] === 'number'
+      ? ([corner[0], corner[1]] as [number, number])
+      : null,
+  );
+  return points.every((point) => point !== null)
+    ? (points as [number, number][])
+    : undefined;
+}
+
+function feature(pixel: [number, number], world: [number, number]) {
+  return {
+    type: 'Feature' as const,
+    properties: { resourceCoords: pixel },
+    geometry: { type: 'Point' as const, coordinates: world },
+  };
+}
+
+/**
+ * A one-item georeference AnnotationPage placing a key-map image on the world.
+ *
+ * `serviceUrl` is the IIIF image service for the image to draw (the sheet or
+ * its P(road) map, which share the sheet's pixel frame, so the same GCPs place
+ * either). Uses a thin-plate spline through the sheet's consistent inlier
+ * intersections when there are enough of them, and the affine corners
+ * otherwise; the returned `transformation` says which.
+ */
+export function keymapAnnotation(
+  georef: unknown,
+  serviceUrl: string,
+  annotationId: string,
+): GeorefAnnotationPage | null {
+  const document = georef as {
+    width?: number;
+    height?: number;
+    intersections?: KeymapGcp[];
+  };
+  const width = document?.width;
+  const height = document?.height;
+  if (!width || !height) return null;
+
+  const gcps = consistentGcps(
+    (document.intersections ?? []).filter((point) => point.inlier),
+  );
+  let transformation: { type: string; options?: { order: number } };
+  let features: ReturnType<typeof feature>[];
+  if (gcps.length >= MIN_KEYMAP_GCPS) {
+    transformation = { type: 'thinPlateSpline' };
+    features = gcps.map((gcp) => feature([gcp.x, gcp.y], [gcp.lon, gcp.lat]));
+  } else {
+    const ring = corners(georef);
+    if (!ring) return null;
+    transformation = { type: 'polynomial', options: { order: 1 } };
+    const pixels: [number, number][] = [
+      [0, 0],
+      [width, 0],
+      [width, height],
+      [0, height],
+    ];
+    features = pixels.map((pixel, index) => feature(pixel, ring[index]));
+  }
+
+  return {
+    '@context': 'http://iiif.io/api/extension/georeference/1/context.json',
+    type: 'AnnotationPage',
+    items: [
+      {
+        id: annotationId,
+        type: 'Annotation',
+        motivation: 'georeferencing',
+        target: {
+          type: 'SpecificResource',
+          source: {
+            id: serviceUrl,
+            type: 'ImageService3',
+            width,
+            height,
+          },
+          // Required by the georeference-annotation schema, and the mask
+          // allmaps clips the image to: the whole sheet, margins included.
+          selector: {
+            type: 'SvgSelector',
+            value: `<svg width="${width}" height="${height}"><polygon points="0,0 ${width},0 ${width},${height} 0,${height}" /></svg>`,
+          },
+        },
+        body: {
+          type: 'FeatureCollection',
+          transformation,
+          features,
+        },
+      },
+    ],
+  } as unknown as GeorefAnnotationPage;
+}

--- a/app/server/keymapAnnotation.ts
+++ b/app/server/keymapAnnotation.ts
@@ -11,11 +11,19 @@
  *
  * So the underlay is served as a georeference annotation carrying the sheet's
  * own GCPs with `transformation: thinPlateSpline`, which allmaps renders
- * directly. The one difference from the pipeline is smoothing: allmaps
- * interpolates the GCPs exactly while `keymap_model` smooths them
- * (TPS_SMOOTHING). On the corpus that moves the median by ~2 ft.
+ * directly. allmaps interpolates exactly, while `keymap_model` smooths
+ * (TPS_SMOOTHING), and that smoothing is what keeps straight streets straight
+ * between GCPs (see thinPlateSpline.ts). So the annotation's targets are not
+ * the raw OSM points but the smoothed spline's prediction at each GCP pixel:
+ * the exact spline allmaps fits through those reproduces the pipeline's
+ * surface (measured 0.0 ft apart on New Orleans 1896).
  */
 import type { GeorefAnnotationPage } from './iiifAnnotations.ts';
+import {
+  thinPlateSpline,
+  TPS_SMOOTHING,
+  type Point2,
+} from './thinPlateSpline.ts';
 
 /** One inlier intersection of a key-map georef: sheet pixel and its world point. */
 export interface KeymapGcp {
@@ -94,6 +102,33 @@ function corners(georef: unknown): [number, number][] | undefined {
     : undefined;
 }
 
+/**
+ * The smoothed key-map model's world point at each GCP pixel, in the frame
+ * `keymap_model` uses: metres from the first GCP, with the longitude scale at
+ * the GCPs' mean latitude.
+ */
+export function smoothedTargets(
+  gcps: KeymapGcp[],
+  smoothing: number = TPS_SMOOTHING,
+): [number, number][] {
+  const origin = [gcps[0].lon, gcps[0].lat];
+  const meanLat = gcps.reduce((sum, gcp) => sum + gcp.lat, 0) / gcps.length;
+  const lonScale = M_PER_DEG_LON_EQUATOR * Math.cos((meanLat * Math.PI) / 180);
+  const pixels: Point2[] = gcps.map((gcp) => [gcp.x, gcp.y]);
+  const metres: Point2[] = gcps.map((gcp) => [
+    (gcp.lon - origin[0]) * lonScale,
+    (gcp.lat - origin[1]) * M_PER_DEG_LAT,
+  ]);
+  return thinPlateSpline(
+    pixels,
+    metres,
+    smoothing,
+  )(pixels).map(([x, y]) => [
+    x / lonScale + origin[0],
+    y / M_PER_DEG_LAT + origin[1],
+  ]);
+}
+
 function feature(pixel: [number, number], world: [number, number]) {
   return {
     type: 'Feature' as const,
@@ -132,7 +167,8 @@ export function keymapAnnotation(
   let features: ReturnType<typeof feature>[];
   if (gcps.length >= MIN_KEYMAP_GCPS) {
     transformation = { type: 'thinPlateSpline' };
-    features = gcps.map((gcp) => feature([gcp.x, gcp.y], [gcp.lon, gcp.lat]));
+    const targets = smoothedTargets(gcps);
+    features = gcps.map((gcp, i) => feature([gcp.x, gcp.y], targets[i]));
   } else {
     const ring = corners(georef);
     if (!ring) return null;

--- a/app/server/keymapInfos.test.ts
+++ b/app/server/keymapInfos.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, mkdtemp, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { georefCorners, keymapInfos } from './keymapInfos.ts';
+
+const corners = [
+  [-90.1158, 29.9432],
+  [-90.0872, 29.9745],
+  [-90.0431, 29.9458],
+  [-90.0717, 29.9145],
+];
+
+let rawDir: string;
+const SERVICE = 'http://localhost:8182/iiif/new_orleans/raw';
+
+// A raw/ directory shaped like New Orleans 1896's: one key map with every
+// sidecar, a second (Los Angeles-style pb) with a georef but no P(road) map,
+// and a third with a georef whose corners are malformed.
+beforeAll(async () => {
+  rawDir = await mkdtemp(join(tmpdir(), 'keymap-infos-'));
+  const write = (name: string, contents = '{}') =>
+    writeFile(join(rawDir, name), contents);
+  await write('p0.jpg', 'jpeg');
+  await write('p0.keymap.json');
+  await write('p0.regions.panels.json');
+  await write('p0.georef.json', JSON.stringify({ corners, width: 6397 }));
+  await write('p0.roadprob.png', 'png');
+  await write('pb.png', 'png');
+  await write('pb.keymap.json');
+  await write('pb.georef.json', JSON.stringify({ corners }));
+  await write('pz.keymap.json');
+  await write(
+    'pz.georef.json',
+    JSON.stringify({ corners: corners.slice(0, 3) }),
+  );
+  await write('p7.georef.json', JSON.stringify({ corners })); // not a key map
+  await mkdir(join(rawDir, 'truth'));
+});
+
+describe('keymapInfos', () => {
+  it('lists key maps with their sidecars and georef corners', async () => {
+    const infos = await keymapInfos(rawDir, SERVICE);
+    expect(infos.map((info) => info.stem)).toEqual(['p0', 'pb', 'pz']);
+    expect(infos[0]).toEqual({
+      stem: 'p0',
+      hasRegions: true,
+      hasGeoref: true,
+      hasRoadprob: true,
+      corners,
+      imageService: `${SERVICE}/p0.jpg`,
+      roadprobService: `${SERVICE}/p0.roadprob.png`,
+    });
+    // A PNG key map (Queens) is addressed as one; no P(road) map, no service.
+    expect(infos[1]).toEqual({
+      stem: 'pb',
+      hasRegions: false,
+      hasGeoref: true,
+      hasRoadprob: false,
+      corners,
+      imageService: `${SERVICE}/pb.png`,
+    });
+  });
+
+  it('omits corners from a georef that lacks four points', async () => {
+    const infos = await keymapInfos(rawDir, SERVICE);
+    expect(infos[2].hasGeoref).toBe(true);
+    expect(infos[2].corners).toBeUndefined();
+  });
+
+  it('is empty for a volume without a raw directory', async () => {
+    expect(await keymapInfos(join(rawDir, 'missing'), SERVICE)).toEqual([]);
+  });
+});
+
+describe('georefCorners', () => {
+  it('accepts four finite lon/lat pairs and nothing else', () => {
+    expect(georefCorners({ corners })).toEqual(corners);
+    expect(
+      georefCorners({
+        corners: [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+        ],
+      }),
+    ).toBeUndefined();
+    expect(
+      georefCorners({ corners: [[1, 2], [3, 4], [5, 6], [7]] }),
+    ).toBeUndefined();
+    expect(
+      georefCorners({
+        corners: [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+          ['7', 8],
+        ],
+      }),
+    ).toBeUndefined();
+    expect(georefCorners({})).toBeUndefined();
+    expect(georefCorners(null)).toBeUndefined();
+  });
+});

--- a/app/server/keymapInfos.ts
+++ b/app/server/keymapInfos.ts
@@ -1,0 +1,88 @@
+/**
+ * A volume's key-map sheets and the sidecars the viewer can use for each.
+ *
+ * Key maps are `raw/<stem>.keymap.json`. Siblings: `<stem>.regions.panels.json`
+ * (region view), `<stem>.georef.json` (the key map's own georeference, whose
+ * `corners` place the sheet on the map) and `<stem>.roadprob.png` (the key
+ * map's P(road) map, #211). The corners are what the key-map underlay draws
+ * the sheet, or its P(road) map, with.
+ */
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+import type { KeymapInfo } from './api.ts';
+
+/** The four (lon, lat) corners of a georef document, or undefined if malformed. */
+export function georefCorners(doc: unknown): [number, number][] | undefined {
+  const corners = (doc as { corners?: unknown })?.corners;
+  if (!Array.isArray(corners) || corners.length !== 4) return undefined;
+  const points: [number, number][] = [];
+  for (const corner of corners) {
+    if (
+      !Array.isArray(corner) ||
+      corner.length < 2 ||
+      typeof corner[0] !== 'number' ||
+      typeof corner[1] !== 'number' ||
+      !Number.isFinite(corner[0]) ||
+      !Number.isFinite(corner[1])
+    ) {
+      return undefined;
+    }
+    points.push([corner[0], corner[1]]);
+  }
+  return points;
+}
+
+/**
+ * Key-map sheets under `rawDir`, sorted by stem, with their sidecars.
+ *
+ * `serviceBaseUrl` is the IIIF image service root for the raw directory
+ * (`.../iiif/<volume>/raw`); each key map's sheet and P(road) map are
+ * addressed under it as absolute URLs, the way the annotation rewrite
+ * addresses page tiles, so the viewer reaches the API server directly in
+ * development too (the Vite proxy does not forward `/iiif`).
+ *
+ * Empty when there is no raw/ directory: the volume has no key maps.
+ */
+export async function keymapInfos(
+  rawDir: string,
+  serviceBaseUrl: string,
+): Promise<KeymapInfo[]> {
+  let files: string[];
+  try {
+    files = await readdir(rawDir);
+  } catch {
+    return [];
+  }
+  const present = new Set(files);
+  const infos: KeymapInfo[] = [];
+  for (const file of files.filter((f) => f.endsWith('.keymap.json')).sort()) {
+    const stem = file.slice(0, -'.keymap.json'.length);
+    const hasGeoref = present.has(`${stem}.georef.json`);
+    let corners: [number, number][] | undefined;
+    if (hasGeoref) {
+      try {
+        corners = georefCorners(
+          JSON.parse(
+            await readFile(join(rawDir, `${stem}.georef.json`), 'utf8'),
+          ),
+        );
+      } catch {
+        corners = undefined;
+      }
+    }
+    const image = ['jpg', 'png'].find((ext) => present.has(`${stem}.${ext}`));
+    const hasRoadprob = present.has(`${stem}.roadprob.png`);
+    infos.push({
+      stem,
+      hasRegions: present.has(`${stem}.regions.panels.json`),
+      hasGeoref,
+      hasRoadprob,
+      ...(corners ? { corners } : {}),
+      ...(image ? { imageService: `${serviceBaseUrl}/${stem}.${image}` } : {}),
+      ...(hasRoadprob
+        ? { roadprobService: `${serviceBaseUrl}/${stem}.roadprob.png` }
+        : {}),
+    });
+  }
+  return infos;
+}

--- a/app/server/thinPlateSpline.test.ts
+++ b/app/server/thinPlateSpline.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  solveLinear,
+  thinPlateSpline,
+  type Point2,
+} from './thinPlateSpline.ts';
+
+// Eight noisy GCPs and three query points, with the Python
+// mapsnap.keymap.snap.thin_plate_spline evaluated on them (rng seed 7).
+const SRC: Point2[] = [
+  [3125.5, 4486.1],
+  [3878.4, 1126.0],
+  [1500.8, 4367.8],
+  [26.3, 4106.1],
+  [3985.3, 2339.7],
+  [1515.2, 1392.1],
+  [1274.3, 2225.4],
+  [2522.7, 2767.5],
+];
+const DST: Point2[] = [
+  [1927.75, -2921.73],
+  [2555.77, -649.13],
+  [765.34, -2909.17],
+  [-221.88, -2774.56],
+  [2705.53, -1402.95],
+  [853.95, -903.19],
+  [800.08, -1442.76],
+  [1563.38, -1784.43],
+];
+const Q: Point2[] = [
+  [1200.0, 2500.0],
+  [4000.0, 800.0],
+  [2600.0, 4100.0],
+];
+
+function close(actual: Point2[], expected: number[][], digits: number) {
+  actual.forEach((point, i) => {
+    expect(point[0]).toBeCloseTo(expected[i][0], digits);
+    expect(point[1]).toBeCloseTo(expected[i][1], digits);
+  });
+}
+
+// The spline system is badly scaled (kernel entries ~1e8 against a [1, x, y]
+// block), so numpy reports it as numerically singular (cond ~1e17). The
+// pipeline solves it with lstsq, which truncates the near-null direction;
+// this port solves it exactly, matching numpy.linalg.solve to every digit.
+// The two agree at the source points and differ elsewhere by up to ~2.3
+// units on this eight-point toy (numpy's own solve-vs-lstsq gap); on New
+// Orleans 1896's 485 GCPs the route's targets sit 0.65 ft median / 19 ft max
+// from the pipeline's model, against a ~50 ft model error.
+const LSTSQ_TOLERANCE = 3.0;
+function near(actual: Point2[], expected: number[][]) {
+  actual.forEach((point, i) => {
+    expect(Math.abs(point[0] - expected[i][0])).toBeLessThan(LSTSQ_TOLERANCE);
+    expect(Math.abs(point[1] - expected[i][1])).toBeLessThan(LSTSQ_TOLERANCE);
+  });
+}
+
+describe('thinPlateSpline', () => {
+  it('matches numpy.linalg.solve when barely smoothed, and interpolates', () => {
+    const spline = thinPlateSpline(SRC, DST, 1e-9);
+    close(
+      spline(Q),
+      [
+        [746.79303, -1629.39961],
+        [2632.83709, -435.08416],
+        [1559.90509, -2684.59378],
+      ],
+      2,
+    );
+    // The pipeline's lstsq answer is within the truncation tolerance.
+    near(spline(Q), [
+      [747.1522, -1629.1677],
+      [2630.566, -436.5506],
+      [1561.2887, -2683.7004],
+    ]);
+    // Interpolates its own points.
+    close(spline(SRC), DST, 3);
+  });
+
+  it('matches numpy.linalg.solve at the pipeline smoothing', () => {
+    const spline = thinPlateSpline(SRC, DST, 1e6);
+    close(
+      spline(Q),
+      [
+        [703.86394, -1638.28134],
+        [2647.63965, -425.65723],
+        [1569.485, -2680.94141],
+      ],
+      2,
+    );
+    near(spline(Q), [
+      [704.6595, -1637.6081],
+      [2645.4303, -427.5268],
+      [1570.5464, -2680.0432],
+    ]);
+    // Smoothing trades interpolation for a flatter surface: the GCPs no
+    // longer pass through exactly.
+    const [x] = spline([SRC[0]])[0];
+    expect(Math.abs(x - DST[0][0])).toBeGreaterThan(1);
+  });
+
+  it('reproduces an affine at any smoothing (it is in the bending null space)', () => {
+    const affine = (p: Point2): Point2 => [
+      3 + 0.7 * p[0] - 0.1 * p[1],
+      -8 - 0.05 * p[0] - 0.6 * p[1],
+    ];
+    for (const smoothing of [0, 1e6]) {
+      const spline = thinPlateSpline(SRC, SRC.map(affine), smoothing);
+      close(spline(Q), Q.map(affine), 4);
+    }
+  });
+});
+
+describe('solveLinear', () => {
+  it('solves a small system with pivoting', () => {
+    const x = solveLinear(
+      [
+        [0, 2, 1],
+        [1, 1, 1],
+        [2, 0, 3],
+      ],
+      [[5], [6], [13]],
+    );
+    // x = [2, 1, 3]
+    expect(x.map((row) => row[0])).toEqual(
+      [2, 1, 3].map((v) => expect.closeTo(v, 9)),
+    );
+  });
+});

--- a/app/server/thinPlateSpline.ts
+++ b/app/server/thinPlateSpline.ts
@@ -1,0 +1,109 @@
+/**
+ * Smoothed thin-plate spline, a port of `mapsnap.keymap.snap.thin_plate_spline`.
+ *
+ * The key-map model keymap-snap places pages in is a spline through the
+ * sheet's inlier intersections with a large smoothing term (TPS_SMOOTHING),
+ * which is what keeps straight streets straight between GCPs: on New Orleans
+ * 1896 the exactly-interpolating spline bends a street's midpoint 9 ft off its
+ * chord (median; 53 ft at p90) while the smoothed one bends it 1.3 ft (6.7 at
+ * p90) at the same held-out accuracy. allmaps only interpolates exactly, so to
+ * draw the pipeline's surface the debugger evaluates this spline at the GCP
+ * pixels and hands allmaps the smoothed targets; the exact spline through
+ * those reproduces the smoothed surface (measured: 0.0 ft apart).
+ *
+ * Same kernel, system and smoothing as the Python: U(r²) = ½ r² ln r², the
+ * smoothing added to the kernel's diagonal, an affine part [1, x, y].
+ */
+
+export type Point2 = [number, number];
+
+/** Mirrors `mapsnap.keymap.snap.TPS_SMOOTHING`. */
+export const TPS_SMOOTHING = 1e6;
+
+// ½ r² ln r² for r² > 0, and 0 at r = 0 (the kernel's removable singularity).
+function kernel(squared: number): number {
+  return squared > 0 ? squared * 0.5 * Math.log(squared) : 0;
+}
+
+/**
+ * Solve A x = B for a square A by Gaussian elimination with partial pivoting.
+ * B may have several columns; both are overwritten. Sized for a few hundred
+ * GCPs (a 500x500 system is a few milliseconds).
+ */
+export function solveLinear(a: number[][], b: number[][]): number[][] {
+  const n = a.length;
+  const width = b[0]?.length ?? 0;
+  for (let col = 0; col < n; col++) {
+    let pivot = col;
+    for (let row = col + 1; row < n; row++) {
+      if (Math.abs(a[row][col]) > Math.abs(a[pivot][col])) pivot = row;
+    }
+    if (a[pivot][col] === 0) throw new Error('singular spline system');
+    if (pivot !== col) {
+      [a[col], a[pivot]] = [a[pivot], a[col]];
+      [b[col], b[pivot]] = [b[pivot], b[col]];
+    }
+    for (let row = col + 1; row < n; row++) {
+      const factor = a[row][col] / a[col][col];
+      if (factor === 0) continue;
+      for (let k = col; k < n; k++) a[row][k] -= factor * a[col][k];
+      for (let k = 0; k < width; k++) b[row][k] -= factor * b[col][k];
+    }
+  }
+  const x: number[][] = Array.from({ length: n }, () => Array(width).fill(0));
+  for (let row = n - 1; row >= 0; row--) {
+    for (let k = 0; k < width; k++) {
+      let sum = b[row][k];
+      for (let col = row + 1; col < n; col++) sum -= a[row][col] * x[col][k];
+      x[row][k] = sum / a[row][row];
+    }
+  }
+  return x;
+}
+
+/**
+ * The smoothed spline mapping `source` points onto `destination`, as a
+ * function of query points. With smoothing 0 it interpolates exactly.
+ */
+export function thinPlateSpline(
+  source: Point2[],
+  destination: Point2[],
+  smoothing: number = TPS_SMOOTHING,
+): (queries: Point2[]) => Point2[] {
+  const count = source.length;
+  const size = count + 3;
+  const system: number[][] = Array.from({ length: size }, () =>
+    Array(size).fill(0),
+  );
+  for (let i = 0; i < count; i++) {
+    for (let j = 0; j < count; j++) {
+      const dx = source[i][0] - source[j][0];
+      const dy = source[i][1] - source[j][1];
+      system[i][j] = kernel(dx * dx + dy * dy) + (i === j ? smoothing : 0);
+    }
+    const poly = [1, source[i][0], source[i][1]];
+    for (let k = 0; k < 3; k++) {
+      system[i][count + k] = poly[k];
+      system[count + k][i] = poly[k];
+    }
+  }
+  const rhs: number[][] = Array.from({ length: size }, (unused, i) =>
+    i < count ? [destination[i][0], destination[i][1]] : [0, 0],
+  );
+  const solution = solveLinear(system, rhs);
+  const weights = solution.slice(0, count);
+  const affine = solution.slice(count);
+  return (queries) =>
+    queries.map(([x, y]) => {
+      let outX = affine[0][0] + affine[1][0] * x + affine[2][0] * y;
+      let outY = affine[0][1] + affine[1][1] * x + affine[2][1] * y;
+      for (let i = 0; i < count; i++) {
+        const dx = x - source[i][0];
+        const dy = y - source[i][1];
+        const value = kernel(dx * dx + dy * dy);
+        outX += value * weights[i][0];
+        outY += value * weights[i][1];
+      }
+      return [outX, outY];
+    });
+}

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -48,6 +48,8 @@ interface VolumeMapProps {
    * beneath the pages, as the sheet or as its P(road) map. Empty removes them.
    */
   keymapUnderlays: KeymapUnderlay[];
+  /** Key-map underlay opacity in [0, 1], independent of the pages'. */
+  keymapOpacity: number;
   /**
    * Show only the selected page's warped image, hiding every other sheet.
    * No-op while nothing is selected -- isolating "nothing" would blank the map.
@@ -146,6 +148,7 @@ export function VolumeMap(props: VolumeMapProps) {
     showMissing,
     snapOverlay,
     keymapUnderlays,
+    keymapOpacity,
     isolateSelected,
     selectedItemIndex,
     onSelectPage,
@@ -157,6 +160,9 @@ export function VolumeMap(props: VolumeMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const layerRef = useRef<WarpedMapLayer | null>(null);
+  const keymapLayerRef = useRef<WarpedMapLayer | null>(null);
+  // Read inside the underlay effect without making it depend on the value.
+  const keymapOpacityRef = useRef(0);
 
   // Panel polygons per parent stem, from the volume's pN.panels.json (25%-jpg
   // frame). null = fetched and absent. The SvgSelector is split INTERSECT
@@ -267,6 +273,13 @@ export function VolumeMap(props: VolumeMapProps) {
       'top-left',
     );
     map.on('load', () => {
+      // Added first, so it sits beneath the pages layer: the key map is the
+      // ground the pages are read against, never over them.
+      const keymapLayer = new WarpedMapLayer({
+        layerId: 'keymap-underlay-layer',
+      });
+      map.addLayer(keymapLayer);
+      keymapLayerRef.current = keymapLayer;
       const layer = new WarpedMapLayer();
       map.addLayer(layer);
       map.addSource('rmse-fills', {
@@ -486,57 +499,55 @@ export function VolumeMap(props: VolumeMapProps) {
       map.remove();
       mapRef.current = null;
       layerRef.current = null;
+      keymapLayerRef.current = null;
       setMapReady(false);
     };
   }, []);
 
-  // The key-map underlay (#211): each georeferenced key map as an image
-  // source at its corner coordinates, inserted BENEATH the pages layer so the
-  // pages (dimmed with the opacity slider) can be read against it. Reconciled
-  // against the previous set: a mode switch swaps the image in place.
-  const underlayIdsRef = useRef<Set<string>>(new Set());
+  // The key-map underlay (#211): each key map as its own georeference
+  // annotation on a second WarpedMapLayer, so allmaps applies the thin-plate
+  // spline through the sheet's GCPs -- the model keymap-snap places pages in.
+  // The layer sits BENEATH the pages layer, so the pages (dimmed with their
+  // own opacity slider) can be read against it.
   useEffect(() => {
-    const map = mapRef.current;
-    const pagesLayer = layerRef.current;
-    if (!map || !pagesLayer || !mapReady) return;
-    const wanted = new Map(
-      keymapUnderlays.map((underlay) => [
-        `keymap-underlay-${underlay.id}`,
-        underlay,
-      ]),
-    );
-    for (const id of [...underlayIdsRef.current]) {
-      if (wanted.has(id)) continue;
-      if (map.getLayer(id)) map.removeLayer(id);
-      if (map.getSource(id)) map.removeSource(id);
-      underlayIdsRef.current.delete(id);
-    }
-    for (const [id, underlay] of wanted) {
-      const existing = map.getSource(id) as maplibregl.ImageSource | undefined;
-      if (existing) {
-        existing.updateImage({
-          url: underlay.url,
-          coordinates: underlay.corners,
+    const layer = keymapLayerRef.current;
+    if (!layer || !mapReady) return;
+    layer.clear();
+    let cancelled = false;
+    for (const underlay of keymapUnderlays) {
+      layer
+        .addGeoreferenceAnnotationByUrl(underlay.annotationUrl)
+        .then((results) => {
+          if (cancelled) return;
+          for (const result of results) {
+            if (result instanceof Error) {
+              console.error(`key-map underlay ${underlay.id}`, result);
+            }
+          }
+          // A newly added map starts at full opacity, so reapply the current
+          // value rather than waiting for the next slider move.
+          layer.setLayerOptions(
+            { opacity: keymapOpacityRef.current },
+            { animate: false },
+          );
+        })
+        .catch((error: unknown) => {
+          if (!cancelled)
+            console.error(`key-map underlay ${underlay.id}`, error);
         });
-        continue;
-      }
-      map.addSource(id, {
-        type: 'image',
-        url: underlay.url,
-        coordinates: underlay.corners,
-      });
-      map.addLayer(
-        {
-          id,
-          type: 'raster',
-          source: id,
-          paint: { 'raster-opacity': 1, 'raster-fade-duration': 0 },
-        },
-        pagesLayer.id,
-      );
-      underlayIdsRef.current.add(id);
     }
+    return () => {
+      cancelled = true;
+    };
   }, [mapReady, keymapUnderlays]);
+
+  // Key-map opacity, independent of the pages'.
+  useEffect(() => {
+    keymapOpacityRef.current = keymapOpacity;
+    const layer = keymapLayerRef.current;
+    if (!layer || !mapReady) return;
+    layer.setLayerOptions({ opacity: keymapOpacity }, { animate: false });
+  }, [keymapOpacity, mapReady]);
 
   // The snap-debugger pose overlay (#325): the selected candidate's P(road)
   // map as an image source at the pose's corner coordinates. Added/updated/

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { WarpedMapLayer } from '@allmaps/maplibre';
+import type { KeymapUnderlay } from '../iiif/underlay';
 import type { FeatureCollection } from 'geojson';
 import { pointInPolygon } from '../geometry';
 import { hasFootprint, type PageGeo } from '../iiif/pages';
@@ -42,6 +43,11 @@ interface VolumeMapProps {
       [number, number],
     ];
   } | null;
+  /**
+   * The key-map underlay (#211): the volume's georeferenced key map(s) drawn
+   * beneath the pages, as the sheet or as its P(road) map. Empty removes them.
+   */
+  keymapUnderlays: KeymapUnderlay[];
   /**
    * Show only the selected page's warped image, hiding every other sheet.
    * No-op while nothing is selected -- isolating "nothing" would blank the map.
@@ -139,6 +145,7 @@ export function VolumeMap(props: VolumeMapProps) {
     truthPages,
     showMissing,
     snapOverlay,
+    keymapUnderlays,
     isolateSelected,
     selectedItemIndex,
     onSelectPage,
@@ -482,6 +489,54 @@ export function VolumeMap(props: VolumeMapProps) {
       setMapReady(false);
     };
   }, []);
+
+  // The key-map underlay (#211): each georeferenced key map as an image
+  // source at its corner coordinates, inserted BENEATH the pages layer so the
+  // pages (dimmed with the opacity slider) can be read against it. Reconciled
+  // against the previous set: a mode switch swaps the image in place.
+  const underlayIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const map = mapRef.current;
+    const pagesLayer = layerRef.current;
+    if (!map || !pagesLayer || !mapReady) return;
+    const wanted = new Map(
+      keymapUnderlays.map((underlay) => [
+        `keymap-underlay-${underlay.id}`,
+        underlay,
+      ]),
+    );
+    for (const id of [...underlayIdsRef.current]) {
+      if (wanted.has(id)) continue;
+      if (map.getLayer(id)) map.removeLayer(id);
+      if (map.getSource(id)) map.removeSource(id);
+      underlayIdsRef.current.delete(id);
+    }
+    for (const [id, underlay] of wanted) {
+      const existing = map.getSource(id) as maplibregl.ImageSource | undefined;
+      if (existing) {
+        existing.updateImage({
+          url: underlay.url,
+          coordinates: underlay.corners,
+        });
+        continue;
+      }
+      map.addSource(id, {
+        type: 'image',
+        url: underlay.url,
+        coordinates: underlay.corners,
+      });
+      map.addLayer(
+        {
+          id,
+          type: 'raster',
+          source: id,
+          paint: { 'raster-opacity': 1, 'raster-fade-duration': 0 },
+        },
+        pagesLayer.id,
+      );
+      underlayIdsRef.current.add(id);
+    }
+  }, [mapReady, keymapUnderlays]);
 
   // The snap-debugger pose overlay (#325): the selected candidate's P(road)
   // map as an image source at the pose's corner coordinates. Added/updated/

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -1,4 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
+import {
+  keymapUnderlays,
+  underlayFromParam,
+  underlayParam,
+  type KeymapUnderlayMode,
+} from '../iiif/underlay';
 import type {
   GeorefAnnotationPage,
   SkippedItem,
@@ -101,6 +107,10 @@ export function VolumeViewer() {
   );
   const [isolateSelected, setIsolateSelected] = useState(
     () => initialParams.get('only') === '1',
+  );
+  // The key-map underlay (#211): off, the sheet, or its P(road) map.
+  const [underlayMode, setUnderlayMode] = useState<KeymapUnderlayMode>(() =>
+    underlayFromParam(initialParams.get('underlay')),
   );
   const [error, setError] = useState<string | null>(null);
   // Selection is tracked by page stem (stable across annotation files, unlike the item index).
@@ -408,6 +418,10 @@ export function VolumeViewer() {
       ),
     };
   }, [snapOpen, snapRecord, snapSelected, volumeName]);
+  const underlays = useMemo(
+    () => keymapUnderlays(keymaps, underlayMode),
+    [keymaps, underlayMode],
+  );
   const selectedIsMissing =
     selectedPage !== null &&
     selectedItemIndex !== null &&
@@ -434,6 +448,7 @@ export function VolumeViewer() {
       adj: showAdjacency ? '1' : null,
       osm: showOsmRelation ? null : '0',
       only: isolateSelected ? '1' : null,
+      underlay: underlayParam(underlayMode),
     });
   }, [
     selectedStem,
@@ -442,6 +457,7 @@ export function VolumeViewer() {
     showAdjacency,
     showOsmRelation,
     isolateSelected,
+    underlayMode,
   ]);
 
   function selectVolume(name: string): void {
@@ -565,6 +581,37 @@ export function VolumeViewer() {
               : 'OSM boundary'}
           </label>
         )}
+        {keymaps.some((keymap) => keymap.corners) && (
+          <label
+            className="rmse-color-control"
+            title="Draw the volume's georeferenced key map beneath the pages (#211). Dim the pages with the opacity slider to read them against it."
+          >
+            <input
+              type="checkbox"
+              checked={underlayMode !== 'off'}
+              onChange={(e) =>
+                setUnderlayMode(e.target.checked ? 'image' : 'off')
+              }
+            />
+            Key map
+          </label>
+        )}
+        {keymaps.some((keymap) => keymap.corners && keymap.hasRoadprob) && (
+          <label
+            className="rmse-color-control"
+            title="Show the key map's P(road) map (raw/<stem>.roadprob.png) in place of the sheet: what a key-map snap would match against."
+          >
+            <input
+              type="checkbox"
+              checked={underlayMode === 'roadprob'}
+              disabled={underlayMode === 'off'}
+              onChange={(e) =>
+                setUnderlayMode(e.target.checked ? 'roadprob' : 'image')
+              }
+            />
+            as P(road)
+          </label>
+        )}
         <div className="opacity-control">
           <label htmlFor="iiif-opacity-slider">Opacity</label>
           <input
@@ -595,6 +642,7 @@ export function VolumeViewer() {
         <div className="volume-map-slot" aria-hidden={debugView !== null}>
           <VolumeMap
             snapOverlay={snapOverlay}
+            keymapUnderlays={underlays}
             annotation={annotation}
             pages={pages}
             missingPages={missingPages}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -274,6 +274,9 @@ export function VolumeViewer() {
       .catch(() => {
         if (!cancelled) setOsmRelation(null);
       });
+    // Drop the previous volume's key maps now, or the underlay briefly asks
+    // for the new volume's key map by the old volume's stem.
+    setKeymaps([]);
     fetchKeymaps(volumeName)
       .then((list) => {
         if (!cancelled) setKeymaps(list);
@@ -440,19 +443,20 @@ export function VolumeViewer() {
   // stays loaded and opacity is only opacity. Clearing the allmaps layer at 0
   // and re-adding the same map at 50 left it blank until a zoom: the clear
   // aborts the in-flight tile fetches the re-add immediately repeats.
-  const [underlayArmed, setUnderlayArmed] = useState(false);
+  // The volume the underlay is armed for: the slider was above 0 while that
+  // volume was selected. Keyed by volume, so switching volumes with the
+  // slider already up arms the new one at once, and a slider parked at 0
+  // does not.
+  const [armedVolume, setArmedVolume] = useState<string | undefined>();
   useEffect(() => {
-    setUnderlayArmed(false);
-  }, [volumeName]);
-  useEffect(() => {
-    if (keymapOpacity > 0) setUnderlayArmed(true);
-  }, [keymapOpacity]);
+    if (keymapOpacity > 0 && volumeName) setArmedVolume(volumeName);
+  }, [keymapOpacity, volumeName]);
   const underlays = useMemo(
     () =>
-      volumeName && underlayArmed
+      volumeName && armedVolume === volumeName
         ? keymapUnderlays(volumeName, keymaps, underlayImage)
         : [],
-    [volumeName, keymaps, underlayImage, underlayArmed],
+    [volumeName, keymaps, underlayImage, armedVolume],
   );
   const selectedIsMissing =
     selectedPage !== null &&

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -436,13 +436,23 @@ export function VolumeViewer() {
       ),
     };
   }, [snapOpen, snapRecord, snapSelected, volumeName]);
-  // Nothing is fetched until the underlay is actually turned up.
+  // Nothing is fetched until the underlay is first turned up; after that it
+  // stays loaded and opacity is only opacity. Clearing the allmaps layer at 0
+  // and re-adding the same map at 50 left it blank until a zoom: the clear
+  // aborts the in-flight tile fetches the re-add immediately repeats.
+  const [underlayArmed, setUnderlayArmed] = useState(false);
+  useEffect(() => {
+    setUnderlayArmed(false);
+  }, [volumeName]);
+  useEffect(() => {
+    if (keymapOpacity > 0) setUnderlayArmed(true);
+  }, [keymapOpacity]);
   const underlays = useMemo(
     () =>
-      volumeName && keymapOpacity > 0
+      volumeName && underlayArmed
         ? keymapUnderlays(volumeName, keymaps, underlayImage)
         : [],
-    [volumeName, keymaps, underlayImage, keymapOpacity],
+    [volumeName, keymaps, underlayImage, underlayArmed],
   );
   const selectedIsMissing =
     selectedPage !== null &&

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
   keymapUnderlays,
-  underlayFromParam,
-  underlayParam,
-  type KeymapUnderlayMode,
+  underlayImageFromParam,
+  underlayImageParam,
+  type KeymapUnderlayImage,
 } from '../iiif/underlay';
 import type {
   GeorefAnnotationPage,
@@ -108,10 +108,15 @@ export function VolumeViewer() {
   const [isolateSelected, setIsolateSelected] = useState(
     () => initialParams.get('only') === '1',
   );
-  // The key-map underlay (#211): off, the sheet, or its P(road) map.
-  const [underlayMode, setUnderlayMode] = useState<KeymapUnderlayMode>(() =>
-    underlayFromParam(initialParams.get('underlay')),
+  // The key-map underlay (#211): which image, and how strongly it shows. The
+  // opacity is independent of the pages' so the two can be cross-faded.
+  const [underlayImage, setUnderlayImage] = useState<KeymapUnderlayImage>(() =>
+    underlayImageFromParam(initialParams.get('underlay')),
   );
+  const [keymapOpacity, setKeymapOpacity] = useState(() => {
+    const value = Number(initialParams.get('keymap'));
+    return Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : 0;
+  });
   const [error, setError] = useState<string | null>(null);
   // Selection is tracked by page stem (stable across annotation files, unlike the item index).
   const [selectedStem, setSelectedStem] = useState<string | null>(() =>
@@ -335,6 +340,19 @@ export function VolumeViewer() {
     return () => window.removeEventListener('keydown', onKeydown);
   }, []);
 
+  // The same 0/50/100% cycle for the key-map underlay, on 'k'.
+  useEffect(() => {
+    function onKeydown(e: KeyboardEvent): void {
+      if (e.key !== 'k' || isTypingTarget(e.target)) return;
+      const steps = [0, 50, 100];
+      setKeymapOpacity(
+        (prev) => steps[(steps.indexOf(prev) + 1) % steps.length] ?? 0,
+      );
+    }
+    window.addEventListener('keydown', onKeydown);
+    return () => window.removeEventListener('keydown', onKeydown);
+  }, []);
+
   const pages = useMemo(
     () =>
       annotation ? pagesFromAnnotation(annotation as GeorefAnnotationPage) : [],
@@ -418,9 +436,13 @@ export function VolumeViewer() {
       ),
     };
   }, [snapOpen, snapRecord, snapSelected, volumeName]);
+  // Nothing is fetched until the underlay is actually turned up.
   const underlays = useMemo(
-    () => keymapUnderlays(keymaps, underlayMode),
-    [keymaps, underlayMode],
+    () =>
+      volumeName && keymapOpacity > 0
+        ? keymapUnderlays(volumeName, keymaps, underlayImage)
+        : [],
+    [volumeName, keymaps, underlayImage, keymapOpacity],
   );
   const selectedIsMissing =
     selectedPage !== null &&
@@ -448,7 +470,8 @@ export function VolumeViewer() {
       adj: showAdjacency ? '1' : null,
       osm: showOsmRelation ? null : '0',
       only: isolateSelected ? '1' : null,
-      underlay: underlayParam(underlayMode),
+      underlay: underlayImageParam(underlayImage),
+      keymap: keymapOpacity > 0 ? String(keymapOpacity) : null,
     });
   }, [
     selectedStem,
@@ -457,7 +480,8 @@ export function VolumeViewer() {
     showAdjacency,
     showOsmRelation,
     isolateSelected,
-    underlayMode,
+    underlayImage,
+    keymapOpacity,
   ]);
 
   function selectVolume(name: string): void {
@@ -581,38 +605,41 @@ export function VolumeViewer() {
               : 'OSM boundary'}
           </label>
         )}
-        {keymaps.some((keymap) => keymap.corners) && (
-          <label
-            className="rmse-color-control"
-            title="Draw the volume's georeferenced key map beneath the pages (#211). Dim the pages with the opacity slider to read them against it."
-          >
-            <input
-              type="checkbox"
-              checked={underlayMode !== 'off'}
-              onChange={(e) =>
-                setUnderlayMode(e.target.checked ? 'image' : 'off')
-              }
-            />
-            Key map
-          </label>
-        )}
-        {keymaps.some((keymap) => keymap.corners && keymap.hasRoadprob) && (
+        {keymaps.some((keymap) => keymap.hasGeoref && keymap.hasRoadprob) && (
           <label
             className="rmse-color-control"
             title="Show the key map's P(road) map (raw/<stem>.roadprob.png) in place of the sheet: what a key-map snap would match against."
           >
             <input
               type="checkbox"
-              checked={underlayMode === 'roadprob'}
-              disabled={underlayMode === 'off'}
+              checked={underlayImage === 'roadprob'}
               onChange={(e) =>
-                setUnderlayMode(e.target.checked ? 'roadprob' : 'image')
+                setUnderlayImage(e.target.checked ? 'roadprob' : 'sheet')
               }
             />
             as P(road)
           </label>
         )}
-        <div className="opacity-control">
+        {keymaps.some((keymap) => keymap.hasGeoref) && (
+          <div
+            className="opacity-control"
+            title="Key-map underlay opacity, independent of the pages' (#211). Press k to cycle 0/50/100%."
+          >
+            <label htmlFor="iiif-keymap-opacity-slider">Key map</label>
+            <input
+              type="range"
+              id="iiif-keymap-opacity-slider"
+              min={0}
+              max={100}
+              value={keymapOpacity}
+              onChange={(e) => setKeymapOpacity(Number(e.target.value))}
+            />
+          </div>
+        )}
+        <div
+          className="opacity-control"
+          title="Page opacity. Press p to cycle 0/50/100%."
+        >
           <label htmlFor="iiif-opacity-slider">Opacity</label>
           <input
             type="range"
@@ -643,6 +670,7 @@ export function VolumeViewer() {
           <VolumeMap
             snapOverlay={snapOverlay}
             keymapUnderlays={underlays}
+            keymapOpacity={keymapOpacity / 100}
             annotation={annotation}
             pages={pages}
             missingPages={missingPages}

--- a/app/src/iiif/underlay.test.ts
+++ b/app/src/iiif/underlay.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { keymapUnderlays, underlayFromParam, underlayParam } from './underlay';
+import {
+  keymapUnderlays,
+  underlayImageFromParam,
+  underlayImageParam,
+} from './underlay';
 import type { KeymapInfo } from '../../server/api';
 
 const corners: [number, number][] = [
@@ -9,65 +13,48 @@ const corners: [number, number][] = [
   [-90.0717, 29.9145],
 ];
 
-const service = 'http://localhost:8182/iiif/new_orleans_la_1896_vol_2/raw';
 const keymaps: KeymapInfo[] = [
-  {
-    stem: 'p0',
-    hasRegions: true,
-    hasGeoref: true,
-    hasRoadprob: true,
-    corners,
-    imageService: `${service}/p0.jpg`,
-    roadprobService: `${service}/p0.roadprob.png`,
-  },
+  { stem: 'p0', hasRegions: true, hasGeoref: true, hasRoadprob: true, corners },
   {
     stem: 'pb',
     hasRegions: false,
     hasGeoref: true,
     hasRoadprob: false,
     corners,
-    imageService: `${service}/pb.png`,
   },
-  {
-    stem: 'pz',
-    hasRegions: false,
-    hasGeoref: false,
-    hasRoadprob: true,
-    imageService: `${service}/pz.jpg`,
-    roadprobService: `${service}/pz.roadprob.png`,
-  },
+  // No georef: nothing to warp it by, in either mode.
+  { stem: 'pz', hasRegions: false, hasGeoref: false, hasRoadprob: true },
 ];
 
 describe('keymapUnderlays', () => {
-  it('draws every georeferenced key map as its sheet through the IIIF service', () => {
-    const underlays = keymapUnderlays(keymaps, 'image');
-    expect(underlays.map((u) => u.id)).toEqual(['p0', 'pb']);
-    expect(underlays[0].url).toBe(
-      `${service}/p0.jpg/full/!2400,2400/0/default.jpg`,
+  it('draws every georeferenced key map from its annotation', () => {
+    const underlays = keymapUnderlays(
+      'new_orleans_la_1896_vol_2',
+      keymaps,
+      'sheet',
     );
-    expect(underlays[0].corners).toEqual(corners);
+    expect(underlays.map((u) => u.id)).toEqual(['p0', 'pb']);
+    expect(underlays[0].annotationUrl).toBe(
+      '/iiif-api/keymap-annotation?volume=new_orleans_la_1896_vol_2&stem=p0&image=sheet',
+    );
   });
 
   it('draws only key maps with a P(road) map in roadprob mode', () => {
-    const underlays = keymapUnderlays(keymaps, 'roadprob');
+    const underlays = keymapUnderlays('queens_1950/vol2', keymaps, 'roadprob');
     expect(underlays.map((u) => u.id)).toEqual(['p0']);
-    expect(underlays[0].url).toBe(
-      `${service}/p0.roadprob.png/full/!2400,2400/0/default.png`,
+    expect(underlays[0].annotationUrl).toBe(
+      '/iiif-api/keymap-annotation?volume=queens_1950%2Fvol2&stem=p0&image=roadprob',
     );
-  });
-
-  it('draws nothing when off', () => {
-    expect(keymapUnderlays(keymaps, 'off')).toEqual([]);
   });
 });
 
-describe('underlay URL parameter', () => {
-  it('round-trips the two on modes and treats anything else as off', () => {
-    expect(underlayFromParam('image')).toBe('image');
-    expect(underlayFromParam('roadprob')).toBe('roadprob');
-    expect(underlayFromParam(null)).toBe('off');
-    expect(underlayFromParam('yes')).toBe('off');
-    expect(underlayParam('off')).toBeNull();
-    expect(underlayParam('roadprob')).toBe('roadprob');
+describe('underlay image URL parameter', () => {
+  it('round-trips roadprob and treats anything else as the sheet', () => {
+    expect(underlayImageFromParam('roadprob')).toBe('roadprob');
+    expect(underlayImageFromParam('sheet')).toBe('sheet');
+    expect(underlayImageFromParam(null)).toBe('sheet');
+    expect(underlayImageFromParam('yes')).toBe('sheet');
+    expect(underlayImageParam('sheet')).toBeNull();
+    expect(underlayImageParam('roadprob')).toBe('roadprob');
   });
 });

--- a/app/src/iiif/underlay.test.ts
+++ b/app/src/iiif/underlay.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { keymapUnderlays, underlayFromParam, underlayParam } from './underlay';
+import type { KeymapInfo } from '../../server/api';
+
+const corners: [number, number][] = [
+  [-90.1158, 29.9432],
+  [-90.0872, 29.9745],
+  [-90.0431, 29.9458],
+  [-90.0717, 29.9145],
+];
+
+const service = 'http://localhost:8182/iiif/new_orleans_la_1896_vol_2/raw';
+const keymaps: KeymapInfo[] = [
+  {
+    stem: 'p0',
+    hasRegions: true,
+    hasGeoref: true,
+    hasRoadprob: true,
+    corners,
+    imageService: `${service}/p0.jpg`,
+    roadprobService: `${service}/p0.roadprob.png`,
+  },
+  {
+    stem: 'pb',
+    hasRegions: false,
+    hasGeoref: true,
+    hasRoadprob: false,
+    corners,
+    imageService: `${service}/pb.png`,
+  },
+  {
+    stem: 'pz',
+    hasRegions: false,
+    hasGeoref: false,
+    hasRoadprob: true,
+    imageService: `${service}/pz.jpg`,
+    roadprobService: `${service}/pz.roadprob.png`,
+  },
+];
+
+describe('keymapUnderlays', () => {
+  it('draws every georeferenced key map as its sheet through the IIIF service', () => {
+    const underlays = keymapUnderlays(keymaps, 'image');
+    expect(underlays.map((u) => u.id)).toEqual(['p0', 'pb']);
+    expect(underlays[0].url).toBe(
+      `${service}/p0.jpg/full/!2400,2400/0/default.jpg`,
+    );
+    expect(underlays[0].corners).toEqual(corners);
+  });
+
+  it('draws only key maps with a P(road) map in roadprob mode', () => {
+    const underlays = keymapUnderlays(keymaps, 'roadprob');
+    expect(underlays.map((u) => u.id)).toEqual(['p0']);
+    expect(underlays[0].url).toBe(
+      `${service}/p0.roadprob.png/full/!2400,2400/0/default.png`,
+    );
+  });
+
+  it('draws nothing when off', () => {
+    expect(keymapUnderlays(keymaps, 'off')).toEqual([]);
+  });
+});
+
+describe('underlay URL parameter', () => {
+  it('round-trips the two on modes and treats anything else as off', () => {
+    expect(underlayFromParam('image')).toBe('image');
+    expect(underlayFromParam('roadprob')).toBe('roadprob');
+    expect(underlayFromParam(null)).toBe('off');
+    expect(underlayFromParam('yes')).toBe('off');
+    expect(underlayParam('off')).toBeNull();
+    expect(underlayParam('roadprob')).toBe('roadprob');
+  });
+});

--- a/app/src/iiif/underlay.ts
+++ b/app/src/iiif/underlay.ts
@@ -1,0 +1,82 @@
+/**
+ * The key-map underlay (#211): a volume's georeferenced key map drawn beneath
+ * its pages, either as the sheet itself or as its P(road) map.
+ *
+ * Where the street grid has changed since the Sanborn survey there is nothing
+ * on OSM for snap to lock onto, and the page lands on an alias. The key map is
+ * a Sanborn-era drawing of the same streets, so a page that fails to snap onto
+ * the modern grid might snap onto the key map's P(road) map instead. This
+ * underlay is the first look at that: does the page's own P(road) map line up
+ * with the key map's?
+ *
+ * The key map's georef is an affine, given by its four corners, so the sheet is
+ * placed the way the snap pose overlay is: a maplibre image source at the
+ * corner coordinates. The image is fetched through the key map's IIIF image
+ * service (an absolute URL from the API, like the pages' tiles) at a bounded
+ * size, since a full-resolution sheet is too large for one texture.
+ */
+import type { KeymapInfo } from '../../server/api';
+
+export type KeymapUnderlayMode = 'off' | 'image' | 'roadprob';
+
+export type Corners = [
+  [number, number],
+  [number, number],
+  [number, number],
+  [number, number],
+];
+
+/** One key map to draw: an image URL and the corner coordinates to pin it to. */
+export interface KeymapUnderlay {
+  /** The key map's stem, e.g. "p0"; the layer id derives from it. */
+  id: string;
+  url: string;
+  /** Top-left, top-right, bottom-right, bottom-left, as maplibre wants them. */
+  corners: Corners;
+}
+
+/** Longest side, in pixels, of the image fetched for the underlay. */
+export const UNDERLAY_MAX_PX = 2400;
+
+/** The underlay mode a URL parameter names; anything unknown is off. */
+export function underlayFromParam(value: string | null): KeymapUnderlayMode {
+  return value === 'image' || value === 'roadprob' ? value : 'off';
+}
+
+/** The URL parameter value for a mode; null (remove the parameter) when off. */
+export function underlayParam(mode: KeymapUnderlayMode): string | null {
+  return mode === 'off' ? null : mode;
+}
+
+/** The IIIF request for a service's image, best-fit inside UNDERLAY_MAX_PX square. */
+export function underlayImageUrl(
+  service: string,
+  format: 'jpg' | 'png',
+): string {
+  return `${service}/full/!${UNDERLAY_MAX_PX},${UNDERLAY_MAX_PX}/0/default.${format}`;
+}
+
+/**
+ * The underlays to draw in a mode: every key map with a georef and an image
+ * service, as its sheet, or in P(road) mode only those with a road-probability
+ * map. Nothing when off.
+ */
+export function keymapUnderlays(
+  keymaps: KeymapInfo[],
+  mode: KeymapUnderlayMode,
+): KeymapUnderlay[] {
+  if (mode === 'off') return [];
+  const underlays: KeymapUnderlay[] = [];
+  for (const keymap of keymaps) {
+    if (!keymap.corners || keymap.corners.length !== 4) continue;
+    const service =
+      mode === 'roadprob' ? keymap.roadprobService : keymap.imageService;
+    if (!service) continue;
+    underlays.push({
+      id: keymap.stem,
+      url: underlayImageUrl(service, mode === 'roadprob' ? 'png' : 'jpg'),
+      corners: keymap.corners as Corners,
+    });
+  }
+  return underlays;
+}

--- a/app/src/iiif/underlay.ts
+++ b/app/src/iiif/underlay.ts
@@ -9,73 +9,59 @@
  * underlay is the first look at that: does the page's own P(road) map line up
  * with the key map's?
  *
- * The key map's georef is an affine, given by its four corners, so the sheet is
- * placed the way the snap pose overlay is: a maplibre image source at the
- * corner coordinates. The image is fetched through the key map's IIIF image
- * service (an absolute URL from the API, like the pages' tiles) at a bounded
- * size, since a full-resolution sheet is too large for one texture.
+ * Each key map is drawn from a georeference annotation the server builds
+ * (`/iiif-api/keymap-annotation`), warped by a thin-plate spline through the
+ * sheet's own GCPs -- the model keymap-snap places pages in, whose residuals
+ * are about half the shipped affine's. Rendering it with allmaps, the way the
+ * pages are rendered, is what makes the spline visible: a four-corner image
+ * would show the affine placement the pipeline does not use.
  */
 import type { KeymapInfo } from '../../server/api';
 
-export type KeymapUnderlayMode = 'off' | 'image' | 'roadprob';
+/** Which image to draw for a key map: the sheet, or its road-probability map. */
+export type KeymapUnderlayImage = 'sheet' | 'roadprob';
 
-export type Corners = [
-  [number, number],
-  [number, number],
-  [number, number],
-  [number, number],
-];
-
-/** One key map to draw: an image URL and the corner coordinates to pin it to. */
+/** One key map to draw, as the annotation URL that places it. */
 export interface KeymapUnderlay {
-  /** The key map's stem, e.g. "p0"; the layer id derives from it. */
+  /** The key map's stem, e.g. "p0". */
   id: string;
-  url: string;
-  /** Top-left, top-right, bottom-right, bottom-left, as maplibre wants them. */
-  corners: Corners;
+  /** Georeference annotation URL; allmaps fetches and warps it. */
+  annotationUrl: string;
 }
 
-/** Longest side, in pixels, of the image fetched for the underlay. */
-export const UNDERLAY_MAX_PX = 2400;
-
-/** The underlay mode a URL parameter names; anything unknown is off. */
-export function underlayFromParam(value: string | null): KeymapUnderlayMode {
-  return value === 'image' || value === 'roadprob' ? value : 'off';
+/** The image a URL parameter names; anything unknown is the sheet. */
+export function underlayImageFromParam(
+  value: string | null,
+): KeymapUnderlayImage {
+  return value === 'roadprob' ? 'roadprob' : 'sheet';
 }
 
-/** The URL parameter value for a mode; null (remove the parameter) when off. */
-export function underlayParam(mode: KeymapUnderlayMode): string | null {
-  return mode === 'off' ? null : mode;
-}
-
-/** The IIIF request for a service's image, best-fit inside UNDERLAY_MAX_PX square. */
-export function underlayImageUrl(
-  service: string,
-  format: 'jpg' | 'png',
-): string {
-  return `${service}/full/!${UNDERLAY_MAX_PX},${UNDERLAY_MAX_PX}/0/default.${format}`;
+/** The URL parameter value for an image; null (omit) for the default sheet. */
+export function underlayImageParam(image: KeymapUnderlayImage): string | null {
+  return image === 'roadprob' ? 'roadprob' : null;
 }
 
 /**
- * The underlays to draw in a mode: every key map with a georef and an image
- * service, as its sheet, or in P(road) mode only those with a road-probability
- * map. Nothing when off.
+ * The underlays to draw for a volume: every key map that has a georeference,
+ * or in P(road) mode only those that also have a road-probability map.
  */
 export function keymapUnderlays(
+  volume: string,
   keymaps: KeymapInfo[],
-  mode: KeymapUnderlayMode,
+  image: KeymapUnderlayImage,
 ): KeymapUnderlay[] {
-  if (mode === 'off') return [];
   const underlays: KeymapUnderlay[] = [];
   for (const keymap of keymaps) {
-    if (!keymap.corners || keymap.corners.length !== 4) continue;
-    const service =
-      mode === 'roadprob' ? keymap.roadprobService : keymap.imageService;
-    if (!service) continue;
+    if (!keymap.hasGeoref) continue;
+    if (image === 'roadprob' && !keymap.hasRoadprob) continue;
+    const query = new URLSearchParams({
+      volume,
+      stem: keymap.stem,
+      image,
+    });
     underlays.push({
       id: keymap.stem,
-      url: underlayImageUrl(service, mode === 'roadprob' ? 'png' : 'jpg'),
-      corners: keymap.corners as Corners,
+      annotationUrl: `/iiif-api/keymap-annotation?${query}`,
     });
   }
   return underlays;

--- a/mapsnap/keymap_target_test.py
+++ b/mapsnap/keymap_target_test.py
@@ -1,0 +1,113 @@
+"""Tests for the key-map snap target (#211): loading and rasterising."""
+
+import json
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from mapsnap.edge_join import FrameSpec
+from mapsnap.osm_snap import (
+    KeymapTarget,
+    frame_around,
+    keymap_rasters,
+    load_keymap_targets,
+    nearest_keymap_target,
+)
+
+
+def affine_georef(width: int, height: int) -> dict:
+    """A key-map georef whose corners are a plain north-up affine, no GCPs."""
+    lon0, lat0, per_px = -90.1, 29.95, 1e-5
+    corners = [
+        [lon0, lat0],
+        [lon0 + width * per_px, lat0],
+        [lon0 + width * per_px, lat0 - height * per_px],
+        [lon0, lat0 - height * per_px],
+    ]
+    return {"width": width, "height": height, "corners": corners, "intersections": []}
+
+
+def make_target(tmp_path: Path, stem: str = "p0", with_roadprob: bool = True) -> Path:
+    raw = tmp_path / "raw"
+    raw.mkdir(exist_ok=True)
+    (raw / f"{stem}.keymap.json").write_text("{}")
+    (raw / f"{stem}.georef.json").write_text(json.dumps(affine_georef(400, 300)))
+    if with_roadprob:
+        prob = np.zeros((300, 400), np.uint8)
+        cv2.line(prob, (0, 150), (399, 150), 255, 6)  # one east-west road
+        cv2.line(prob, (200, 0), (200, 299), 255, 6)  # one north-south road
+        cv2.imwrite(str(raw / f"{stem}.roadprob.png"), prob)
+    return raw
+
+
+def test_load_keymap_targets_needs_georef_and_roadprob(tmp_path):
+    make_target(tmp_path, "p0")
+    make_target(tmp_path, "pb", with_roadprob=False)
+    targets = load_keymap_targets(tmp_path)
+    assert [t.stem for t in targets] == ["p0"]
+    assert targets[0].prob.shape == (300, 400)
+    assert targets[0].prob.max() == 1.0
+
+
+def test_keymap_rasters_put_the_roads_where_the_georef_says(tmp_path):
+    make_target(tmp_path, "p0")
+    target = load_keymap_targets(tmp_path)[0]
+    georef = affine_georef(400, 300)
+    # A frame around the key map's centre: the two roads cross there.
+    centre = (georef["corners"][0][0] + 200e-5, georef["corners"][0][1] - 150e-5)
+    frame = frame_around(centre, half_m=200.0, res_m=2.0)
+    prob, valid, skeleton = keymap_rasters(frame, target)
+    assert prob.shape == frame.shape and valid.shape == frame.shape
+    assert valid.mean() > 0.5  # the frame lies mostly on the sheet
+    # The east-west road runs through the frame centre row; sample it.
+    rows, cols = frame.shape
+    assert prob[rows // 2, cols // 4] > 0.5
+    assert prob[rows // 2, 3 * cols // 4] > 0.5
+    assert prob[rows // 4, cols // 4] < 0.1  # off-road stays dark
+    assert skeleton.any()
+    # Skeleton cells sit on inked cells.
+    assert prob[skeleton].mean() > 0.5
+
+
+def test_keymap_rasters_mark_cells_off_the_sheet_invalid(tmp_path):
+    make_target(tmp_path, "p0")
+    target = load_keymap_targets(tmp_path)[0]
+    georef = affine_georef(400, 300)
+    # A frame centred on the sheet's top-left corner: three quarters off-sheet.
+    frame = frame_around(tuple(georef["corners"][0]), half_m=150.0, res_m=2.0)
+    prob, valid, _skeleton = keymap_rasters(frame, target)
+    assert 0.15 < valid.mean() < 0.4
+    assert not prob[~valid].any()
+
+
+def test_nearest_keymap_target_prefers_the_sheet_that_contains_the_point(tmp_path):
+    make_target(tmp_path, "p0")
+    far = tmp_path / "far"
+    far.mkdir()
+    make_target(far, "p0")
+    near_target = load_keymap_targets(tmp_path)[0]
+    far_target = load_keymap_targets(far)[0]
+    far_target.georef["corners"] = [
+        [c[0] + 1.0, c[1]] for c in far_target.georef["corners"]
+    ]
+    inside = (-90.1 + 100e-5, 29.95 - 100e-5)
+    assert nearest_keymap_target([far_target, near_target], inside) is near_target
+    assert nearest_keymap_target([], inside) is None
+
+
+def test_keymap_target_builds_its_model_lazily_and_leaves_it_out_of_state(
+    tmp_path,
+):
+    make_target(tmp_path, "p0")
+    target = load_keymap_targets(tmp_path)[0]
+    assert target.model_cache is None
+    world = target.model(np.array([[0.0, 0.0]]))
+    assert np.allclose(world[0], affine_georef(400, 300)["corners"][0])
+    assert target.model_cache is not None
+    # What a worker receives: the georef, never the unpicklable spline.
+    state = target.__getstate__()
+    assert state["model_cache"] is None and state["georef"] is target.georef
+    clone = KeymapTarget(**{k: v for k, v in state.items()})
+    assert np.allclose(clone.model(np.array([[0.0, 0.0]]))[0], world[0])
+    assert isinstance(FrameSpec, type)

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -19,9 +19,12 @@ objects, and evaluates against truth; nothing in this module reads truth data.
 """
 
 import dataclasses
+import json
 import math
 import os
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import cv2
 import numpy as np
@@ -229,6 +232,9 @@ class SnapCandidate:
     # satisfies most of them).
     stamp_separation_m: float | None = None
     stamp_median_m: float | None = None
+    # What the page was matched against: "osm", or "keymap:<stem>" for the
+    # key map's P(road) map (#211).
+    target: str = "osm"
 
     def select_score(self) -> float:
         """The ranking score: matcher verification plus soft evidence bonuses."""
@@ -436,6 +442,184 @@ def osm_rasters(
             cv2.polylines(skeleton, [poly], False, 1, 1)
     valid = np.ones((rows, cols), dtype=bool)
     return prob, valid, skeleton.astype(bool)
+
+
+@dataclass
+class KeymapTarget:
+    """A key map's P(road) map as a snap target, in place of OSM (#211).
+
+    Where the street grid has changed since the survey there is nothing on OSM
+    for a page to lock onto and it lands on an alias. The key map is a
+    Sanborn-era drawing of the same streets, so its road-probability map can
+    stand in for OSM as the thing the page's P(road) is matched against. The
+    sheet is placed by the pipeline's own key-map model (keymap_model: a
+    smoothed thin-plate spline through the sheet's inlier intersections).
+
+    `model` is built lazily from `georef`, so a target pickles into a worker.
+    """
+
+    stem: str
+    georef: dict
+    prob: np.ndarray  # float32 in [0, 1], key-map pixels
+    image_path: Path
+    model_cache: Callable[[np.ndarray], np.ndarray] | None = field(
+        default=None, repr=False, compare=False
+    )
+
+    @property
+    def model(self) -> Callable[[np.ndarray], np.ndarray]:
+        """Key-map pixel (N, 2) -> lon/lat (N, 2)."""
+        if self.model_cache is None:
+            from mapsnap.keymap.snap import keymap_model
+
+            self.model_cache = keymap_model(self.georef)
+        return self.model_cache
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["model_cache"] = None
+        return state
+
+    def corner_centroid(self) -> tuple[float, float]:
+        corners = self.georef["corners"]
+        return (
+            sum(c[0] for c in corners) / len(corners),
+            sum(c[1] for c in corners) / len(corners),
+        )
+
+
+def load_keymap_targets(volume: Path) -> list[KeymapTarget]:
+    """Every key map of a volume with a georef and a P(road) map, by stem."""
+    raw = volume / "raw"
+    targets: list[KeymapTarget] = []
+    for keymap_json in sorted(raw.glob("*.keymap.json")):
+        stem = keymap_json.name[: -len(".keymap.json")]
+        georef_path = raw / f"{stem}.georef.json"
+        prob_path = raw / f"{stem}.roadprob.png"
+        if not georef_path.exists() or not prob_path.exists():
+            continue
+        image = cv2.imread(str(prob_path), cv2.IMREAD_GRAYSCALE)
+        if image is None:
+            continue
+        georef = json.loads(georef_path.read_text())
+        if not georef.get("corners"):
+            continue
+        image_path = next(
+            (
+                raw / f"{stem}.{ext}"
+                for ext in ("jpg", "png")
+                if (raw / f"{stem}.{ext}").exists()
+            ),
+            prob_path,
+        )
+        targets.append(
+            KeymapTarget(
+                stem=stem,
+                georef=georef,
+                prob=image.astype(np.float32) / 255.0,
+                image_path=image_path,
+            )
+        )
+    return targets
+
+
+def nearest_keymap_target(
+    targets: list[KeymapTarget], lonlat: tuple[float, float]
+) -> KeymapTarget | None:
+    """The key map whose corner quadrilateral contains the point, else the nearest."""
+    if not targets:
+        return None
+    from shapely.geometry import Point, Polygon
+
+    point = Point(lonlat)
+    for target in targets:
+        if Polygon(target.georef["corners"]).contains(point):
+            return target
+    return min(
+        targets,
+        key=lambda t: math.hypot(
+            (t.corner_centroid()[0] - lonlat[0]) * math.cos(math.radians(lonlat[1])),
+            t.corner_centroid()[1] - lonlat[1],
+        ),
+    )
+
+
+# Inverse-mapping grid step (raster cells) and Newton iterations for
+# keymap_rasters; the spline is near-affine over a search frame.
+KEYMAP_RASTER_GRID = 8
+KEYMAP_RASTER_NEWTON = 4
+KEYMAP_SKELETON_MIN_AREA = 100
+
+
+def keymap_rasters(
+    frame: FrameSpec, target: KeymapTarget
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """(prob, valid, skeleton) rasters of a key map's P(road) map in the frame.
+
+    The key-map analog of osm_rasters. Each raster cell is mapped back to a
+    key-map pixel by inverting the key-map model: a coarse grid of cells is
+    solved by Newton iteration with the model's tangent at the frame centre
+    as the Jacobian (the spline is near-affine over a frame), interpolated
+    to every cell, and the P(road) map is resampled through it. valid marks
+    cells that land on the sheet; skeleton is the thinned road mask, which
+    the chamfer distance transform is built from, as OSM's centerlines are.
+    """
+    from mapsnap.keymap.snap import local_tangent
+    from mapsnap.road_model import road_mask, road_skeleton
+
+    rows, cols = frame.shape
+    kx, ky = frame.metre_scales()
+    step = KEYMAP_RASTER_GRID
+    grid_rows = np.arange(0, rows + step, step, dtype=np.float64)
+    grid_cols = np.arange(0, cols + step, step, dtype=np.float64)
+    cc, rr = np.meshgrid(grid_cols, grid_rows)
+    lon = frame.origin[0] + (frame.x_min + cc * frame.res_m) / kx
+    lat = frame.origin[1] + (frame.y_max - rr * frame.res_m) / ky
+    wanted = np.column_stack([lon.ravel(), lat.ravel()])
+
+    # Seed every node from the tangent at the sheet point nearest the frame
+    # centre, then refine with the same Jacobian: Newton on a near-affine map.
+    centre_lonlat = (float(lon.mean()), float(lat.mean()))
+    height, width = target.prob.shape
+    seed_px = np.array([width / 2.0, height / 2.0])
+    tangent = local_tangent(target.model, (float(seed_px[0]), float(seed_px[1])))
+    jacobian = tangent[:, :2]
+    inverse = np.linalg.inv(jacobian)
+    seed_world = target.model(seed_px[None, :])[0]
+    pixels = seed_px + (np.array(centre_lonlat) - seed_world) @ inverse.T
+    tangent = local_tangent(target.model, (float(pixels[0]), float(pixels[1])))
+    inverse = np.linalg.inv(tangent[:, :2])
+    pixels = np.tile(pixels, (len(wanted), 1))
+    for _ in range(KEYMAP_RASTER_NEWTON):
+        pixels = pixels + (wanted - target.model(pixels)) @ inverse.T
+
+    map_x = pixels[:, 0].reshape(cc.shape).astype(np.float32)
+    map_y = pixels[:, 1].reshape(cc.shape).astype(np.float32)
+    # Interpolate the node grid at each cell's fractional node coordinate.
+    # (cv2.resize would do this with pixel-centre alignment, shifting every
+    # cell by nearly half a step.)
+    fine_r, fine_c = np.mgrid[0:rows, 0:cols]
+    node_c = (fine_c / step).astype(np.float32)
+    node_r = (fine_r / step).astype(np.float32)
+    full_x = cv2.remap(map_x, node_c, node_r, cv2.INTER_LINEAR)
+    full_y = cv2.remap(map_y, node_c, node_r, cv2.INTER_LINEAR)
+    valid = (full_x >= 0) & (full_x < width - 1) & (full_y >= 0) & (full_y < height - 1)
+    prob = cv2.remap(
+        target.prob, full_x, full_y, cv2.INTER_LINEAR, borderMode=cv2.BORDER_CONSTANT
+    )
+    prob[~valid] = 0.0
+    mask = road_mask(prob, threshold=0.5, min_area=KEYMAP_SKELETON_MIN_AREA)
+    skeleton = road_skeleton(mask)
+    return prob.astype(np.float32), valid, skeleton.astype(bool)
+
+
+def target_rasters(
+    frame: FrameSpec, features: FeatureIndex, target: KeymapTarget | None
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """The fixed rasters for a frame: OSM's, or the key map's when a target is given."""
+    if target is None:
+        return osm_rasters(frame, features)
+    return keymap_rasters(frame, target)
 
 
 def osm_distance_m(skeleton: np.ndarray, res_m: float = OSM_RES_M) -> np.ndarray:
@@ -812,6 +996,7 @@ def evaluate_pose(
     features: FeatureIndex,
     world_affine: np.ndarray,
     params: MatchParams = OSM_MATCH_PARAMS,
+    target: KeymapTarget | None = None,
 ) -> dict | None:
     """Score an EXISTING pose with the matcher's own evidence (no search).
 
@@ -839,7 +1024,7 @@ def evaluate_pose(
         sp.m_per_px for sp in ctx.scale_priors
     )
     frame = frame_around((lon_c, lat_c), half_m=diag_m / 2 + 100.0, res_m=res)
-    osm_prob, valid, skeleton = osm_rasters(frame, features)
+    osm_prob, valid, skeleton = target_rasters(frame, features, target)
     if not skeleton.any():
         return None
     distance = osm_distance_m(skeleton, res)
@@ -887,6 +1072,7 @@ def rank_pose(
     features: FeatureIndex,
     world_affine: np.ndarray,
     params: MatchParams = OSM_MATCH_PARAMS,
+    target: KeymapTarget | None = None,
 ) -> dict | None:
     """Score an EXISTING pose with the ladder's FULL ranking features.
 
@@ -899,7 +1085,7 @@ def rank_pose(
     page's evidence itself prefers a wrong pose. None when the pose cannot be
     evaluated (see evaluate_pose).
     """
-    evaluation = evaluate_pose(ctx, features, world_affine, params)
+    evaluation = evaluate_pose(ctx, features, world_affine, params, target)
     if evaluation is None:
         return None
     affine = np.asarray(world_affine, dtype=float)
@@ -974,6 +1160,7 @@ def snap_page(
     ctx: PageContext,
     features: FeatureIndex,
     params: MatchParams = OSM_MATCH_PARAMS,
+    target: KeymapTarget | None = None,
 ) -> list[SnapCandidate]:
     """Candidate placements of a page against OSM around its keymap location.
 
@@ -1006,7 +1193,7 @@ def snap_page(
     collected: list[SnapCandidate] = []
     for center in ctx.search_centers:
         frame = frame_around(center, half_m=half_m, res_m=res)
-        osm_prob, valid, skeleton = osm_rasters(frame, features)
+        osm_prob, valid, skeleton = target_rasters(frame, features, target)
         if not skeleton.any():
             continue
         distance = osm_distance_m(skeleton, res)
@@ -1097,6 +1284,7 @@ def snap_page(
                 center_dist_m=center_dist,
                 verification=candidate.verification_score(),
                 plausible=candidate.plausible,
+                target="osm" if target is None else f"keymap:{target.stem}",
             )
             if refine_shift > REFINE_SHIFT_MAX_M:
                 snap.plausible = False

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -46,6 +46,7 @@ from mapsnap.keymap.align_page_region import (
 )
 from mapsnap.keymap.locate import KeymapLocator, usable_keymaps
 from mapsnap.osm_snap import (
+    KeymapTarget,
     PageContext,
     RotationPrior,
     ScalePrior,
@@ -57,6 +58,8 @@ from mapsnap.osm_snap import (
     evaluate_pose,
     frame_around,
     label_osm_rotations,
+    load_keymap_targets,
+    nearest_keymap_target,
     osm_rasters,
     page_scale_priors,
     rank_pose,
@@ -102,6 +105,9 @@ class VolumeContext:
     # Lazily-built map of stem -> FittedPage for neighbor-stamp priors
     # (#335 phase 2); None until the first unplaced page asks for it.
     stamp_fitted: dict | None = None
+    # The volume's key maps as snap targets (#211), when the run matches
+    # against the key map's P(road) map instead of OSM; None for OSM.
+    keymap_targets: list[KeymapTarget] | None = None
 
 
 def ring_centroid(ring: list[list[float]]) -> tuple[float, float]:
@@ -908,6 +914,7 @@ def candidate_record(candidate: SnapCandidate, unit: PageUnit) -> dict:
         else None,
         "plausible": candidate.plausible,
         "gate_reasons": candidate.gate_reasons,
+        "target": candidate.target,
     }
     if candidate.stamp_separation_m is not None:
         record["stamp_separation_m"] = round(candidate.stamp_separation_m, 1)
@@ -979,10 +986,20 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
             for p in ctx.scale_priors
         ],
     }
+    # The key map to match against, when the run targets key maps: the one
+    # whose sheet holds the page's first search centre (#211).
+    target = (
+        nearest_keymap_target(vctx.keymap_targets, ctx.search_centers[0])
+        if vctx.keymap_targets and ctx.search_centers
+        else None
+    )
+    record["match_target"] = "osm" if target is None else f"keymap:{target.stem}"
     if unit.fit_state == "fitted" and unit.gen_affine is not None:
         # Arbitration head-to-head: score the incumbent RANSAC pose with the
         # same evidence the challenger candidates carry.
-        incumbent = evaluate_pose(ctx, vctx.feature_index, unit.gen_affine)
+        incumbent = evaluate_pose(
+            ctx, vctx.feature_index, unit.gen_affine, target=target
+        )
         if incumbent is not None:
             incumbent["world_affine"] = [
                 [float(v) for v in row] for row in unit.gen_affine
@@ -1047,10 +1064,12 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
         # classifies every snap failure: truth outscoring every candidate is
         # a SEARCH problem; a candidate outscoring truth is a DATA problem
         # (the page's P(road)/OSM evidence prefers a wrong pose).
-        truth = rank_pose(ctx, vctx.feature_index, unit.truth.affine_local)
+        truth = rank_pose(
+            ctx, vctx.feature_index, unit.truth.affine_local, target=target
+        )
         if truth is not None:
             record["truth_pose"] = truth
-    candidates = snap_page(ctx, vctx.feature_index)
+    candidates = snap_page(ctx, vctx.feature_index, target=target)
     # #324: a candidate whose pose reads the page upside-down is
     # corpus-impossible (0/1,332 truth pages in the zone); snap's rotation
     # ladder has admitted 180-off aliases before (detroit p77 at 116 deg,
@@ -1201,11 +1220,19 @@ def cmd_candidates(
     vis: bool,
     *,
     num_workers: int = 1,
+    target: str = "osm",
 ) -> None:
-    """Generate candidates.jsonl for the volume's rescue targets."""
+    """Generate candidates.jsonl for the volume's rescue targets.
+
+    ``target="keymap"`` matches pages against the volume's key-map P(road)
+    maps instead of OSM (#211) and keeps its records apart, in
+    candidates-keymap.jsonl, so the OSM cache is untouched.
+    """
     out_dir = artifacts_dir(volume)
     out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / "candidates.jsonl"
+    out_path = out_dir / (
+        "candidates.jsonl" if target == "osm" else f"candidates-{target}.jsonl"
+    )
     units = load_page_units(volume)
     if not any(u.fit_state == "fitted" and u.gen_affine is not None for u in units):
         # Nothing to calibrate scale/radius/rotation against — and nothing for
@@ -1219,6 +1246,15 @@ def cmd_candidates(
             out_path.write_text("")
         return
     vctx = load_volume_context(volume, units)
+    if target == "keymap":
+        vctx.keymap_targets = load_keymap_targets(volume)
+        if not vctx.keymap_targets:
+            print(f"{volume.name}: no key map with a georef and a P(road) map.")
+            return
+        print(
+            f"{volume.name}: matching against key map(s) "
+            + ", ".join(t.stem for t in vctx.keymap_targets)
+        )
     existing: dict[str, dict] = {}
     if out_path.exists():
         for line in out_path.read_text().splitlines():
@@ -1302,8 +1338,8 @@ def cmd_candidates(
             write_contact_sheet(vctx, by_stem[stem], record, vis_dir)
         # Rewrite after every page so an interrupted run keeps its progress.
         with out_path.open("w") as handle:
-            for target in sorted(existing):
-                handle.write(json.dumps(existing[target]) + "\n")
+            for page_key in sorted(existing):
+                handle.write(json.dumps(existing[page_key]) + "\n")
 
     if num_workers > 1 and len(stale) > 1:
         # Matching is independent per page and CPU-bound. Workers rebuild the
@@ -3559,6 +3595,12 @@ def main() -> None:
         metavar="N",
         help="worker processes for the per-page matching pass (default: %(default)s)",
     )
+    p_cand.add_argument(
+        "--target",
+        choices=("osm", "keymap"),
+        default="osm",
+        help="match against OSM (default) or the key map's P(road) map (#211)",
+    )
 
     p_rep = sub.add_parser("report", help="ranking diagnostics vs truth")
     p_rep.add_argument("volume", type=Path, nargs="+")
@@ -3622,6 +3664,7 @@ def main() -> None:
             args.recompute,
             vis=not args.no_vis,
             num_workers=args.num_workers,
+            target=args.target,
         )
     elif args.command == "report":
         if args.sweep_refine:


### PR DESCRIPTION
Stacked on #392 (so the debugger keeps the underlay while this is reviewed); the diff against that branch is the Python only. Toward #211.

Where the street grid has changed since the survey there is nothing on OSM for snap to lock onto: New Orleans 1896 p119 lands 704 ft off, Brooklyn 1939 p44 783 ft, and Detroit p7/p8/p22/p30 abstain and stay unplaced. The key map is a Sanborn-era drawing of the same streets, so its P(road) map can stand in for OSM as the thing the page's P(road) is matched against.

## What this adds

An alternate **target** for the existing matcher, not a new matcher. `KeymapTarget` carries a key map's P(road) map and the pipeline's own key-map model (the smoothed spline through the sheet's inlier intersections). `keymap_rasters` resamples it into the search frame in place of `osm_rasters`, inverting the spline on a coarse node grid by Newton iteration. `snap_page`, `evaluate_pose` and `rank_pose` take an optional target, so the rotation ladder, masked NCC, chamfer refinement, verification, and the incumbent and truth evaluations all run unchanged against the key map, and every candidate record says which target it was matched against. The candidates command gains `--target keymap` and writes `candidates-keymap.jsonl` beside the OSM cache, which is untouched.

## Results on the six pages

Top candidate by select score, grid RMSE against truth; OSM's result is today's.

| page | OSM today | key-map target | note |
|---|---|---|---|
| detroit p22 | abstain (515 ft top) | **28 ft** | verification 0.72 |
| detroit p7 | abstain (371 ft) | **40 ft** | |
| detroit p30 | abstain (17 ft top, score 0.93) | 76 ft | verification 0.14, weak |
| detroit p8 | abstain (301 ft) | 316 ft | a 70 ft candidate sits one score-point behind (select 1.239 vs 1.245); by verification alone it wins |
| new_orleans p119 | 704 ft alias published | 100 ft | truth pose verifies **−0.36** against the key map |
| brooklyn p44 | 783 ft alias published | 214 ft | truth pose verifies **−0.48** against the key map |

The last column is the finding. On both alias pages the truth pose scores negatively against the key map: at the true location the page's roads do not line up with the key map as georeferenced, so the remaining error is the key-map georeference in that neighbourhood, not the matcher. That is the premium on key-map accuracy made concrete; the cross-validated spline error near p119 was ~100 ft in the earlier measurement, matching the 100 ft here.

## What was tried first

The standalone `mapsnap keymap-snap` module on the same pages: it rescues the Detroit stack too (33 to 83 ft) but fails New Orleans and Brooklyn on rotation, since it searches only the volume median plus neighbour clusters and those volumes print pages at many angles (p119 was tried 116° off). Feeding it the OSM channel's rotation ladder fixed p119 (917 → 115 ft) but made both volumes worse overall (pages more than 45° off went from 30% to 50%): its blurred correlation cannot reject a wrong angle. The matcher's refinement and verification are what this route adds.

## Not in this PR

Arbitration. A key-map candidate needs an admission rule of its own (its key-map verification, not OSM evidence; and the select score's name term is OSM-derived, which is what edges p8's alias ahead). That rule wants a study over all rescue targets in these volumes, not six pages. The debugger's snap panel also does not read `candidates-keymap.jsonl` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)