### PR TITLE
craft detects parents before deriving their panels; baseline pre-flight notes

### DIFF
--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -42,6 +42,20 @@ of them silently corrupts the comparison.
    half of its two-panel pages here — expect `p12__1` and `p12__2` to swap
    meaning on those, in every artifact that names them.
 
+   A key-map sheet whose old split the #383 gate now rejects (Chicago's p0
+   notch) is cleaned up only beside the 25% image: the splitter removes the
+   stale `p0__N.jpg` panels and their sidecars there, but the key-map
+   pipeline's `raw/p0__N.*` copies (`keymap.json`, `georef.json`,
+   `regions.panels.json`, `streets.json`, `txt`, `boxes.json`, `jpg`) are not
+   its to touch and must be deleted by hand, or the key-map chain keeps
+   finding the dead panel. Check with `ls data/$VOL/raw/ | grep __`.
+
+   Deleting a split sheet's `boxes.json` before the run exercises craft's
+   parent-derivation path (#362) for its panels; the parents are detected
+   first and the panels remapped from them (fixed 2026-09-03: the loop used
+   to try every derivation before any detection, so a missing parent file
+   sent every panel to its own detection instead).
+
 2. **Let `split` drop the reads of panels that changed, then `ocr --resume`.**
    `split` compares the new panel rings with the previous `panels.json` and
    deletes every derived sidecar (`boxes.json` / `streets.json` / `txt` /

--- a/mapsnap/craft.py
+++ b/mapsnap/craft.py
@@ -18,6 +18,7 @@ command to run; this is the only command that runs CRAFT.
 import argparse
 import glob
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 from tqdm import tqdm
@@ -144,38 +145,61 @@ def main() -> None:
         print("All images already have current boxes.", file=sys.stderr)
         return
 
-    # Parents before panels, so a panel's derivation (#361) can see boxes its
-    # parent wrote earlier in this same invocation.
-    todo.sort(key=lambda image: ("__" in Path(image).stem, image))
+    reader = None
+
+    def detect(image: str) -> None:
+        nonlocal reader
+        if reader is None:
+            import easyocr
+
+            reader = easyocr.Reader(["en"], gpu=not args.no_gpu, verbose=False)
+        write_craft_boxes(
+            image,
+            reader,
+            min_size=args.min_size,
+            link_threshold=args.link_threshold,
+            craft_scale=args.craft_scale,
+            tile_size=args.tile_size,
+        )
+
+    derived, detected = process_pending(todo, detect)
+    print(
+        f"Wrote boxes for {len(todo)} image(s) ({derived} derived, "
+        f"{detected} detected).",
+        file=sys.stderr,
+    )
+
+
+def process_pending(todo: list[str], detect: Callable[[str], None]) -> tuple[int, int]:
+    """Detect parents, then derive panels from them, detecting what cannot be.
+
+    Order is the whole point. A panel's boxes are derived from its parent's
+    (#361), so the parent's detection has to have run first: deriving every
+    pending image before detecting any -- the previous shape of this loop --
+    meant a panel whose parent's boxes.json was missing (a fresh volume, or a
+    re-split that dropped it) never found them, fell through to its own
+    detection, and the derivation path was never taken in exactly the run
+    meant to exercise it. Returns (derived, detected) counts.
+    """
+    parents = [image for image in todo if "__" not in Path(image).stem]
+    panels = [image for image in todo if "__" in Path(image).stem]
+    for image in tqdm(parents, smoothing=0, disable=not parents):
+        detect(image)
     derived = 0
-    detect: list[str] = []
-    for image in todo:
+    leftover: list[str] = []
+    for image in panels:
         if derive_boxes_for_panel_image(image):
             derived += 1
         else:
-            detect.append(image)
+            leftover.append(image)
     if derived:
         print(
             f"Derived {derived} panel box file(s) from parents (#361).",
             file=sys.stderr,
         )
-    if detect:
-        import easyocr
-
-        reader = easyocr.Reader(["en"], gpu=not args.no_gpu, verbose=False)
-        for image in tqdm(detect, smoothing=0):
-            write_craft_boxes(
-                image,
-                reader,
-                min_size=args.min_size,
-                link_threshold=args.link_threshold,
-                craft_scale=args.craft_scale,
-                tile_size=args.tile_size,
-            )
-    print(
-        f"Wrote boxes for {len(todo)} image(s) ({derived} derived).",
-        file=sys.stderr,
-    )
+    for image in tqdm(leftover, smoothing=0, disable=not leftover):
+        detect(image)
+    return derived, len(parents) + len(leftover)
 
 
 if __name__ == "__main__":

--- a/mapsnap/craft_test.py
+++ b/mapsnap/craft_test.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from mapsnap.craft import expand_images, pending_images
+from mapsnap.craft import expand_images, pending_images, process_pending
 from mapsnap.detect_text import boxes_path, craft_hint, missing_boxes, require_boxes
 
 
@@ -76,3 +76,40 @@ def test_volume_craft_images_covers_panels_and_split_parents(tmp_path):
 
     stems = {Path(p).stem for p in volume_craft_images(tmp_path, ["p0"])}
     assert {"p1", "p2", "p2__1", "p2__2", "p0"} <= stems
+
+
+def test_process_pending_detects_parents_before_deriving_panels(tmp_path):
+    # A split sheet whose parent has NO boxes yet (deleted before a re-run):
+    # the parent must be detected first so the panel can be derived from it,
+    # and the panel must then not be detected on its own.
+    from PIL import Image
+
+    parent = tmp_path / "p12.jpg"
+    Image.new("RGB", (200, 100), "white").save(parent)
+    panel = tmp_path / "p12__1.jpg"
+    Image.new("RGB", (100, 100), "white").save(panel)
+    (tmp_path / "p12.panels.json").write_text(
+        json.dumps(
+            {
+                "image": "p12.jpg",
+                "width": 200,
+                "height": 100,
+                "panels": [
+                    [[0, 0], [100, 0], [100, 100], [0, 100]],
+                    [[100, 0], [200, 0], [200, 100], [100, 100]],
+                ],
+            }
+        )
+    )
+    detected: list[str] = []
+
+    def detect(image: str) -> None:
+        detected.append(Path(image).name)
+        Path(image).with_suffix(".boxes.json").write_text(
+            json.dumps({"width": 200, "height": 100, "boxes": [], "command": []})
+        )
+
+    derived, count = process_pending([str(panel), str(parent)], detect)
+    assert detected == ["p12.jpg"]
+    assert derived == 1 and count == 1
+    assert (tmp_path / "p12__1.boxes.json").exists()


### PR DESCRIPTION
Two things found on the 2026-09-03 fresh run of Richmond and Chicago (pre-flight: straggler key-map panels removed, split sheets re-split under the bottom-left rule, split-sheet `boxes.json` deleted, reads dropped, `rerun --no-fit` then `fit`).

## craft never took its derivation path when the parent's boxes were missing

A panel's boxes are derived from its parent's (#361/#362), so the parent's detection has to run first. The loop tried every pending image's derivation before detecting any, so a panel whose parent's `boxes.json` was missing (a fresh volume, or the pre-flight above) found nothing to derive from and fell through to its own detection. Proof from the run: Richmond p370__1's box file was byte-identical to a fresh CRAFT pass on the panel image (29 of 29 boxes), while a scratch remap from the parent gave 28 boxes at 1 to 3 px offsets.

`process_pending` now detects the parents, derives the panels, and detects only the panels whose derivation still fails. The test drives it with an injected detector and a parent that has no boxes yet. Re-running craft on Richmond's six panels after the fix: `Derived 6 panel box file(s) from parents`, each identical to a scratch remap.

## What the derived boxes did to the fits

Richmond under a second tag with derived panel boxes: five of six panels unchanged or marginally better (p326__2 12.9 → 12.1 ft, p370__2 50.5 → 48.9 ft); p370__1 went from a 10 ft fit to `misscale`. Same three streets and same two intersection GCPs either way; a two-point fit tipped over the scale gate on geometry shifted by a pixel or two. Volume score 86.5 → 86.4.

## Baseline pre-flight notes (docs/baseline.md)

The splitter's rejection of a key-map sheet's old split cleans the 25% directory only; the key-map pipeline's `raw/p0__N.*` copies must be deleted by hand or the key-map chain keeps finding the dead panel (Chicago). And how to exercise the craft-derivation path deliberately.

## The run itself (no code change involved)

| volume | 2026-08-28 | 2026-09-03 | note |
|---|---|---|---|
| richmond | 86.5 (post-#376) | 86.5 | p370 renumbered under the bottom-left rule; inset masking and rebuilt key map moved nothing |
| chicago | 80.0, 103/111 placed | 79.1, 106/111 placed | notch split rejected at the source, key map whole again; p1N (hidden by the notch) 4478 → 656 ft; three snap rescues newly placed, one a 629 ft alias (p106W) that the metric counts where an unplaced page counted nothing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)