### PR TITLE
Content-region overlap as a pairwise reconcile factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,8 @@ npm run dev
 
 Then visit localhost:5173/mapsnap/.
 
+The same app also hosts the **volume viewer** (`localhost:5173/mapsnap/?view=iiif`), which draws a whole run's pages warped onto OpenStreetMap; it needs the local API server (`npm run server`) alongside `npm run dev`. Its Page / Region / P(road) toggle draws each page as its sheet, its content-region map, or its road-probability map. Region maps come from `mapsnap region data/<vol>` (written to `artifacts/region/`), P(road) maps from the snap experiments' `artifacts/edge_join/roadprob/`.
+
 To deploy the debugger:
 
 ```

--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -14,6 +14,7 @@
 import type { Endpoint, GetEndpoint } from 'crosswalk/dist/api-spec';
 import type {
   GeorefAnnotationPage,
+  PageImage,
   RewrittenAnnotationResponse,
   VolumeListResponse,
 } from './iiifAnnotations.ts';
@@ -56,6 +57,8 @@ export interface OsmRelationResponse {
 /** Query naming a georeference AnnotationPage, repo-root-relative. */
 export interface AnnotationQuery {
   path: string;
+  /** Draw each page's P(region) or P(road) map in place of its sheet; the sheet when absent. */
+  image?: PageImage;
 }
 
 /** Response of GET /api/images. */

--- a/app/server/iiifAnnotations.test.ts
+++ b/app/server/iiifAnnotations.test.ts
@@ -298,6 +298,21 @@ describe('rewriteAnnotationPage', () => {
     ]);
   });
 
+  it("serves a named alternate image in the sheet's place", () => {
+    const [imageKey, sheet] = [...localPages.entries()][0];
+    const alternate = new Map([
+      [imageKey, { ...sheet, file: `artifacts/region/${imageKey}.png` }],
+    ]);
+    const { annotation } = rewriteAnnotationPage(
+      fixturePage(),
+      alternate,
+      baseUrl,
+    );
+    expect(annotation.items[0]!.target?.source?.id).toBe(
+      `${baseUrl}/artifacts/region/${imageKey}.png`,
+    );
+  });
+
   it('does not mutate its input', () => {
     const input = fixturePage();
     rewriteAnnotationPage(input, localPages, baseUrl);

--- a/app/server/iiifAnnotations.ts
+++ b/app/server/iiifAnnotations.ts
@@ -14,6 +14,32 @@
 export interface LocalPageImage {
   width: number;
   height: number;
+  /**
+   * The image to serve, relative to the volume directory; the page's own
+   * `<imageKey>.jpg` when absent. An alternate raster in the sheet's pixel
+   * frame -- its P(region) or P(road) map -- is served in the sheet's place by
+   * naming it here, with its own dimensions.
+   */
+  file?: string;
+}
+
+/** Which raster to draw for each page: its sheet, its P(region) map, or its P(road) map. */
+export type PageImage = 'page' | 'region' | 'roadprob';
+
+/**
+ * The file, relative to the volume directory, holding a page's alternate image.
+ *
+ * P(region) maps are written by `mapsnap region` (#226, #352); P(road) maps
+ * by the edge-join and snap experiments. Both are rendered at the 25% page's
+ * own resolution, but callers read the PNG's real size rather than assume it.
+ */
+export function pageImageFile(
+  image: Exclude<PageImage, 'page'>,
+  imageKey: string,
+): string {
+  return image === 'region'
+    ? `artifacts/region/${imageKey}.png`
+    : `artifacts/edge_join/roadprob/${imageKey}.png`;
 }
 
 export interface GeorefSource {
@@ -88,7 +114,14 @@ export interface VolumeListResponse {
 }
 
 /** Response shape of GET /iiif-api/annotation?path=... */
-export type RewrittenAnnotationResponse = RewriteResult;
+export interface RewrittenAnnotationResponse extends RewriteResult {
+  /**
+   * Page keys drawn from their sheet because the requested alternate image
+   * (`?image=region|roadprob`) is not on disk. Absent when the sheet itself
+   * was requested.
+   */
+  imageFallbacks?: string[];
+}
 
 /**
  * Extract the page key from an OIM annotation label, or null if it has none.
@@ -288,7 +321,7 @@ export function rewriteAnnotationPage(
     const scaleX = local.width / source.width;
     const scaleY = local.height / source.height;
     target.source = {
-      id: `${serviceBaseUrl}/${imageKey}.jpg`,
+      id: `${serviceBaseUrl}/${local.file ?? `${imageKey}.jpg`}`,
       type: 'ImageService3',
       width: local.width,
       height: local.height,

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -14,6 +14,9 @@ import type { Express } from 'express';
 import { HTTPError, type TypedRouter } from 'crosswalk';
 import type { API } from './api.ts';
 import {
+  pageImageFile,
+  type LocalPageImage,
+  type PageImage,
   imageStemsByLowercase,
   rewriteAnnotationPage,
   serviceUrlToPageKey,
@@ -22,6 +25,7 @@ import {
   type VolumeInfo,
 } from './iiifAnnotations.ts';
 import { jpegDimensions } from './jpegDimensions.ts';
+import { pngDimensions } from './pngDimensions.ts';
 import {
   parseCompareFooter,
   parseCompareTxt,
@@ -127,6 +131,33 @@ async function cachedJpegDimensions(
  * info.json responses are passed through {@link withTiles} first; see there
  * for why an advertised tileset is load-bearing for the map viewer.
  */
+const PAGE_IMAGES: readonly PageImage[] = ['page', 'region', 'roadprob'];
+
+// The annotation route's `image` query value, the sheet when absent; anything
+// else is a client error rather than a silent fall-through to the sheet.
+function pageImageOf(value: unknown): PageImage {
+  const image = value ?? 'page';
+  if (!PAGE_IMAGES.includes(image as PageImage)) {
+    throw new HTTPError(400, `invalid image: ${String(value)}`);
+  }
+  return image as PageImage;
+}
+
+// A page's alternate image (its P(region) or P(road) map) at the PNG's own
+// size when it is on disk, else null so the caller serves the sheet.
+function alternatePageImage(
+  volumeDir: string,
+  image: Exclude<PageImage, 'page'>,
+  imageKey: string,
+): LocalPageImage | null {
+  const file = pageImageFile(image, imageKey);
+  try {
+    return { ...pngDimensions(join(volumeDir, file)), file };
+  } catch {
+    return null;
+  }
+}
+
 export function registerIiifImages(app: Express, dataDir: string): void {
   app.use('/iiif', (request, response, next) => {
     if (!request.path.endsWith('/info.json')) return next();
@@ -202,6 +233,7 @@ export function registerIiifApi(
   // "data/" is tolerated (dataDir already points at the data directory).
   router.get('/iiif-api/annotation', async (_params, request) => {
     const rawPath = request.query.path;
+    const image = pageImageOf(request.query.image);
     const relativePath = rawPath.replace(/^data\//, '');
     const parts = relativePath.split('/');
     if (
@@ -221,7 +253,8 @@ export function registerIiifApi(
     }
     const volumeDir = dirname(annotationPath);
     const stems = await imageStemsByLowercase(volumeDir);
-    const localPages = new Map<string, { width: number; height: number }>();
+    const localPages = new Map<string, LocalPageImage>();
+    const fallbacks: string[] = [];
     for (const item of page.items) {
       // Same (url, label) pair rewriteAnnotationPage will use: the label
       // carries the split-panel variant and, for volumes that link no image
@@ -245,17 +278,30 @@ export function registerIiifApi(
       const imageKey = stems.get(parent.toLowerCase()) ?? parent;
       if (localPages.has(imageKey)) continue;
       try {
-        const dims = await cachedJpegDimensions(
+        const sheet = await cachedJpegDimensions(
           join(volumeDir, `${imageKey}.jpg`),
         );
-        localPages.set(imageKey, dims);
+        const alternate =
+          image === 'page'
+            ? null
+            : alternatePageImage(volumeDir, image, imageKey);
+        if (image !== 'page' && !alternate) fallbacks.push(imageKey);
+        localPages.set(imageKey, alternate ?? sheet);
       } catch {
         // No local image for this page; rewriteAnnotationPage reports it.
       }
     }
     const volumePath = parts.slice(0, -1).join('/');
     const serviceBaseUrl = `${request.protocol}://${request.get('host')}/iiif/${volumePath}`;
