### PR TITLE
Per-page content-region maps and a Page / Region / P(road) toggle in the volume viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,8 @@ npm run dev
 
 Then visit localhost:5173/mapsnap/.
 
+The same app also hosts the **volume viewer** (`localhost:5173/mapsnap/?view=iiif`), which draws a whole run's pages warped onto OpenStreetMap; it needs the local API server (`npm run server`) alongside `npm run dev`. Its Page / Region / P(road) toggle draws each page as its sheet, its content-region map, or its road-probability map. Region maps come from `mapsnap region data/<vol>` (written to `artifacts/region/`), P(road) maps from the snap experiments' `artifacts/edge_join/roadprob/`.
+
 To deploy the debugger:
 
 ```

--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -14,6 +14,7 @@
 import type { Endpoint, GetEndpoint } from 'crosswalk/dist/api-spec';
 import type {
   GeorefAnnotationPage,
+  PageImage,
   RewrittenAnnotationResponse,
   VolumeListResponse,
 } from './iiifAnnotations.ts';
@@ -56,6 +57,8 @@ export interface OsmRelationResponse {
 /** Query naming a georeference AnnotationPage, repo-root-relative. */
 export interface AnnotationQuery {
   path: string;
+  /** Draw each page's P(region) or P(road) map in place of its sheet; the sheet when absent. */
+  image?: PageImage;
 }
 
 /** Response of GET /api/images. */

--- a/app/server/iiifAnnotations.test.ts
+++ b/app/server/iiifAnnotations.test.ts
@@ -298,6 +298,21 @@ describe('rewriteAnnotationPage', () => {
     ]);
   });
 
+  it("serves a named alternate image in the sheet's place", () => {
+    const [imageKey, sheet] = [...localPages.entries()][0];
+    const alternate = new Map([
+      [imageKey, { ...sheet, file: `artifacts/region/${imageKey}.png` }],
+    ]);
+    const { annotation } = rewriteAnnotationPage(
+      fixturePage(),
+      alternate,
+      baseUrl,
+    );
+    expect(annotation.items[0]!.target?.source?.id).toBe(
+      `${baseUrl}/artifacts/region/${imageKey}.png`,
+    );
+  });
+
   it('does not mutate its input', () => {
     const input = fixturePage();
     rewriteAnnotationPage(input, localPages, baseUrl);

--- a/app/server/iiifAnnotations.ts
+++ b/app/server/iiifAnnotations.ts
@@ -14,6 +14,32 @@
 export interface LocalPageImage {
   width: number;
   height: number;
+  /**
+   * The image to serve, relative to the volume directory; the page's own
+   * `<imageKey>.jpg` when absent. An alternate raster in the sheet's pixel
+   * frame -- its P(region) or P(road) map -- is served in the sheet's place by
+   * naming it here, with its own dimensions.
+   */
+  file?: string;
+}
+
+/** Which raster to draw for each page: its sheet, its P(region) map, or its P(road) map. */
+export type PageImage = 'page' | 'region' | 'roadprob';
+
+/**
+ * The file, relative to the volume directory, holding a page's alternate image.
+ *
+ * P(region) maps are written by `mapsnap region` (#226, #352); P(road) maps
+ * by the edge-join and snap experiments. Both are rendered at the 25% page's
+ * own resolution, but callers read the PNG's real size rather than assume it.
+ */
+export function pageImageFile(
+  image: Exclude<PageImage, 'page'>,
+  imageKey: string,
+): string {
+  return image === 'region'
+    ? `artifacts/region/${imageKey}.png`
+    : `artifacts/edge_join/roadprob/${imageKey}.png`;
 }
 
 export interface GeorefSource {
@@ -88,7 +114,14 @@ export interface VolumeListResponse {
 }
 
 /** Response shape of GET /iiif-api/annotation?path=... */
-export type RewrittenAnnotationResponse = RewriteResult;
+export interface RewrittenAnnotationResponse extends RewriteResult {
+  /**
+   * Page keys drawn from their sheet because the requested alternate image
+   * (`?image=region|roadprob`) is not on disk. Absent when the sheet itself
+   * was requested.
+   */
+  imageFallbacks?: string[];
+}
 
 /**
  * Extract the page key from an OIM annotation label, or null if it has none.
@@ -288,7 +321,7 @@ export function rewriteAnnotationPage(
     const scaleX = local.width / source.width;
     const scaleY = local.height / source.height;
     target.source = {
-      id: `${serviceBaseUrl}/${imageKey}.jpg`,
+      id: `${serviceBaseUrl}/${local.file ?? `${imageKey}.jpg`}`,
       type: 'ImageService3',
       width: local.width,
       height: local.height,

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -14,6 +14,9 @@ import type { Express } from 'express';
 import { HTTPError, type TypedRouter } from 'crosswalk';
 import type { API } from './api.ts';
 import {
+  pageImageFile,
+  type LocalPageImage,
+  type PageImage,
   imageStemsByLowercase,
   rewriteAnnotationPage,
   serviceUrlToPageKey,
@@ -22,6 +25,7 @@ import {
   type VolumeInfo,
 } from './iiifAnnotations.ts';
 import { jpegDimensions } from './jpegDimensions.ts';
+import { pngDimensions } from './pngDimensions.ts';
 import {
   parseCompareFooter,
   parseCompareTxt,
@@ -127,6 +131,33 @@ async function cachedJpegDimensions(
  * info.json responses are passed through {@link withTiles} first; see there
  * for why an advertised tileset is load-bearing for the map viewer.
  */
+const PAGE_IMAGES: readonly PageImage[] = ['page', 'region', 'roadprob'];
+
+// The annotation route's `image` query value, the sheet when absent; anything
+// else is a client error rather than a silent fall-through to the sheet.
+function pageImageOf(value: unknown): PageImage {
+  const image = value ?? 'page';
+  if (!PAGE_IMAGES.includes(image as PageImage)) {
+    throw new HTTPError(400, `invalid image: ${String(value)}`);
+  }
+  return image as PageImage;
+}
+
+// A page's alternate image (its P(region) or P(road) map) at the PNG's own
+// size when it is on disk, else null so the caller serves the sheet.
+function alternatePageImage(
+  volumeDir: string,
+  image: Exclude<PageImage, 'page'>,
+  imageKey: string,
+): LocalPageImage | null {
+  const file = pageImageFile(image, imageKey);
+  try {
+    return { ...pngDimensions(join(volumeDir, file)), file };
+  } catch {
+    return null;
+  }
+}
+
 export function registerIiifImages(app: Express, dataDir: string): void {
   app.use('/iiif', (request, response, next) => {
     if (!request.path.endsWith('/info.json')) return next();
@@ -202,6 +233,7 @@ export function registerIiifApi(
   // "data/" is tolerated (dataDir already points at the data directory).
   router.get('/iiif-api/annotation', async (_params, request) => {
     const rawPath = request.query.path;
+    const image = pageImageOf(request.query.image);
     const relativePath = rawPath.replace(/^data\//, '');
     const parts = relativePath.split('/');
     if (
@@ -221,7 +253,8 @@ export function registerIiifApi(
     }
     const volumeDir = dirname(annotationPath);
     const stems = await imageStemsByLowercase(volumeDir);
-    const localPages = new Map<string, { width: number; height: number }>();
+    const localPages = new Map<string, LocalPageImage>();
+    const fallbacks: string[] = [];
     for (const item of page.items) {
       // Same (url, label) pair rewriteAnnotationPage will use: the label
       // carries the split-panel variant and, for volumes that link no image
@@ -245,17 +278,30 @@ export function registerIiifApi(
       const imageKey = stems.get(parent.toLowerCase()) ?? parent;
       if (localPages.has(imageKey)) continue;
       try {
-        const dims = await cachedJpegDimensions(
+        const sheet = await cachedJpegDimensions(
           join(volumeDir, `${imageKey}.jpg`),
         );
-        localPages.set(imageKey, dims);
+        const alternate =
+          image === 'page'
+            ? null
+            : alternatePageImage(volumeDir, image, imageKey);
+        if (image !== 'page' && !alternate) fallbacks.push(imageKey);
+        localPages.set(imageKey, alternate ?? sheet);
       } catch {
         // No local image for this page; rewriteAnnotationPage reports it.
       }
     }
     const volumePath = parts.slice(0, -1).join('/');
     const serviceBaseUrl = `${request.protocol}://${request.get('host')}/iiif/${volumePath}`;