-    return rewriteAnnotationPage(page, localPages, serviceBaseUrl, stems);
+    const rewritten = rewriteAnnotationPage(
+      page,
+      localPages,
+      serviceBaseUrl,
+      stems,
+    );
+    return image === 'page'
+      ? rewritten
+      : { ...rewritten, imageFallbacks: fallbacks };
   });
 
   // Where a run's own per-page sidecars live, so the viewer can link to the files

--- a/app/server/pngDimensions.test.ts
+++ b/app/server/pngDimensions.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { pngDimensionsFromBuffer } from './pngDimensions';
+
+// The first 24 bytes of a PNG: signature, IHDR length, "IHDR", width, height.
+function syntheticPng(width: number, height: number, type = 'IHDR'): Buffer {
+  const head = Buffer.alloc(24);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(head, 0);
+  head.writeUInt32BE(13, 8);
+  head.write(type, 12, 'latin1');
+  head.writeUInt32BE(width, 16);
+  head.writeUInt32BE(height, 20);
+  return head;
+}
+
+describe('pngDimensionsFromBuffer', () => {
+  it('reads width and height from the IHDR chunk', () => {
+    expect(pngDimensionsFromBuffer(syntheticPng(1586, 1949))).toEqual({
+      width: 1586,
+      height: 1949,
+    });
+  });
+
+  it('rejects other formats and a misplaced IHDR', () => {
+    expect(() =>
+      pngDimensionsFromBuffer(Buffer.from([0xff, 0xd8, 0xff, 0xe0])),
+    ).toThrow('Not a PNG');
+    expect(() => pngDimensionsFromBuffer(syntheticPng(1, 1, 'IDAT'))).toThrow(
+      'IHDR',
+    );
+  });
+});

--- a/app/server/pngDimensions.ts
+++ b/app/server/pngDimensions.ts
@@ -1,0 +1,34 @@
+/**
+ * PNG dimension reading without an image library.
+ *
+ * A PNG's first chunk is always IHDR, so the size sits at fixed offsets: the
+ * 8-byte signature, a 4-byte chunk length, the 4-byte type "IHDR", then width
+ * and height as big-endian 32-bit integers.
+ */
+
+import { readFileSync } from 'fs';
+import type { ImageDimensions } from './jpegDimensions.ts';
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/**
+ * Return the dimensions of a PNG from its bytes.
+ *
+ * Throws if the buffer is not a PNG or its first chunk is not IHDR.
+ */
+export function pngDimensionsFromBuffer(data: Buffer): ImageDimensions {
+  if (data.length < 24 || !data.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    throw new Error('Not a PNG');
+  }
+  if (data.toString('latin1', 12, 16) !== 'IHDR') {
+    throw new Error('PNG does not start with an IHDR chunk');
+  }
+  return { width: data.readUInt32BE(16), height: data.readUInt32BE(20) };
+}
+
+/** Read a PNG file's dimensions from its IHDR chunk. */
+export function pngDimensions(path: string): ImageDimensions {
+  return pngDimensionsFromBuffer(readFileSync(path));
+}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -5,6 +5,12 @@ import {
   underlayImageParam,
   type KeymapUnderlayImage,
 } from '../iiif/underlay';
+import {
+  pageImageFromParam,
+  pageImageNoun,
+  pageImageParam,
+  type PageImage,
+} from '../iiif/pageImage';
 import type {
   GeorefAnnotationPage,
   SkippedItem,
@@ -114,6 +120,13 @@ export function VolumeViewer() {
     const value = Number(initialParams.get('keymap'));
     return Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : 0;
   });