-    return rewriteAnnotationPage(page, localPages, serviceBaseUrl, stems);
+    const rewritten = rewriteAnnotationPage(
+      page,
+      localPages,
+      serviceBaseUrl,
+      stems,
+    );
+    return image === 'page'
+      ? rewritten
+      : { ...rewritten, imageFallbacks: fallbacks };
   });
 
   // Where a run's own per-page sidecars live, so the viewer can link to the files

--- a/app/server/pngDimensions.test.ts
+++ b/app/server/pngDimensions.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { pngDimensionsFromBuffer } from './pngDimensions';
+
+// The first 24 bytes of a PNG: signature, IHDR length, "IHDR", width, height.
+function syntheticPng(width: number, height: number, type = 'IHDR'): Buffer {
+  const head = Buffer.alloc(24);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(head, 0);
+  head.writeUInt32BE(13, 8);
+  head.write(type, 12, 'latin1');
+  head.writeUInt32BE(width, 16);
+  head.writeUInt32BE(height, 20);
+  return head;
+}
+
+describe('pngDimensionsFromBuffer', () => {
+  it('reads width and height from the IHDR chunk', () => {
+    expect(pngDimensionsFromBuffer(syntheticPng(1586, 1949))).toEqual({
+      width: 1586,
+      height: 1949,
+    });
+  });
+
+  it('rejects other formats and a misplaced IHDR', () => {
+    expect(() =>
+      pngDimensionsFromBuffer(Buffer.from([0xff, 0xd8, 0xff, 0xe0])),
+    ).toThrow('Not a PNG');
+    expect(() => pngDimensionsFromBuffer(syntheticPng(1, 1, 'IDAT'))).toThrow(
+      'IHDR',
+    );
+  });
+});