+  // What the pages are drawn as (#352): their sheets, or their P(region) or
+  // P(road) maps, served through the same annotation so they warp identically.
+  const [pageImage, setPageImage] = useState<PageImage>(() =>
+    pageImageFromParam(initialParams.get('pages')),
+  );
+  // Pages drawn as their sheet because the chosen map is not on disk.
+  const [imageFallbacks, setImageFallbacks] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   // Selection is tracked by page stem (stable across annotation files, unlike the item index).
   const [selectedStem, setSelectedStem] = useState<string | null>(() =>
@@ -190,11 +203,12 @@ export function VolumeViewer() {
     let cancelled = false;
     setError(null);
     setLoadResult(null);
-    fetchRewrittenAnnotation(selectedPath)
+    fetchRewrittenAnnotation(selectedPath, pageImage)
       .then((resp) => {
         if (cancelled) return;
         setAnnotation(resp.annotation);
         setSkipped(resp.skipped);
+        setImageFallbacks(resp.imageFallbacks ?? []);
       })
       .catch((err) => {
         if (!cancelled) setError(String(err));
@@ -245,7 +259,7 @@ export function VolumeViewer() {
     return () => {
       cancelled = true;
     };
-  }, [selectedPath]);
+  }, [selectedPath, pageImage]);
 
   const selection = parseAnnotationPath(selectedPath);
   const selectedVolume = volumes?.find((v) => v.name === selection?.volume);
@@ -482,6 +496,7 @@ export function VolumeViewer() {
       only: isolateSelected ? '1' : null,
       underlay: underlayImageParam(underlayImage),
       keymap: keymapOpacity > 0 ? String(keymapOpacity) : null,
+      pages: pageImageParam(pageImage),
     });
   }, [
     selectedStem,
@@ -491,6 +506,7 @@ export function VolumeViewer() {
     isolateSelected,
     underlayImage,
     keymapOpacity,
+    pageImage,
   ]);
 
   function selectVolume(name: string): void {
@@ -506,6 +522,12 @@ export function VolumeViewer() {
     const parts: string[] = [];
     if (loadResult.failed > 0) parts.push(`${loadResult.failed} pages failed`);
     if (skipped.length > 0) parts.push(`${skipped.length} skipped`);
+    if (pageImage !== 'page' && imageFallbacks.length > 0) {
+      const hint = pageImage === 'region' ? ' (mapsnap region <volume>)' : '';
+      parts.push(
+        `${imageFallbacks.length} pages have no ${pageImageNoun(pageImage)}${hint}, drawn as sheets`,
+      );
+    }
     status = parts.join(', ');
   } else if (selectedPath) {
     status = 'loading…';
@@ -611,6 +633,38 @@ export function VolumeViewer() {
             onChange={(e) => setOpacity(Number(e.target.value))}
           />
           <label htmlFor="iiif-opacity-slider">Opacity (p)</label>
+          {/* Disabled while the pages are hidden, like the key-map toggle. */}
+          <div
+            className="segmented"
+            role="group"
+            aria-label="Page image"
+            title="Draw each page as its sheet, its content-region map (mapsnap region, #352), or its P(road) map."
+          >
+            <button
+              type="button"
+              aria-pressed={pageImage === 'page'}
+              disabled={opacity === 0}
+              onClick={() => setPageImage('page')}
+            >
+              Page
+            </button>
+            <button
+              type="button"
+              aria-pressed={pageImage === 'region'}
+              disabled={opacity === 0}
+              onClick={() => setPageImage('region')}
+            >
+              Region
+            </button>
+            <button
+              type="button"
+              aria-pressed={pageImage === 'roadprob'}
+              disabled={opacity === 0}
+              onClick={() => setPageImage('roadprob')}
+            >
+              P(road)
+            </button>
+          </div>
         </div>
         {keymaps.some((keymap) => keymap.hasGeoref) && (
           <div

--- a/app/src/iiif/api.ts
+++ b/app/src/iiif/api.ts
@@ -4,6 +4,7 @@ import type { API, KeymapInfo, RunArtifactsResponse } from '../../server/api';
 import type { CompareResponse } from '../../server/compareTxt';
 import type { OsmRelationResponse } from '../../server/api';
 import type {
+  PageImage,
   RewrittenAnnotationResponse,
   VolumeListResponse,
 } from '../../server/iiifAnnotations';
@@ -20,11 +21,17 @@ export function fetchVolumes(): Promise<VolumeListResponse> {
  * Fetch an annotation file, rewritten to target the local IIIF image server.
  *
  * The path is repo-root-relative, e.g. "data/brooklyn_ny_1906_vol_6/generated.iiif.json".
+ * With an `image` other than the sheet, each page's image service points at
+ * its P(region) or P(road) map instead (falling back to the sheet per page).
  */
 export function fetchRewrittenAnnotation(
   path: string,
+  image: PageImage = 'page',
 ): Promise<RewrittenAnnotationResponse> {
-  return api.get('/iiif-api/annotation')(null, { path });
+  return api.get('/iiif-api/annotation')(
+    null,
+    image === 'page' ? { path } : { path, image },
+  );
 }
 
 /** A volume's page-image stems, and every georef sidecar each page has. */

--- a/app/src/iiif/pageImage.test.ts
+++ b/app/src/iiif/pageImage.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { pageImageFromParam, pageImageParam } from './pageImage';
+
+describe('page image URL parameter', () => {
+  it('round-trips the alternate images and omits the default sheet', () => {
+    expect(pageImageParam('page')).toBeNull();
+    expect(pageImageParam('region')).toBe('region');
+    expect(pageImageFromParam(pageImageParam('roadprob'))).toBe('roadprob');
+  });
+
+  it('reads anything unknown as the sheet', () => {
+    expect(pageImageFromParam(null)).toBe('page');
+    expect(pageImageFromParam('heatmap')).toBe('page');
+  });
+});

--- a/app/src/iiif/pageImage.ts
+++ b/app/src/iiif/pageImage.ts
@@ -1,0 +1,27 @@
+/**
+ * Which raster the volume viewer draws for each page (#352): the sheet
+ * itself, its P(region) map (`mapsnap region`), or its P(road) map.
+ *
+ * The maps are served through the same annotation as the sheets, each page's
+ * image service pointed at the PNG instead, so they warp and clip exactly as
+ * the sheets do: where two neighbours' content regions overlap on the map, the
+ * pages overlap on the ground.
+ */
+import type { PageImage } from '../../server/iiifAnnotations';
+
+export type { PageImage };
+
+/** The image a URL parameter names; anything unknown is the sheet. */
+export function pageImageFromParam(value: string | null): PageImage {
+  return value === 'region' || value === 'roadprob' ? value : 'page';
+}
+
+/** The URL parameter value for an image; null (omit) for the default sheet. */
+export function pageImageParam(image: PageImage): string | null {
+  return image === 'page' ? null : image;
+}
+
+/** What the status line calls a page's alternate image when it is missing. */
+export function pageImageNoun(image: PageImage): string {
+  return image === 'region' ? 'region map' : 'P(road) map';
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -192,7 +192,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
-  width: 126px; /* the Key map / P(road) toggle's natural width; both sliders match it */
+  width: 168px; /* the Page / Region / P(road) toggle's natural width; both sliders match it */
   flex-shrink: 0;
 }
 

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -83,6 +83,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
     "download-osm": ("mapsnap.download_osm", "Download street data from OSM"),
     "osm-to-geojson": ("mapsnap.osm_to_centerlines", "Convert OSM data to GeoJSON."),
     "scale": ("mapsnap.scale_images", "Shrink images by a uniform amount."),
+    "region": (
+        "mapsnap.region_predict",
+        "Predict each page's content region as a P(region) PNG.",
+    ),
     "download-oim": (
         "mapsnap.download_oim_iiif",
         "Fetch all images for a Sanborn volume from OldInsuranceMaps.net",

--- a/mapsnap/reconcile.py
+++ b/mapsnap/reconcile.py
@@ -125,8 +125,20 @@ OVERLAP_HARD_DELTA = 0.35
 # published adjacent pairs, floored here, because the model's boundaries are
 # softer on some volumes (kansas_city, washington_dc: true neighbours at
 # 25-35%) than on others (detroit: good pages at a median of 3%).
-W_REGION = 3.0
-REGION_SOFT = 0.10
+#
+# Weight and floor come from a 7-setting sweep over 18 truth volumes on the
+# 2026-09-03 sidecars (report-only, real compare). At 10% / 3.0 the factor
+# removed 24 of 59 disasters but evicted 22 good pages (mean -0.06): a
+# correct page whose region overlaps a wrong neighbour's by 20-25% is often
+# the cheaper member of the pair to move, and it moves to an alias in empty
+# space (brooklyn p5, nashville p12). At 15% / 1.5 the same 24 disasters go
+# for 6 good pages (mean +0.72, 14 volumes up or flat, kansas_city -1.8),
+# and the mid-30s overlaps that separate a disaster from a soft boundary are
+# left to the unaries: detroit p85 (32%, 368 -> 12 ft) still flips because
+# its alternative is well evidenced; schenectady p9__2 (32% with a correct
+# neighbour, one pose) is the cost.
+W_REGION = 1.5
+REGION_SOFT = 0.15
 REGION_HARD_DELTA = 0.30
 # NO sibling factor. Split panels are separate maps that happen to share a
 # sheet: no geographic relationship (champaign p4's panels sit 891 m apart at

--- a/mapsnap/reconcile.py
+++ b/mapsnap/reconcile.py
@@ -116,6 +116,18 @@ STAMP_JUNK_COST = 0.15
 W_OVERLAP = 3.0
 OVERLAP_SOFT = 0.15
 OVERLAP_HARD_DELTA = 0.35
+# Content-region overlap factor (#352), opt-in via --region-overlap. Truth
+# content regions tile the ground (no pair overlaps by more than 5%), so two
+# chosen poses whose PREDICTED regions overlap cannot both be right. Unlike
+# the full-footprint overlap above, this applies to stamp-adjacent pairs too:
+# seam overlap between neighbours is margin and duplicated strip, which the
+# region model removes. The soft threshold self-calibrates from the p90 of
+# published adjacent pairs, floored here, because the model's boundaries are
+# softer on some volumes (kansas_city, washington_dc: true neighbours at
+# 25-35%) than on others (detroit: good pages at a median of 3%).
+W_REGION = 3.0
+REGION_SOFT = 0.10
+REGION_HARD_DELTA = 0.30
 # NO sibling factor. Split panels are separate maps that happen to share a
 # sheet: no geographic relationship (champaign p4's panels sit 891 m apart at
 # +0.2 and +48.9 degrees) and they may legitimately depict OVERLAPPING ground,
@@ -163,6 +175,9 @@ class Hypothesis:
     scores: dict = field(default_factory=dict)
     unary_terms: dict = field(default_factory=dict)
     unary: float = 0.0
+    # The page's predicted content region at this pose, in metres about the
+    # volume origin; None when the page has no usable region or is unplaced.
+    region: object | None = None
 
 
 @dataclass
@@ -174,6 +189,7 @@ class PageNode:
     base: str | None
     hypotheses: list[Hypothesis]
     published_index: int | None  # index of the published pose, None if unplaced
+    region_px: object | None = None  # predicted content region in page pixels
 
 
 def sidecar_pose(doc: dict) -> np.ndarray | None:
@@ -219,7 +235,14 @@ def collect_hypotheses(
     exists to weigh.
     """
     channel = published_channel(sidecar_dir, stem)
-    variant_paths = sorted(sidecar_dir.glob(f"{stem}.georef*.json"))
+    # The arbiter's own previous answer (pN.georef-final.json, from a prior
+    # publish) is not a channel: read back in, it would re-enter as a zombie
+    # candidate that no channel still proposes.
+    variant_paths = sorted(
+        path
+        for path in sidecar_dir.glob(f"{stem}.georef*.json")
+        if path.name != f"{stem}.georef-final.json"
+    )
     ordered: list[tuple[str, Path]] = []
     for path in variant_paths:
         name = path.name[len(stem) + 1 : -len(".json")]
@@ -595,6 +618,18 @@ def stamp_energy(
     return W_STAMP * min(STAMP_CLAMP, (distance / bar) ** 2)
 
 
+def region_energy(
+    hyp_a: Hypothesis, hyp_b: Hypothesis, soft: float, weight: float = W_REGION
+) -> float:
+    """Content-region overlap cost of two chosen poses (#352); zero without regions."""
+    if hyp_a.region is None or hyp_b.region is None:
+        return 0.0
+    from mapsnap.region_overlap import overlap_over_min
+
+    overlap = overlap_over_min(hyp_a.region, hyp_b.region)  # type: ignore[arg-type]
+    return weight * overlap_penalty(overlap, soft, soft + REGION_HARD_DELTA)
+
+
 def pairwise_energy(
     kind: str,
     adjacency: dict,
@@ -605,10 +640,14 @@ def pairwise_energy(
     median_log_scale: float,
     origin,
     overlap_soft: float = OVERLAP_SOFT,
+    region_soft: float = REGION_SOFT,
+    region_weight: float = W_REGION,
 ) -> float:
     """Energy of a pair of chosen hypotheses; zero when either is UNPLACED."""
     if hyp_a.affine is None or hyp_b.affine is None:
         return 0.0
+    if kind == "region":
+        return region_energy(hyp_a, hyp_b, region_soft, region_weight)
     if kind == "stamp":
         # Stamp edges carry the relative-pose evidence themselves; overlap
         # between mutually-claiming neighbors is legitimate sheet layout (DC's
@@ -671,6 +710,8 @@ def solve(
     median_log_scale: float,
     origin,
     overlap_soft: float = OVERLAP_SOFT,
+    region_soft: float = REGION_SOFT,
+    region_weight: float = W_REGION,
 ) -> dict[str, int]:
     """Choose one hypothesis per page minimizing joint energy (deterministic).
 
@@ -685,18 +726,29 @@ def solve(
         neighbors[a].append((kind, b))
         neighbors[b].append((kind, a))
 
+    # Pair energies are pure functions of the two hypotheses, and ICM asks for
+    # the same ones every sweep; region terms cost a polygon intersection each.
+    pair_cache: dict[tuple[str, str, int, str, int], float] = {}
+
     def pair_e(kind: str, a: str, ia: int, b: str, ib: int) -> float:
-        return pairwise_energy(
-            kind,
-            adjacency,
-            nodes[a],
-            nodes[a].hypotheses[ia],
-            nodes[b],
-            nodes[b].hypotheses[ib],
-            median_log_scale,
-            origin,
-            overlap_soft=overlap_soft,
-        )
+        key = (kind, a, ia, b, ib)
+        energy = pair_cache.get(key)
+        if energy is None:
+            energy = pairwise_energy(
+                kind,
+                adjacency,
+                nodes[a],
+                nodes[a].hypotheses[ia],
+                nodes[b],
+                nodes[b].hypotheses[ib],
+                median_log_scale,
+                origin,
+                overlap_soft=overlap_soft,
+                region_soft=region_soft,
+                region_weight=region_weight,
+            )
+            pair_cache[key] = energy
+        return energy
 
     # Union-find components.
     parent = {stem: stem for stem in nodes}
@@ -927,11 +979,152 @@ def build_edges(
     return edges
 
 
+def attach_regions(volume: Path, nodes: dict[str, PageNode], origin) -> int:
+    """Load each page's predicted content region and pose it per hypothesis.
+
+    Returns the number of pages that got a region; pages without a usable
+    map (missing, wrong size, or under REGION_MIN_FRAC of the page) take no
+    part in the region factor.
+    """
+    from mapsnap.region_overlap import posed_region_metres, region_polygon_px
+
+    attached = 0
+    for node in nodes.values():
+        node.region_px = region_polygon_px(
+            volume, node.unit.stem, (node.unit.width, node.unit.height)
+        )
+        if node.region_px is None:
+            continue
+        attached += 1
+        for hypothesis in node.hypotheses:
+            if hypothesis.affine is not None:
+                hypothesis.region = posed_region_metres(
+                    node.region_px,  # type: ignore[arg-type]
+                    hypothesis.affine,
+                    origin,
+                )
+    return attached
+
+
+def skeleton_twins(a: str, b: str) -> bool:
+    """True for a skeleton sheet and its full-colour twin (p102s / p102).
+
+    OIM's Skeleton Map layer maps the same ground as the page it shadows, so
+    their regions coincide by design; compare grades at most one of them.
+    """
+    base_a, base_b = a.split("__")[0], b.split("__")[0]
+    return base_a == base_b + "s" or base_b == base_a + "s"
+
+
+def build_region_edges(nodes: dict[str, PageNode]) -> list[tuple[str, str, str]]:
+    """("region", a, b) for every pair whose posed regions could meet.
+
+    Any hypothesis pair counts: a page's alias 300 ft away lands on a
+    neighbour it does not touch at its published pose. Sibling panels are
+    excluded (an inset legitimately details ground its large panel also
+    covers), as are skeleton twins.
+    """
+    bounds: dict[str, tuple[float, float, float, float]] = {}
+    for stem, node in nodes.items():
+        boxes = [h.region.bounds for h in node.hypotheses if h.region is not None]  # type: ignore[attr-defined]
+        if boxes:
+            bounds[stem] = (
+                min(b[0] for b in boxes),
+                min(b[1] for b in boxes),
+                max(b[2] for b in boxes),
+                max(b[3] for b in boxes),
+            )
+    stems = sorted(bounds)
+    edges: list[tuple[str, str, str]] = []
+    for i, a in enumerate(stems):
+        for b in stems[i + 1 :]:
+            if panel_base(a) is not None and panel_base(a) == panel_base(b):
+                continue
+            if skeleton_twins(a, b):
+                continue
+            ba, bb = bounds[a], bounds[b]
+            if ba[2] < bb[0] or bb[2] < ba[0] or ba[3] < bb[1] or bb[3] < ba[1]:
+                continue
+            edges.append(("region", a, b))
+    return edges
+
+
+def calibrate_region_soft(nodes: dict[str, PageNode], adjacency: dict) -> float:
+    """p90 region overlap across published adjacent pairs, floored at REGION_SOFT."""
+    from mapsnap.region_overlap import overlap_over_min
+
+    overlaps = []
+    for a, b in adjacency.get("adjacency", []) if adjacency else []:
+        na, nb = nodes.get(a), nodes.get(b)
+        if not na or not nb or na.published_index is None or nb.published_index is None:
+            continue
+        ha = na.hypotheses[na.published_index]
+        hb = nb.hypotheses[nb.published_index]
+        if ha.region is None or hb.region is None or skeleton_twins(a, b):
+            continue
+        overlaps.append(overlap_over_min(ha.region, hb.region))  # type: ignore[arg-type]
+    if not overlaps:
+        return REGION_SOFT
+    return max(REGION_SOFT, float(np.percentile(overlaps, 90)))
+
+
+def max_region_overlap(
+    nodes: dict[str, PageNode],
+    assignment: dict[str, int],
+    neighbours: list[str],
+    hypothesis: Hypothesis,
+) -> float | None:
+    """Max region overlap of one hypothesis with the chosen poses of its neighbours."""
+    from mapsnap.region_overlap import overlap_over_min
+
+    if hypothesis.region is None:
+        return None
+    best = 0.0
+    for other in neighbours:
+        theirs = nodes[other].hypotheses[assignment[other]].region
+        if theirs is not None:
+            best = max(best, overlap_over_min(hypothesis.region, theirs))  # type: ignore[arg-type]
+    return best
+
+
+def region_overlap_summary(
+    nodes: dict[str, PageNode],
+    edges: list[tuple[str, str, str]],
+    assignment: dict[str, int],
+) -> dict[str, tuple[float | None, float | None]]:
+    """Per page: max region overlap of its published and chosen poses with the chosen neighbours."""
+    neighbours: dict[str, list[str]] = {stem: [] for stem in nodes}
+    for kind, a, b in edges:
+        if kind == "region":
+            neighbours[a].append(b)
+            neighbours[b].append(a)
+    summary: dict[str, tuple[float | None, float | None]] = {}
+    for stem, node in nodes.items():
+        if node.region_px is None:
+            continue
+        published = (
+            max_region_overlap(
+                nodes,
+                assignment,
+                neighbours[stem],
+                node.hypotheses[node.published_index],
+            )
+            if node.published_index is not None
+            else None
+        )
+        chosen = max_region_overlap(
+            nodes, assignment, neighbours[stem], node.hypotheses[assignment[stem]]
+        )
+        summary[stem] = (published, chosen)
+    return summary
+
+
 def write_outputs(
     volume: Path,
     nodes: dict[str, PageNode],
     assignment: dict[str, int],
     out_dir: Path,
+    region_overlaps: dict[str, tuple[float | None, float | None]] | None = None,
 ) -> tuple[int, list[dict]]:
     """verdicts.jsonl + report.md; returns (flip count, verdict rows)."""
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -942,6 +1135,7 @@ def write_outputs(
         published = node.published_index
         chosen_h = node.hypotheses[chosen]
         published_h = node.hypotheses[published] if published is not None else None
+        region_pub, region_chosen = (region_overlaps or {}).get(stem, (None, None))
         rivals = sorted(
             (h.unary, i) for i, h in enumerate(node.hypotheses) if i != chosen
         )
@@ -962,6 +1156,8 @@ def write_outputs(
                 ),
                 "near_flip": near_flip,
                 "unverified": bool(chosen_h.scores.get("unverified")),
+                "region_overlap_published": region_pub,
+                "region_overlap_chosen": region_chosen,
                 "hypotheses": [
                     {
                         "source": h.source,
@@ -997,6 +1193,15 @@ def write_outputs(
                 else ""
             )
         )
+        if (
+            row["region_overlap_published"] is not None
+            or row["region_overlap_chosen"] is not None
+        ):
+            fmt = lambda v: "—" if v is None else f"{100 * v:.0f}%"
+            lines.append(
+                f"region overlap with chosen neighbours: "
+                f"{fmt(row['region_overlap_published'])} -> {fmt(row['region_overlap_chosen'])}"
+            )
         lines.append("")
         lines.append("| hypothesis | unary | verification | grid rmse ft |")
         lines.append("|---|---|---|---|")
@@ -1109,9 +1314,11 @@ def materialize_and_grade(
                 indent=1,
             )
         )
-    # compare resolves split-panel polygons from the generated dir.
+    # compare resolves split-panel polygons from the generated IIIF's own
+    # directory, so the panels files go beside the IIIF as well as the sidecars.
     for panels in volume.glob("p*.panels.json"):
         shutil.copy2(panels, mat_dir / panels.name)
+        shutil.copy2(panels, out_dir / panels.name)
     ref = find_ref_iiif(volume)
     iiif_path = out_dir / "reconcile.iiif.json"
     subprocess.run(
@@ -1163,6 +1370,25 @@ def main() -> None:
     parser.add_argument(
         "--pages", nargs="*", default=None, help="Restrict to these stems (debug)."
     )
+    parser.add_argument(
+        "--region-overlap",
+        action="store_true",
+        help="Add the content-region overlap factor (#352) between every pair "
+        "of pages whose predicted regions (artifacts/region/) could meet.",
+    )
+    parser.add_argument(
+        "--region-weight",
+        type=float,
+        default=W_REGION,
+        help=f"Weight of the region overlap factor (default {W_REGION}).",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Where to write verdicts/report/materialized (default "
+        "<volume>/artifacts/reconcile); experiments keep the run's own apart.",
+    )
     args = parser.parse_args()
 
     global ENTRY_PENALTY
@@ -1207,6 +1433,17 @@ def main() -> None:
     print(
         f"overlap soft threshold (p90 of published adjacent pairs): {overlap_soft:.3f}"
     )
+    region_soft = REGION_SOFT
+    if args.region_overlap:
+        attached = attach_regions(volume, nodes, origin or (0.0, 0.0))
+        region_edges = build_region_edges(nodes)
+        region_soft = calibrate_region_soft(nodes, adjacency)
+        print(
+            f"region overlap: {attached}/{len(nodes)} pages with regions, "
+            f"{len(region_edges)} pair edges, soft threshold {region_soft:.3f}, "
+            f"weight {args.region_weight}"
+        )
+        edges = [*edges, *region_edges]
     assignment = solve(
         nodes,
         edges,
@@ -1214,9 +1451,22 @@ def main() -> None:
         median_log_scale,
         origin or (0.0, 0.0),
         overlap_soft=overlap_soft,
+        region_soft=region_soft,
+        region_weight=args.region_weight,
     )
-    out_dir = volume / "artifacts" / "reconcile"
-    flips, _ = write_outputs(volume, nodes, assignment, out_dir)
+    out_dir = args.out_dir or volume / "artifacts" / "reconcile"
+    if (
+        not out_dir.is_absolute()
+        and not out_dir.exists()
+        and not str(out_dir).startswith("data")
+    ):
+        out_dir = volume / out_dir
+    region_overlaps = (
+        region_overlap_summary(nodes, edges, assignment)
+        if args.region_overlap
+        else None
+    )
+    flips, _ = write_outputs(volume, nodes, assignment, out_dir, region_overlaps)
     print(f"{flips} decisions flipped -> {out_dir / 'report.md'}")
     if args.publish:
         written, unplaced = publish(volume, nodes, assignment)

--- a/mapsnap/reconcile_test.py
+++ b/mapsnap/reconcile_test.py
@@ -579,7 +579,7 @@ def test_region_energy_is_zero_without_regions_and_free_below_soft():
     b = boxed(scored("georef", affine(0), 1.0), 480.0)  # 4% overlap
     assert region_energy(a, b, soft=0.10) == 0.0
     c = boxed(scored("georef", affine(0), 1.0), 0.0)  # total overlap
-    assert region_energy(a, c, soft=0.10) == pytest.approx(3.0)
+    assert region_energy(a, c, soft=0.10, weight=3.0) == pytest.approx(3.0)
     bare = scored("georef", affine(0), 1.0)
     assert region_energy(a, bare, soft=0.10) == 0.0
 

--- a/mapsnap/reconcile_test.py
+++ b/mapsnap/reconcile_test.py
@@ -495,3 +495,101 @@ def test_normalize_name_penalty_leaves_unpenalized_pages_alone():
     )
     normalize_name_penalty(node)
     assert hypothesis.scores["name"] == pytest.approx(0.4)
+
+
+def boxed(hypothesis: Hypothesis, west_m: float, width_m: float = 500.0):
+    """Give a hypothesis a posed content region: a 500 x 400 m box at west_m."""
+    from shapely.geometry import box
+
+    hypothesis.region = box(west_m, 0.0, west_m + width_m, 400.0)
+    return hypothesis
+
+
+def test_region_edges_skip_siblings_and_skeleton_twins():
+    from mapsnap.reconcile import build_region_edges
+
+    nodes = {
+        "p1": make_node("p1", [boxed(scored("georef", affine(0), 1.8), 0.0)]),
+        "p1s": make_node("p1s", [boxed(scored("georef", affine(0), 1.8), 0.0)]),
+        "p2__1": make_node(
+            "p2__1", [boxed(scored("georef", affine(0), 1.8), 100.0)], base="p2"
+        ),
+        "p2__2": make_node(
+            "p2__2", [boxed(scored("georef", affine(0), 1.8), 100.0)], base="p2"
+        ),
+        # Far away at its published pose, but an alias hypothesis lands on p1.
+        "p3": make_node(
+            "p3",
+            [
+                boxed(scored("georef", affine(0), 1.8), 5000.0),
+                boxed(scored("snap:0", affine(0), 1.0), 200.0),
+            ],
+        ),
+        # No region at all: never an edge.
+        "p4": make_node("p4", [scored("georef", affine(0), 1.8)]),
+    }
+    for node in nodes.values():
+        node.region_px = object()
+    edges = build_region_edges(nodes)
+    pairs = {(a, b) for _, a, b in edges}
+    assert ("p1", "p1s") not in pairs
+    assert ("p2__1", "p2__2") not in pairs
+    assert ("p1", "p3") in pairs  # via p3's alias hypothesis
+    assert ("p1s", "p3") in pairs
+    assert not any("p4" in pair for pair in pairs)
+
+
+def test_region_factor_evicts_the_less_supported_overlapping_pose():
+    # p2's published pose sits on p1's ground (100% region overlap). p1 is
+    # well supported; p2 barely beats unplaced. With the factor the pair is
+    # penalized and the cheaper fix is p2 -> unplaced; without it (weight 0)
+    # both stay, which is the 2026-09-03 miami p11/p14 disaster.
+    from mapsnap.reconcile import build_region_edges
+
+    def volume():
+        p1 = boxed(scored("georef", affine(0), verification=1.9, published=True), 0.0)
+        p2_bad = boxed(scored("georef", affine(0), verification=0.6), 0.0)
+        p2_alt = boxed(scored("snap:0", affine(0), verification=0.5), 5000.0)
+        nodes = {
+            "p1": make_node("p1", [p1, scored(UNPLACED, None, 0)]),
+            "p2": make_node("p2", [p2_bad, p2_alt, scored(UNPLACED, None, 0)]),
+        }
+        for node in nodes.values():
+            node.region_px = object()
+        return nodes
+
+    nodes = volume()
+    edges = build_region_edges(nodes)
+    assert edges == [("region", "p1", "p2")]
+    with_factor = solve(nodes, edges, {}, 0.0, (-74.0, LAT0), region_weight=3.0)
+    assert nodes["p1"].hypotheses[with_factor["p1"]].source == "georef"
+    assert nodes["p2"].hypotheses[with_factor["p2"]].source != "georef"
+
+    control = volume()
+    without = solve(
+        control, build_region_edges(control), {}, 0.0, (-74.0, LAT0), region_weight=0.0
+    )
+    assert control["p2"].hypotheses[without["p2"]].source == "georef"
+
+
+def test_region_energy_is_zero_without_regions_and_free_below_soft():
+    from mapsnap.reconcile import region_energy
+
+    a = boxed(scored("georef", affine(0), 1.0), 0.0)
+    b = boxed(scored("georef", affine(0), 1.0), 480.0)  # 4% overlap
+    assert region_energy(a, b, soft=0.10) == 0.0
+    c = boxed(scored("georef", affine(0), 1.0), 0.0)  # total overlap
+    assert region_energy(a, c, soft=0.10) == pytest.approx(3.0)
+    bare = scored("georef", affine(0), 1.0)
+    assert region_energy(a, bare, soft=0.10) == 0.0
+
+
+def test_collect_ignores_the_arbiters_own_final(tmp_path):
+    # A previous publish left pN.georef-final.json behind; it is the answer,
+    # not a channel, and must not re-enter as a hypothesis.
+    write_sidecar(tmp_path, "p7", "georef", georef_doc(affine(0)))
+    write_sidecar(tmp_path, "p7", "georef-final", georef_doc(affine(3000)))
+    hypotheses, _ = collect_hypotheses(
+        tmp_path, "p7", None, None, page_size=(1000, 800)
+    )
+    assert [h.source for h in hypotheses] == ["georef", UNPLACED]

--- a/mapsnap/region_model.py
+++ b/mapsnap/region_model.py
@@ -262,15 +262,27 @@ def cmd_train(args: argparse.Namespace) -> None:
     print(f"best val IoU {best:.3f} -> {args.output}")
 
 
-def cmd_predict(args: argparse.Namespace) -> None:
+def load_region_model(
+    path: Path = REGION_MODEL_PATH, device: torch.device | None = None
+) -> tuple[UNet, torch.device]:
+    """Load the trained content-region UNet, on the best available device by default.
+
+    The encoder width is read from the checkpoint, so weights trained with a
+    different ``--base`` load without a flag.
+    """
     from mapsnap.keymap.number_model import select_device
 
-    device = select_device()
-    state = torch.load(args.model, map_location=device)
+    device = device or select_device()
+    state = torch.load(path, map_location=device)
     base = state["enc1.block.0.weight"].shape[0]
     model = UNet(base=base, in_channels=3, norm="group").to(device)
     model.load_state_dict(state)
     model.eval()
+    return model, device
+
+
+def cmd_predict(args: argparse.Namespace) -> None:
+    model, device = load_region_model(args.model)
     args.out_dir.mkdir(parents=True, exist_ok=True)
     for path in args.images:
         image = cv2.imread(str(path))

--- a/mapsnap/region_overlap.py
+++ b/mapsnap/region_overlap.py
@@ -1,0 +1,100 @@
+"""Content-region geometry for the reconciler's overlap factor (#352).
+
+A page's content region is the part of its sheet exclusive to that page:
+truth regions tile the ground with no pair overlapping by more than 5%, so
+two placed pages whose regions overlap substantially cannot both be right.
+The region model's prediction (``mapsnap region`` -> ``artifacts/region/
+<stem>.png``) stands in for the truth region here; at the 2026-09-03
+published poses its overlap caught every ≥200 ft disaster on detroit while
+good pages sat at a median of 3%.
+
+This module turns a P(region) map into a polygon in page pixels, poses it
+through a hypothesis affine into local metres, and measures overlap the way
+the corpus measurement did: intersection over the smaller region.
+"""
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+from shapely.affinity import affine_transform
+from shapely.geometry import MultiPolygon, Polygon
+from shapely.ops import unary_union
+from shapely.validation import make_valid
+
+from mapsnap.region_predict import region_prob_path
+
+# P(region) at or above this is content.
+REGION_THRESHOLD = 0.5
+# A predicted region smaller than this share of its page carries no usable
+# tiling signal: intersection over the smaller area explodes against it
+# (detroit p69__2, 7% of its panel, "overlapped" its siblings 89%).
+REGION_MIN_FRAC = 0.15
+# Contour components below this share of the page are speckle.
+COMPONENT_MIN_FRAC = 0.01
+
+
+def region_polygon_px(
+    volume: Path, stem: str, page_size: tuple[int, int]
+) -> Polygon | MultiPolygon | None:
+    """The page's predicted content region as a polygon in page pixels.
+
+    None when the map is missing, does not match the page's size, or covers
+    less than REGION_MIN_FRAC of the page.
+    """
+    path = region_prob_path(volume, stem)
+    if not path.exists():
+        return None
+    prob = cv2.imread(str(path), cv2.IMREAD_GRAYSCALE)
+    if prob is None:
+        return None
+    height, width = prob.shape
+    if (width, height) != tuple(page_size):
+        return None
+    mask = (prob >= REGION_THRESHOLD * 255).astype(np.uint8)
+    if float(mask.mean()) < REGION_MIN_FRAC:
+        return None
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    polygons = []
+    for contour in contours:
+        if (
+            len(contour) < 3
+            or cv2.contourArea(contour) < COMPONENT_MIN_FRAC * width * height
+        ):
+            continue
+        polygons.append(make_valid(Polygon(contour[:, 0, :].astype(np.float64))))
+    if not polygons:
+        return None
+    region = unary_union(polygons).buffer(0)
+    return region if not region.is_empty else None
+
+
+def posed_region_metres(
+    region_px: Polygon | MultiPolygon,
+    affine: np.ndarray,
+    origin: tuple[float, float],
+) -> Polygon | MultiPolygon:
+    """Pose a page-pixel region through ``affine`` (px -> lon/lat) into metres about origin."""
+    lon0, lat0 = origin
+    kx = 111_320.0 * np.cos(np.radians(lat0))
+    ky = 110_540.0
+    matrix = [
+        affine[0, 0] * kx,
+        affine[0, 1] * kx,
+        affine[1, 0] * ky,
+        affine[1, 1] * ky,
+        (affine[0, 2] - lon0) * kx,
+        (affine[1, 2] - lat0) * ky,
+    ]
+    posed = affine_transform(region_px, matrix)
+    return make_valid(posed).buffer(0)
+
+
+def overlap_over_min(a: Polygon | MultiPolygon, b: Polygon | MultiPolygon) -> float:
+    """Intersection area over the smaller area; 0 when either is empty or they are apart."""
+    if a.is_empty or b.is_empty or not a.intersects(b):
+        return 0.0
+    smaller = min(a.area, b.area)
+    if smaller <= 0:
+        return 0.0
+    return float(a.intersection(b).area / smaller)

--- a/mapsnap/region_overlap_test.py
+++ b/mapsnap/region_overlap_test.py
@@ -1,0 +1,61 @@
+"""Tests for the content-region overlap geometry."""
+
+import math
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from mapsnap.region_overlap import (
+    overlap_over_min,
+    posed_region_metres,
+    region_polygon_px,
+)
+from mapsnap.region_predict import region_prob_path
+
+LAT0 = 40.0
+KX = 111_320.0 * math.cos(math.radians(LAT0))
+KY = 110_540.0
+
+
+def write_map(volume: Path, stem: str, width: int, height: int, box) -> None:
+    prob = np.zeros((height, width), np.uint8)
+    x0, y0, x1, y1 = box
+    prob[y0:y1, x0:x1] = 255
+    path = region_prob_path(volume, stem)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(str(path), prob)
+
+
+def north_up(shift_east_m: float, m_per_px: float = 0.5) -> np.ndarray:
+    return np.array(
+        [[m_per_px / KX, 0.0, -74.0 + shift_east_m / KX], [0.0, -m_per_px / KY, LAT0]]
+    )
+
+
+def test_region_polygon_reads_content_and_guards_tiny_maps(tmp_path: Path) -> None:
+    write_map(tmp_path, "p3", 200, 100, (20, 10, 180, 90))
+    region = region_polygon_px(tmp_path, "p3", (200, 100))
+    assert region is not None
+    assert abs(region.area - 160 * 80) < 0.05 * 160 * 80
+    # 5% of the page: no tiling signal.
+    write_map(tmp_path, "p4", 200, 100, (0, 0, 20, 50))
+    assert region_polygon_px(tmp_path, "p4", (200, 100)) is None
+    # Missing map, and a map at the wrong size.
+    assert region_polygon_px(tmp_path, "p5", (200, 100)) is None
+    assert region_polygon_px(tmp_path, "p3", (400, 200)) is None
+
+
+def test_posed_regions_overlap_by_displacement(tmp_path: Path) -> None:
+    write_map(tmp_path, "p3", 200, 100, (0, 0, 200, 100))
+    region = region_polygon_px(tmp_path, "p3", (200, 100))
+    assert region is not None
+    origin = (-74.0, LAT0)
+    at_home = posed_region_metres(region, north_up(0.0), origin)
+    # 200 px * 0.5 m = 100 m wide; shifted half a width east -> 50% overlap.
+    shifted = posed_region_metres(region, north_up(50.0), origin)
+    # Contours trace pixel centres, so the polygon is half a pixel short per side.
+    assert abs(at_home.area - 100 * 50) < 0.03 * 100 * 50
+    assert abs(overlap_over_min(at_home, shifted) - 0.5) < 0.02
+    apart = posed_region_metres(region, north_up(500.0), origin)
+    assert overlap_over_min(at_home, apart) == 0.0

--- a/mapsnap/region_predict.py
+++ b/mapsnap/region_predict.py
@@ -1,0 +1,93 @@
+"""Predict every page's content region and write it as a P(region) map.
+
+The content-region model (``mapsnap.region_model``, #226) predicts per pixel
+whether a sheet position holds content exclusive to that page, as opposed to
+margin, title block, or a strip duplicated from a neighbour. This command runs
+it over a volume's 25% page images, parents and split panels alike, and writes
+each map as an 8-bit PNG at the page's own resolution:
+
+    data/<vol>/artifacts/region/<stem>.png     0 = margin, 255 = content
+
+The volume viewer draws these in place of the sheets (its Page / Region /
+P(road) toggle), and the content-region overlap analysis (#352) reads them.
+
+    mapsnap region data/<vol>            # every p*.jpg that lacks a map
+    mapsnap region data/<vol> --force    # redo them all
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+
+from mapsnap.region_model import predict_region
+
+REGION_DIR = Path("artifacts") / "region"
+
+
+def region_prob_path(volume: Path, stem: str) -> Path:
+    """Where a page's P(region) map lives: ``<volume>/artifacts/region/<stem>.png``."""
+    return volume / REGION_DIR / f"{stem}.png"
+
+
+def write_region_maps(
+    volume: Path,
+    images: list[Path],
+    *,
+    model: torch.nn.Module,
+    device: torch.device,
+    force: bool = False,
+) -> list[Path]:
+    """Predict and write P(region) maps for ``images``; returns the paths written.
+
+    Maps that already exist are kept unless ``force``. Unreadable images are
+    reported on stderr and skipped.
+    """
+    written: list[Path] = []
+    for image_path in images:
+        out = region_prob_path(volume, image_path.stem)
+        if out.exists() and not force:
+            continue
+        image = cv2.imread(str(image_path))
+        if image is None:
+            print(f"skip (unreadable): {image_path}", file=sys.stderr)
+            continue
+        prob = predict_region(model, image, device)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        cv2.imwrite(str(out), np.clip(prob * 255, 0, 255).astype(np.uint8))
+        written.append(out)
+    return written
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "volume", type=Path, help="Volume directory holding the p*.jpg pages."
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Rewrite maps that already exist."
+    )
+    args = parser.parse_args()
+
+    from mapsnap.region_model import load_region_model
+
+    images = sorted(args.volume.glob("p*.jpg"))
+    if not images:
+        sys.exit(f"no p*.jpg pages under {args.volume}")
+    model, device = load_region_model()
+    written = write_region_maps(
+        args.volume, images, model=model, device=device, force=args.force
+    )
+    print(
+        f"wrote {len(written)} of {len(images)} P(region) maps"
+        f" to {args.volume / REGION_DIR}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/region_predict_test.py
+++ b/mapsnap/region_predict_test.py
@@ -1,0 +1,59 @@
+"""Tests for the per-page P(region) map writer."""
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+import torch
+
+from mapsnap.region_predict import region_prob_path, write_region_maps
+
+
+class HalfModel(torch.nn.Module):
+    """Stub UNet: zero logits everywhere, so P(region) is 0.5 at every pixel."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.zeros(x.shape[0], 1, x.shape[2], x.shape[3])
+
+
+def write_page(path: Path, width: int, height: int) -> None:
+    cv2.imwrite(str(path), np.full((height, width, 3), 200, np.uint8))
+
+
+def test_writes_maps_at_page_resolution_and_keeps_existing(tmp_path: Path) -> None:
+    write_page(tmp_path / "p7.jpg", 40, 30)
+    write_page(tmp_path / "p7__1.jpg", 20, 30)
+    model, device = HalfModel(), torch.device("cpu")
+    images = sorted(tmp_path.glob("p*.jpg"))
+
+    written = write_region_maps(tmp_path, images, model=model, device=device)
+
+    assert written == [
+        region_prob_path(tmp_path, "p7"),
+        region_prob_path(tmp_path, "p7__1"),
+    ]
+    prob = cv2.imread(str(region_prob_path(tmp_path, "p7")), cv2.IMREAD_GRAYSCALE)
+    assert prob is not None
+    assert prob.shape == (30, 40)
+    assert np.all(prob == 127)  # sigmoid(0) * 255, truncated
+    panel = cv2.imread(str(region_prob_path(tmp_path, "p7__1")), cv2.IMREAD_GRAYSCALE)
+    assert panel is not None
+    assert panel.shape == (30, 20)
+
+    # A second pass rewrites nothing; --force redoes everything.
+    assert write_region_maps(tmp_path, images, model=model, device=device) == []
+    redone = write_region_maps(tmp_path, images, model=model, device=device, force=True)
+    assert len(redone) == 2
+
+
+def test_skips_unreadable_images(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / "p9.jpg").write_bytes(b"not a jpeg")
+    written = write_region_maps(
+        tmp_path, [tmp_path / "p9.jpg"], model=HalfModel(), device=torch.device("cpu")
+    )
+    assert written == []
+    assert not region_prob_path(tmp_path, "p9").exists()
+    assert "skip (unreadable)" in capsys.readouterr().err


### PR DESCRIPTION
Stacked on #401 (needs its `mapsnap region` maps and `region_prob_path`).

## What

`mapsnap reconcile --region-overlap` adds a pairwise **content-region overlap factor** (#352). Each page's P(region) map (`artifacts/region/<stem>.png`) is polygonized once and posed through every hypothesis; a "region" edge joins any two pages whose posed regions could meet under *any* hypothesis pair (an alias 300 ft away lands on a neighbour it never touches at its published pose). Between the chosen poses the pair pays `W_REGION · overlap_penalty(intersection / smaller region)`, free below a soft threshold and full 30 points above it. The threshold self-calibrates from the p90 of published adjacent pairs, floored at 15%. Sibling panels and skeleton twins are excluded. UNPLACED costs nothing, so a page whose every pose overlaps a better-held neighbour drops out instead of staying wrong: that is the escape valve, and it already existed in the arbiter.

Also: the collector no longer reads the arbiter's own `pN.georef-final.json` back in as a hypothesis (it re-entered as a zombie candidate on every refit); the graded IIIF gets the panels files beside it, where compare looks; `--out-dir` and `--region-weight` for experiments.

## Results (report-only, 2026-09-03 sidecars, real compare, 18 volumes; Columbus and NO-1896 excluded until the region model is retrained without their whole-page labels)

Seven settings, re-solved from one scoring pass per volume:

| volume | base | 10% / 3.0 | 15% / 3.0 | 20% / 3.0 | 25% / 3.0 | 10% / 1.5 | **15% / 1.5** |
|---|---:|---:|---:|---:|---:|---:|---:|
| brooklyn | 83.6 | −0.6 | −0.6 | +0.5 | +0.5 | −0.6 | **+0.5** |
| chicago | 79.1 | +0.9 | +1.8 | +1.8 | +1.8 | +0.9 | **+0.9** |
| columbia | 74.8 | +0.8 | +0.8 | +0.8 | +0.8 | +0.8 | **+0.8** |
| detroit | 76.8 | +4.0 | +4.0 | +4.0 | +1.8 | +4.0 | **+4.0** |
| fargo | 74.9 | +0.7 | −0.4 | +1.3 | +1.3 | +0.9 | **+2.3** |
| grand rapids | 78.1 | −2.4 | −2.4 | −2.4 | +2.2 | +2.2 | **+2.2** |
| hudson | 77.8 | −1.2 | −1.9 | −1.0 | −1.0 | −0.9 | **0.0** |
| kansas city | 79.1 | −1.9 | −1.8 | −1.1 | +0.1 | −1.9 | **−1.8** |
| los angeles | 89.1 | +0.4 | +0.8 | +0.8 | −0.1 | −0.1 | **−0.1** |
| miami | 82.2 | +2.9 | +1.7 | +1.7 | +1.7 | +1.7 | **+1.7** |
| nashville | 71.2 | −2.6 | −2.6 | 0.0 | 0.0 | −2.6 | **0.0** |
| new orleans 1951 | 93.8 | −0.5 | 0.0 | 0.0 | 0.0 | 0.0 | **0.0** |
| philadelphia | 88.4 | −1.9 | +0.5 | +0.5 | +0.5 | +0.5 | **+0.5** |
| schenectady | 78.3 | −1.4 | −0.8 | −0.6 | −0.6 | −0.6 | **−0.5** |
| washington dc | 84.0 | +1.8 | +1.8 | +2.5 | +2.5 | +1.8 | **+2.5** |
| asheville, champaign, richmond | | 0 | 0 | 0 | 0 | 0 | **0** |
| **mean over 18** | | −0.06 | +0.05 | +0.49 | +0.64 | +0.34 | **+0.72** |
| volumes down / up | | 8 / 7 | 7 / 7 | 4 / 9 | 3 / 10 | 6 / 8 | **3 / 9** |

At the chosen default: **disasters 59 → 35, good pages 1314 → 1308, unplaced 212 → 249**. Five pages moved to a *correct alternative* rather than dropping out: detroit p85 368 → 12 ft, DC p210 350 → 12, grand rapids p828 614 → 15, kansas city p453 668 → 33, brooklyn p7 654 → 44. Miami p11 (2,487 ft, 98% overlap with the correctly placed p14) and p30 drop to unplaced.

**Why not the original 10% / 3.0.** It removes the same 24 disasters but evicts 22 good pages: a correct page whose region overlaps a *wrong* neighbour's by 20–25% is often the cheaper member of the pair to move, and it moves to an alias in empty space that overlaps nothing (brooklyn p5 65 → 639 ft, nashville p12 9 → 358 ft against a correctly placed p31 at 25%). The overlap names the pair, not the culprit; the lower weight leaves the mid-30s overlaps to the unaries, and detroit p85 still flips because its 12 ft alternative is well evidenced.

**Costs at the default.** Kansas City −1.8: five good split panels (p493__1, p526__1, p555__1, p573__1, p574__1) evicted by overlaps with other panels; it is the softest-boundary volume in the corpus measurement (6% good-page median). Schenectady p9__2 (14 ft, one pose, 32% with the correct p17) drops out.

## Verification

- `uv run pytest mapsnap/reconcile_test.py mapsnap/region_overlap_test.py` (region edges skip siblings and skeleton twins; the factor evicts the less-supported overlapping pose and is inert at weight 0; energy shape; the collector ignores `georef-final`) plus ruff / pyright repo-wide.
- The sweep driver's base setting reproduces each volume's 2026-09-03 score exactly.

Part of #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)