--- a/app/server/pngDimensions.ts
+++ b/app/server/pngDimensions.ts
@@ -1,0 +1,34 @@
+/**
+ * PNG dimension reading without an image library.
+ *
+ * A PNG's first chunk is always IHDR, so the size sits at fixed offsets: the
+ * 8-byte signature, a 4-byte chunk length, the 4-byte type "IHDR", then width
+ * and height as big-endian 32-bit integers.
+ */
+
+import { readFileSync } from 'fs';
+import type { ImageDimensions } from './jpegDimensions.ts';
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/**
+ * Return the dimensions of a PNG from its bytes.
+ *
+ * Throws if the buffer is not a PNG or its first chunk is not IHDR.
+ */
+export function pngDimensionsFromBuffer(data: Buffer): ImageDimensions {
+  if (data.length < 24 || !data.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    throw new Error('Not a PNG');
+  }
+  if (data.toString('latin1', 12, 16) !== 'IHDR') {
+    throw new Error('PNG does not start with an IHDR chunk');
+  }
+  return { width: data.readUInt32BE(16), height: data.readUInt32BE(20) };
+}
+
+/** Read a PNG file's dimensions from its IHDR chunk. */
+export function pngDimensions(path: string): ImageDimensions {
+  return pngDimensionsFromBuffer(readFileSync(path));
+}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -5,6 +5,12 @@ import {
   underlayImageParam,
   type KeymapUnderlayImage,
 } from '../iiif/underlay';
+import {
+  pageImageFromParam,
+  pageImageNoun,
+  pageImageParam,
+  type PageImage,
+} from '../iiif/pageImage';
 import type {
   GeorefAnnotationPage,
   SkippedItem,
@@ -114,6 +120,13 @@ export function VolumeViewer() {
     const value = Number(initialParams.get('keymap'));
     return Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : 0;
   });
+  // What the pages are drawn as (#352): their sheets, or their P(region) or
+  // P(road) maps, served through the same annotation so they warp identically.
+  const [pageImage, setPageImage] = useState<PageImage>(() =>
+    pageImageFromParam(initialParams.get('pages')),
+  );
+  // Pages drawn as their sheet because the chosen map is not on disk.
+  const [imageFallbacks, setImageFallbacks] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   // Selection is tracked by page stem (stable across annotation files, unlike the item index).
   const [selectedStem, setSelectedStem] = useState<string | null>(() =>
@@ -190,11 +203,12 @@ export function VolumeViewer() {
     let cancelled = false;
     setError(null);
     setLoadResult(null);
-    fetchRewrittenAnnotation(selectedPath)
+    fetchRewrittenAnnotation(selectedPath, pageImage)
       .then((resp) => {
         if (cancelled) return;
         setAnnotation(resp.annotation);
         setSkipped(resp.skipped);
+        setImageFallbacks(resp.imageFallbacks ?? []);
       })
       .catch((err) => {
         if (!cancelled) setError(String(err));
@@ -245,7 +259,7 @@ export function VolumeViewer() {
     return () => {
       cancelled = true;
     };
-  }, [selectedPath]);
+  }, [selectedPath, pageImage]);
 
   const selection = parseAnnotationPath(selectedPath);
   const selectedVolume = volumes?.find((v) => v.name === selection?.volume);
@@ -482,6 +496,7 @@ export function VolumeViewer() {
       only: isolateSelected ? '1' : null,
       underlay: underlayImageParam(underlayImage),
       keymap: keymapOpacity > 0 ? String(keymapOpacity) : null,
+      pages: pageImageParam(pageImage),
     });
   }, [
     selectedStem,
@@ -491,6 +506,7 @@ export function VolumeViewer() {
     isolateSelected,
     underlayImage,
     keymapOpacity,
+    pageImage,
   ]);
 
   function selectVolume(name: string): void {
@@ -506,6 +522,12 @@ export function VolumeViewer() {
     const parts: string[] = [];
     if (loadResult.failed > 0) parts.push(`${loadResult.failed} pages failed`);
     if (skipped.length > 0) parts.push(`${skipped.length} skipped`);
+    if (pageImage !== 'page' && imageFallbacks.length > 0) {
+      const hint = pageImage === 'region' ? ' (mapsnap region <volume>)' : '';
+      parts.push(
+        `${imageFallbacks.length} pages have no ${pageImageNoun(pageImage)}${hint}, drawn as sheets`,
+      );
+    }
     status = parts.join(', ');
   } else if (selectedPath) {
     status = 'loading…';
@@ -611,6 +633,38 @@ export function VolumeViewer() {
             onChange={(e) => setOpacity(Number(e.target.value))}
           />
           <label htmlFor="iiif-opacity-slider">Opacity (p)</label>
+          {/* Disabled while the pages are hidden, like the key-map toggle. */}
+          <div
+            className="segmented"
+            role="group"
+            aria-label="Page image"
+            title="Draw each page as its sheet, its content-region map (mapsnap region, #352), or its P(road) map."
+          >
+            <button
+              type="button"
+              aria-pressed={pageImage === 'page'}
+              disabled={opacity === 0}
+              onClick={() => setPageImage('page')}
+            >
+              Page
+            </button>
+            <button
+              type="button"
+              aria-pressed={pageImage === 'region'}
+              disabled={opacity === 0}
+              onClick={() => setPageImage('region')}
+            >
+              Region
+            </button>
+            <button
+              type="button"
+              aria-pressed={pageImage === 'roadprob'}
+              disabled={opacity === 0}
+              onClick={() => setPageImage('roadprob')}
+            >
+              P(road)
+            </button>
+          </div>
         </div>
         {keymaps.some((keymap) => keymap.hasGeoref) && (
           <div

--- a/app/src/iiif/api.ts
+++ b/app/src/iiif/api.ts
@@ -4,6 +4,7 @@ import type { API, KeymapInfo, RunArtifactsResponse } from '../../server/api';
 import type { CompareResponse } from '../../server/compareTxt';
 import type { OsmRelationResponse } from '../../server/api';
 import type {
+  PageImage,
   RewrittenAnnotationResponse,
   VolumeListResponse,
 } from '../../server/iiifAnnotations';
@@ -20,11 +21,17 @@ export function fetchVolumes(): Promise<VolumeListResponse> {
  * Fetch an annotation file, rewritten to target the local IIIF image server.
  *
  * The path is repo-root-relative, e.g. "data/brooklyn_ny_1906_vol_6/generated.iiif.json".
+ * With an `image` other than the sheet, each page's image service points at
+ * its P(region) or P(road) map instead (falling back to the sheet per page).
  */
 export function fetchRewrittenAnnotation(
   path: string,
+  image: PageImage = 'page',
 ): Promise<RewrittenAnnotationResponse> {
-  return api.get('/iiif-api/annotation')(null, { path });
+  return api.get('/iiif-api/annotation')(
+    null,
+    image === 'page' ? { path } : { path, image },
+  );
 }
 
 /** A volume's page-image stems, and every georef sidecar each page has. */

--- a/app/src/iiif/pageImage.test.ts
+++ b/app/src/iiif/pageImage.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { pageImageFromParam, pageImageParam } from './pageImage';
+
+describe('page image URL parameter', () => {
+  it('round-trips the alternate images and omits the default sheet', () => {
+    expect(pageImageParam('page')).toBeNull();
+    expect(pageImageParam('region')).toBe('region');
+    expect(pageImageFromParam(pageImageParam('roadprob'))).toBe('roadprob');
+  });
+
+  it('reads anything unknown as the sheet', () => {
+    expect(pageImageFromParam(null)).toBe('page');
+    expect(pageImageFromParam('heatmap')).toBe('page');
+  });
+});

--- a/app/src/iiif/pageImage.ts
+++ b/app/src/iiif/pageImage.ts
@@ -1,0 +1,27 @@
+/**
+ * Which raster the volume viewer draws for each page (#352): the sheet
+ * itself, its P(region) map (`mapsnap region`), or its P(road) map.
+ *
+ * The maps are served through the same annotation as the sheets, each page's
+ * image service pointed at the PNG instead, so they warp and clip exactly as
+ * the sheets do: where two neighbours' content regions overlap on the map, the
+ * pages overlap on the ground.
+ */
+import type { PageImage } from '../../server/iiifAnnotations';
+
+export type { PageImage };
+
+/** The image a URL parameter names; anything unknown is the sheet. */
+export function pageImageFromParam(value: string | null): PageImage {
+  return value === 'region' || value === 'roadprob' ? value : 'page';
+}
+
+/** The URL parameter value for an image; null (omit) for the default sheet. */
+export function pageImageParam(image: PageImage): string | null {
+  return image === 'page' ? null : image;
+}
+
+/** What the status line calls a page's alternate image when it is missing. */
+export function pageImageNoun(image: PageImage): string {
+  return image === 'region' ? 'region map' : 'P(road) map';
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -192,7 +192,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
-  width: 126px; /* the Key map / P(road) toggle's natural width; both sliders match it */
+  width: 168px; /* the Page / Region / P(road) toggle's natural width; both sliders match it */
   flex-shrink: 0;
 }
 

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -83,6 +83,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
     "download-osm": ("mapsnap.download_osm", "Download street data from OSM"),
     "osm-to-geojson": ("mapsnap.osm_to_centerlines", "Convert OSM data to GeoJSON."),
     "scale": ("mapsnap.scale_images", "Shrink images by a uniform amount."),
+    "region": (
+        "mapsnap.region_predict",
+        "Predict each page's content region as a P(region) PNG.",
+    ),
     "download-oim": (
         "mapsnap.download_oim_iiif",
         "Fetch all images for a Sanborn volume from OldInsuranceMaps.net",

--- a/mapsnap/region_model.py
+++ b/mapsnap/region_model.py
@@ -262,15 +262,27 @@ def cmd_train(args: argparse.Namespace) -> None:
     print(f"best val IoU {best:.3f} -> {args.output}")
 
 
-def cmd_predict(args: argparse.Namespace) -> None:
+def load_region_model(
+    path: Path = REGION_MODEL_PATH, device: torch.device | None = None
+) -> tuple[UNet, torch.device]:
+    """Load the trained content-region UNet, on the best available device by default.
+
+    The encoder width is read from the checkpoint, so weights trained with a
+    different ``--base`` load without a flag.
+    """
     from mapsnap.keymap.number_model import select_device
 
-    device = select_device()
-    state = torch.load(args.model, map_location=device)
+    device = device or select_device()
+    state = torch.load(path, map_location=device)
     base = state["enc1.block.0.weight"].shape[0]
     model = UNet(base=base, in_channels=3, norm="group").to(device)
     model.load_state_dict(state)
     model.eval()
+    return model, device
+
+
+def cmd_predict(args: argparse.Namespace) -> None:
+    model, device = load_region_model(args.model)
     args.out_dir.mkdir(parents=True, exist_ok=True)
     for path in args.images:
         image = cv2.imread(str(path))

--- a/mapsnap/region_predict.py
+++ b/mapsnap/region_predict.py
@@ -1,0 +1,93 @@
+"""Predict every page's content region and write it as a P(region) map.
+
+The content-region model (``mapsnap.region_model``, #226) predicts per pixel
+whether a sheet position holds content exclusive to that page, as opposed to
+margin, title block, or a strip duplicated from a neighbour. This command runs
+it over a volume's 25% page images, parents and split panels alike, and writes
+each map as an 8-bit PNG at the page's own resolution:
+
+    data/<vol>/artifacts/region/<stem>.png     0 = margin, 255 = content
+
+The volume viewer draws these in place of the sheets (its Page / Region /
+P(road) toggle), and the content-region overlap analysis (#352) reads them.
+
+    mapsnap region data/<vol>            # every p*.jpg that lacks a map
+    mapsnap region data/<vol> --force    # redo them all
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+
+from mapsnap.region_model import predict_region
+
+REGION_DIR = Path("artifacts") / "region"
+
+
+def region_prob_path(volume: Path, stem: str) -> Path:
+    """Where a page's P(region) map lives: ``<volume>/artifacts/region/<stem>.png``."""
+    return volume / REGION_DIR / f"{stem}.png"
+
+
+def write_region_maps(
+    volume: Path,
+    images: list[Path],
+    *,
+    model: torch.nn.Module,
+    device: torch.device,
+    force: bool = False,
+) -> list[Path]:
+    """Predict and write P(region) maps for ``images``; returns the paths written.
+
+    Maps that already exist are kept unless ``force``. Unreadable images are
+    reported on stderr and skipped.
+    """
+    written: list[Path] = []
+    for image_path in images:
+        out = region_prob_path(volume, image_path.stem)
+        if out.exists() and not force:
+            continue
+        image = cv2.imread(str(image_path))
+        if image is None:
+            print(f"skip (unreadable): {image_path}", file=sys.stderr)
+            continue
+        prob = predict_region(model, image, device)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        cv2.imwrite(str(out), np.clip(prob * 255, 0, 255).astype(np.uint8))
+        written.append(out)
+    return written
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "volume", type=Path, help="Volume directory holding the p*.jpg pages."
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Rewrite maps that already exist."
+    )
+    args = parser.parse_args()
+
+    from mapsnap.region_model import load_region_model
+
+    images = sorted(args.volume.glob("p*.jpg"))
+    if not images:
+        sys.exit(f"no p*.jpg pages under {args.volume}")
+    model, device = load_region_model()
+    written = write_region_maps(
+        args.volume, images, model=model, device=device, force=args.force
+    )
+    print(
+        f"wrote {len(written)} of {len(images)} P(region) maps"
+        f" to {args.volume / REGION_DIR}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/region_predict_test.py
+++ b/mapsnap/region_predict_test.py
@@ -1,0 +1,59 @@
+"""Tests for the per-page P(region) map writer."""
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+import torch
+
+from mapsnap.region_predict import region_prob_path, write_region_maps
+
+
+class HalfModel(torch.nn.Module):
+    """Stub UNet: zero logits everywhere, so P(region) is 0.5 at every pixel."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.zeros(x.shape[0], 1, x.shape[2], x.shape[3])
+
+
+def write_page(path: Path, width: int, height: int) -> None:
+    cv2.imwrite(str(path), np.full((height, width, 3), 200, np.uint8))
+
+
+def test_writes_maps_at_page_resolution_and_keeps_existing(tmp_path: Path) -> None:
+    write_page(tmp_path / "p7.jpg", 40, 30)
+    write_page(tmp_path / "p7__1.jpg", 20, 30)
+    model, device = HalfModel(), torch.device("cpu")
+    images = sorted(tmp_path.glob("p*.jpg"))
+
+    written = write_region_maps(tmp_path, images, model=model, device=device)
+
+    assert written == [
+        region_prob_path(tmp_path, "p7"),
+        region_prob_path(tmp_path, "p7__1"),
+    ]
+    prob = cv2.imread(str(region_prob_path(tmp_path, "p7")), cv2.IMREAD_GRAYSCALE)
+    assert prob is not None
+    assert prob.shape == (30, 40)
+    assert np.all(prob == 127)  # sigmoid(0) * 255, truncated
+    panel = cv2.imread(str(region_prob_path(tmp_path, "p7__1")), cv2.IMREAD_GRAYSCALE)
+    assert panel is not None
+    assert panel.shape == (30, 20)
+
+    # A second pass rewrites nothing; --force redoes everything.
+    assert write_region_maps(tmp_path, images, model=model, device=device) == []
+    redone = write_region_maps(tmp_path, images, model=model, device=device, force=True)
+    assert len(redone) == 2
+
+
+def test_skips_unreadable_images(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / "p9.jpg").write_bytes(b"not a jpeg")
+    written = write_region_maps(
+        tmp_path, [tmp_path / "p9.jpg"], model=HalfModel(), device=torch.device("cpu")
+    )
+    assert written == []
+    assert not region_prob_path(tmp_path, "p9").exists()
+    assert "skip (unreadable)" in capsys.readouterr().err


### PR DESCRIPTION
## What

- **`mapsnap region data/<vol>`** (new): runs the content-region UNet from #355 over every 25% page image, parents and split panels alike, and writes each prediction as an 8-bit P(region) PNG at the page's own resolution to `data/<vol>/artifacts/region/<stem>.png` (0 = margin, 255 = content). Existing maps are kept unless `--force`. Detroit's 116 pages take 17 s on MPS. Until now nothing consumed the region model; its only output was a JET preview overlay.
- **Volume viewer toggle**: a Page / Region / P(road) segmented control under the opacity slider (URL `pages=region|roadprob`). The annotation route accepts `?image=` and points each page's image service at the PNG instead of the sheet, with the PNG's real dimensions, so the maps warp and clip exactly as the sheets do. Pages without the map fall back to their sheet and the status line says how many (`86 pages have no region map (mapsnap region <volume>), drawn as sheets`). P(road) reuses the page maps the snap experiments leave in `artifacts/edge_join/roadprob/`.
- `load_region_model()` factored out of the region model's predict command; a PNG IHDR dimension reader beside the JPEG one; README notes for the command and the viewer.

## Why

#352 measures content-region overlap as a wrong-fit signal but there was no way to look at the regions. On Detroit's 2026-09-03 run, placing the predicted regions at the published poses shows all three ≥200 ft disasters overlapping a neighbour by 32–49% of the smaller region (p61 ↔ p59, p85 ↔ p86, p93 ↔ p94) while good pages sit at a median 3%. The toggle makes that visible directly on the map.

Part of #352.

## Verification

- `uv run pytest mapsnap/region_predict_test.py` (stub model: page-resolution PNGs, skip-existing, `--force`, unreadable input) plus ruff / pyright repo-wide.
- `npm run type-check`, `npx vitest run` (282 tests incl. the alternate-image rewrite, PNG reader, URL param round trip), `npx prettier --check .`
- Viewed Detroit 2026-09-03 in all three modes and NO-1896 (no region maps) for the fallback status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)