### PR TITLE
mapsnap loc-mirror: build the Sanborn mirror from LoC full-resolution JP2s

### DIFF
--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -83,6 +83,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
     "download-osm": ("mapsnap.download_osm", "Download street data from OSM"),
     "osm-to-geojson": ("mapsnap.osm_to_centerlines", "Convert OSM data to GeoJSON."),
     "scale": ("mapsnap.scale_images", "Shrink images by a uniform amount."),
+    "loc-mirror": (
+        "mapsnap.loc_mirror",
+        "Build the Sanborn mirror (25% JPEGs + raw key-map candidates) from LoC JP2s.",
+    ),
     "download-oim": (
         "mapsnap.download_oim_iiif",
         "Fetch all images for a Sanborn volume from OldInsuranceMaps.net",

--- a/mapsnap/cli_test.py
+++ b/mapsnap/cli_test.py
@@ -24,14 +24,42 @@ def test_every_command_module_imports(name: str) -> None:
     the cycle is imported first, which is precisely what running the command
     does.
     """
-    for module_name in [key for key in sys.modules if key.startswith("mapsnap")]:
-        del sys.modules[module_name]
+    evicted = {
+        key: sys.modules[key] for key in list(sys.modules) if key.startswith("mapsnap")
+    }
+    for key in evicted:
+        del sys.modules[key]
+    try:
+        module_name, _ = SUBCOMMANDS[name]
+        module = importlib.import_module(module_name)
+        assert callable(getattr(module, "main", None)), (
+            f"{module_name} has no main() for `mapsnap {name}`"
+        )
+    finally:
+        # Put the original module objects back. Without this the rest of the
+        # session sees FRESH mapsnap modules while already-imported test
+        # modules hold the old ones, and the two are different objects: a
+        # ProcessPoolExecutor then cannot pickle a worker function by name
+        # ("not the same object as mapsnap.loc_mirror.decode_item"), which
+        # broke loc_mirror's pipeline tests in the full suite but not alone.
+        for key in [k for k in list(sys.modules) if k.startswith("mapsnap")]:
+            del sys.modules[key]
+        sys.modules.update(evicted)
 
-    module_name, _ = SUBCOMMANDS[name]
-    module = importlib.import_module(module_name)
-    assert callable(getattr(module, "main", None)), (
-        f"{module_name} has no main() for `mapsnap {name}`"
-    )
+
+def test_command_import_check_leaves_sys_modules_alone() -> None:
+    """The import check must not swap the session's mapsnap modules for fresh ones.
+
+    It evicts them all to import each command into a clean interpreter; if it
+    does not put the originals back, every later test runs against a module
+    object its own imports do not share.
+    """
+    before = {
+        key: sys.modules[key] for key in list(sys.modules) if key.startswith("mapsnap")
+    }
+    test_every_command_module_imports(min(SUBCOMMANDS))
+    after = {key: sys.modules.get(key) for key in before}
+    assert after == before
 
 
 def test_fatal_signal_produces_a_python_traceback():

--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -81,6 +81,12 @@ JPEG_QUALITY = 95  # what mapsnap scale writes; the pipeline is tuned on it
 QUARTER_REDUCE = 2  # JPEG 2000 resolution levels to drop: 1/4 linear = 25%
 RETRIES = 4
 RETRY_DELAY = 5.0  # seconds, times the attempt number
+# A failed upload is retried by the running process, first after this many
+# seconds and then with doubling delays up to UPLOAD_RETRY_MAX: an expired
+# `aws login` session (12 h) fails every sync until it is renewed, and the
+# renewal should not need a restart.
+UPLOAD_RETRY_DELAY = 60.0
+UPLOAD_RETRY_MAX = 600.0
 DONE, UPLOADED = ".done", ".uploaded"
 
 
@@ -590,8 +596,9 @@ def run_pipeline(
     never wait for the uplink. New items are held back only while more than
     ``max_staging_bytes`` of decoded output is waiting to upload, so a slow
     uplink costs staging disk rather than download throughput. A stage failure
-    is logged to errors.log and the item is left for the next resume; it never
-    ends the run. One tqdm bar counts decoded sheets, with downloaded
+    is logged to errors.log and never ends the run: a failed upload (an expired
+    AWS session, say) is retried by this process with backoff, its staging copy
+    kept; a failed decode is left for the next resume. One tqdm bar counts decoded sheets, with downloaded
     gigabytes, uploaded items, the staging backlog, broken sheets, and stage
     errors in the postfix.
     """
@@ -603,6 +610,7 @@ def run_pipeline(
         "uploaded": 0,
         "bytes": 0,
         "errors": 0,
+        "retries": 0,
     }
     bar = tqdm(
         total=sum(len(item.sheets) for item in todo),
@@ -646,9 +654,11 @@ def run_stages(
     downloads: dict[Future, tuple[ItemPlan, int]] = {}
     item_fetch: dict[str, list[bool | None]] = {}
     decodes: dict[Future, ItemPlan] = {}
-    uploads: dict[Future, ItemPlan] = {}
+    uploads: dict[Future, tuple[ItemPlan, int]] = {}
     item_staged: dict[str, int] = {}
     staged_bytes = 0
+    # Failed uploads wait here as (not-before time, attempt, item) until retried.
+    retry_queue: deque[tuple[float, int, ItemPlan]] = deque()
     settings.out_dir.mkdir(parents=True, exist_ok=True)
     with (
         open(settings.out_dir / "progress.jsonl", "a") as progress_log,
@@ -661,7 +671,18 @@ def run_stages(
             fetched = [bool(ok) for ok in item_fetch.pop(plan.item)]
             decodes[decode_pool.submit(decode_item, plan, fetched, settings)] = plan
 
-        while todo or downloads or decodes or uploads:
+        while todo or downloads or decodes or uploads or retry_queue:
+            now = time.time()
+            for _ in range(len(retry_queue)):
+                not_before, attempt, plan = retry_queue.popleft()
+                if now >= not_before:
+                    totals["retries"] += 1
+                    uploads[upload_pool.submit(upload_item, plan, settings)] = (
+                        plan,
+                        attempt,
+                    )
+                else:
+                    retry_queue.append((not_before, attempt, plan))
             while (
                 todo
                 and len(item_fetch) + len(decodes) < prefetch_items
@@ -676,7 +697,7 @@ def run_stages(
                     staged = staged_size(settings.staging_dir / item_relative(plan))
                     item_staged[plan.item] = staged
                     staged_bytes += staged
-                    uploads[upload_pool.submit(upload_item, plan, settings)] = plan
+                    uploads[upload_pool.submit(upload_item, plan, settings)] = (plan, 0)
                     continue
                 item_fetch[plan.item] = [None] * len(plan.sheets)
                 if not plan.sheets:
@@ -684,11 +705,11 @@ def run_stages(
                 for index, sheet in enumerate(plan.sheets):
                     future = fetch_pool.submit(fetch_sheet, plan, sheet, settings)
                     downloads[future] = (plan, index)
-            done, _ = wait(
-                list(downloads) + list(decodes) + list(uploads),
-                timeout=1.0,
-                return_when=FIRST_COMPLETED,
-            )
+            pending = list(downloads) + list(decodes) + list(uploads)
+            if not pending:  # only the retry queue is left: wait for its clock
+                time.sleep(min(1.0, max(0.0, retry_queue[0][0] - time.time())))
+                continue
+            done, _ = wait(pending, timeout=1.0, return_when=FIRST_COMPLETED)
             for future in done:
                 if future in downloads:
                     plan, index = downloads.pop(future)
@@ -728,23 +749,29 @@ def run_stages(
                     if settings.upload and settings.bucket:
                         item_staged[plan.item] = staged
                         staged_bytes += staged
-                        uploads[upload_pool.submit(upload_item, plan, settings)] = plan
+                        uploads[upload_pool.submit(upload_item, plan, settings)] = (
+                            plan,
+                            0,
+                        )
                 else:
-                    plan = uploads.pop(future)
-                    staged_bytes -= item_staged.pop(plan.item, 0)
+                    plan, attempt = uploads.pop(future)
                     try:
                         future.result()
-                    except Exception as error:  # noqa: BLE001 -- staging kept; re-synced on resume
+                    except Exception as error:  # noqa: BLE001 -- staging kept; retried with backoff
                         log_error(settings.out_dir, "upload", plan.item, error)
                         totals["errors"] += 1
+                        delay = min(UPLOAD_RETRY_DELAY * 2**attempt, UPLOAD_RETRY_MAX)
+                        retry_queue.append((time.time() + delay, attempt + 1, plan))
                         continue
                     totals["uploaded"] += 1
+                    staged_bytes -= item_staged.pop(plan.item, 0)
             bar.set_postfix(
                 dl=f"{totals['bytes'] / 1e9:.1f}GB",
                 up=totals["uploaded"],
                 staged=f"{staged_bytes / 1e9:.1f}GB",
                 broken=totals["broken"],
                 errors=totals["errors"],
+                retry=len(retry_queue),
                 refresh=False,
             )
 

--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -1,0 +1,532 @@
+"""Build the mapsnap Sanborn mirror from full-resolution LoC JP2s.
+
+Source of truth is the Library of Congress `storage-services` tree as served by
+the torrent's HTTP mirror: every sheet is a JP2 whose filename carries the
+sheet's own identity (``06246_1914-0051``), so no sequence-number mapping is
+involved. The plan comes from a mapping table (one row per sheet: item, state,
+year, city, sequence, stem, page key, source, bytes, storage dir) built from the
+torrent listing and the loc.gov catalog.
+
+Per item (one LoC catalog record, normally one volume):
+
+  * download each kept sheet's JP2 to ``--jp2-dir`` mirroring the torrent tree
+    (``storage-services/service/<dir>/<stem>.jp2``), verified against the
+    listed byte count, so the copy stays a valid torrent payload;
+  * decode it at the JPEG 2000 quarter-resolution level, which IS the pipeline's
+    25% working scale, to ``<out>/by-state/<state>/<year>/<item>/p<key>.jpg``
+    (JPEG quality 95, as ``mapsnap scale`` writes);
+  * for key-map candidates (page 0 and page 1 families, letter pages -- see
+    ``keymap.identify.candidate_keys``) also decode at full resolution to
+    ``raw/p<key>.jpg``, as the ``data/`` volumes keep them;
+  * write ``metadata.json`` (the catalog fields and the sheet table) and a
+    ``.done`` marker; optionally ``aws s3 sync`` the item directory to the
+    bucket and mark ``.uploaded``.
+
+Sheets whose page key does not start with a digit (covr, ind1, cbd, titl, note)
+are skipped: nothing in the pipeline reads them. A sheet whose download or
+decode fails after retries is appended to ``broken.log`` (tab-separated: item,
+stem, source, reason) and left out of the item; the item still completes.
+
+Resumable and parallel: items with a ``.done`` marker are skipped, a JP2 on
+disk at the listed size is not re-fetched, an existing output is not re-decoded;
+``--workers`` items run at once, each fetching ``--streams`` sheets at a time.
+The HTTP mirror sustains about 20 MB/s in aggregate, so the run is bound by it:
+about two days for the whole collection.
+
+    mapsnap loc-mirror ~/Downloads/loc-sanborn-maps.mapping.tsv \\
+        --jp2-dir /Volumes/fivetera/loc-sanborn-maps/jp2 \\
+        --out-dir /Volumes/fivetera/mapsnap-sanborn \\
+        --bucket s3://mapsnap-sanborn --workers 4 --streams 2
+    mapsnap loc-mirror MAPPING.tsv ... --upload-only     # sync finished items later
+"""
+
+import argparse
+import csv
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass, field
+from multiprocessing import Pool
+from pathlib import Path
+
+from PIL import Image
+
+from mapsnap.keymap.fit_keymap import page_number
+from mapsnap.keymap.identify import CANDIDATE_PAGE_NUMBERS, is_letter_page
+
+DEFAULT_MIRROR = "http://50.35.157.188:27182"
+LOC_IIIF = "https://tile.loc.gov/image-services/iiif"
+JPEG_QUALITY = 95  # what mapsnap scale writes; the pipeline is tuned on it
+QUARTER_REDUCE = 2  # JPEG 2000 resolution levels to drop: 1/4 linear = 25%
+RETRIES = 4
+DONE, UPLOADED = ".done", ".uploaded"
+
+
+@dataclass
+class Sheet:
+    """One sheet of an item, as the mapping table describes it."""
+
+    seq: int
+    stem: str
+    key: str  # mapsnap page key, e.g. p101s
+    source: str  # torrent-jp2 | torrent-master-tif | torrent-master-jp2 | loc-iiif
+    bytes: int
+    storage_dir: (
+        str  # gmd/.../g0..., the torrent directory under storage-services/service
+    )
+
+
+@dataclass
+class ItemPlan:
+    """An item's catalog fields and its kept sheets."""
+
+    item: str
+    state: str
+    year: str
+    city: str
+    sheets: list[Sheet] = field(default_factory=list)
+
+
+def keep_sheet(key: str) -> bool:
+    """Whether the pipeline can use this sheet: numbered pages and letter pages only."""
+    return re.match(r"p\d", key) is not None or is_letter_page(key)
+
+
+def is_candidate(key: str) -> bool:
+    """Whether the sheet is a key-map candidate, mirroring keymap.identify.candidate_keys."""
+    if is_letter_page(key):
+        return True
+    base = re.sub(r"[a-j]$", "", key) if re.match(r"p\d+[a-j]$", key) else key
+    number = page_number(base)
+    return number is not None and number in CANDIDATE_PAGE_NUMBERS
+
+
+def load_mapping(path: Path) -> dict[str, ItemPlan]:
+    """Items keyed by id from the mapping TSV, with only the kept sheets."""
+    plans: dict[str, ItemPlan] = {}
+    with open(path, newline="") as handle:
+        for row in csv.DictReader(handle, delimiter="\t"):
+            if not row["stem"] or not keep_sheet(row["page_key"]):
+                continue
+            plan = plans.setdefault(
+                row["item"],
+                ItemPlan(row["item"], row["state"], row["year"], row["city"]),
+            )
+            plan.sheets.append(
+                Sheet(
+                    int(row["seq"]),
+                    row["stem"],
+                    row["page_key"],
+                    row["source"],
+                    int(row["bytes"] or 0),
+                    row["storage_dir"],
+                )
+            )
+    return plans
+
+
+def item_dir(out_dir: Path, plan: ItemPlan) -> Path:
+    """``<out>/by-state/<state>/<year>/<item>``, the same shape as the S3 prefix."""
+    return out_dir / "by-state" / plan.state / plan.year / plan.item
+
+
+def s3_prefix(bucket: str, plan: ItemPlan) -> str:
+    """The item's destination prefix, e.g. ``s3://mapsnap-sanborn/by-state/alabama/1922/sanborn00081_001``."""
+    return f"{bucket.rstrip('/')}/by-state/{plan.state}/{plan.year}/{plan.item}"
+
+
+def jp2_path(jp2_dir: Path, sheet: Sheet) -> Path:
+    """Where the sheet's JP2 lives locally, mirroring the torrent tree."""
+    return (
+        jp2_dir
+        / "storage-services"
+        / "service"
+        / sheet.storage_dir
+        / f"{sheet.stem}.jp2"
+    )
+
+
+def source_url(mirror: str, sheet: Sheet, full: bool = False) -> str:
+    """The URL to fetch a sheet from: the mirror's JP2/TIFF, or LoC's IIIF for the rest."""
+    if sheet.source == "torrent-jp2":
+        return f"{mirror}/storage-services/service/{sheet.storage_dir}/{sheet.stem}.jp2"
+    if sheet.source == "torrent-master-tif":
+        return f"{mirror}/storage-services/master/{sheet.storage_dir}/{sheet.stem}.tif"
+    if sheet.source == "torrent-master-jp2":
+        return f"{mirror}/storage-services/master/{sheet.storage_dir}/{sheet.stem}.jp2"
+    service = "service:" + sheet.storage_dir.replace("/", ":")
+    size = "full" if full else "pct:25"
+    return f"{LOC_IIIF}/{service}:{sheet.stem}/full/{size}/0/default.jpg"
+
+
+def fetch(url: str, dest: Path, expected_bytes: int = 0) -> None:
+    """Download ``url`` to ``dest`` with retries; verify the byte count when known."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    last: Exception | None = None
+    for attempt in range(RETRIES):
+        try:
+            partial = dest.with_suffix(dest.suffix + ".part")
+            with (
+                urllib.request.urlopen(url, timeout=300) as response,
+                open(partial, "wb") as out,
+            ):
+                shutil.copyfileobj(response, out, 1 << 20)
+            size = partial.stat().st_size
+            if expected_bytes and size != expected_bytes:
+                raise OSError(f"size {size} != listed {expected_bytes}")
+            partial.replace(dest)
+            return
+        except (OSError, urllib.error.URLError) as error:
+            last = error
+            time.sleep(5 * (attempt + 1))
+    raise OSError(f"{url}: {last}")
+
+
+def opj_available() -> bool:
+    """Whether the OpenJPEG decoder CLI is on the PATH."""
+    return shutil.which("opj_decompress") is not None
+
+
+def decode_jp2(jp2: Path, out_jpg: Path, reduce: int) -> tuple[int, int]:
+    """Decode a JP2 at ``reduce`` resolution levels down and write a JPEG; returns its size.
+
+    Uses ``opj_decompress`` (fast, multithreaded) when present, else Pillow.
+    """
+    out_jpg.parent.mkdir(parents=True, exist_ok=True)
+    if opj_available():
+        with tempfile.TemporaryDirectory() as tmp:
+            ppm = Path(tmp) / "decoded.ppm"
+            subprocess.run(
+                [
+                    "opj_decompress",
+                    "-threads",
+                    "4",
+                    "-i",
+                    str(jp2),
+                    "-r",
+                    str(reduce),
+                    "-o",
+                    str(ppm),
+                ],
+                check=True,
+                capture_output=True,
+            )
+            image = Image.open(ppm)
+            image.load()
+    else:
+        image = Image.open(jp2)
+        image.reduce = reduce  # type: ignore[attr-defined]
+        image.load()
+    image.convert("RGB").save(out_jpg, "JPEG", quality=JPEG_QUALITY)
+    return image.size
+
+
+def scale_to_quarter(src: Path, out_jpg: Path) -> tuple[int, int]:
+    """Write a 25% JPEG of a full-resolution TIFF or JPEG (the non-JP2 sources)."""
+    out_jpg.parent.mkdir(parents=True, exist_ok=True)
+    Image.MAX_IMAGE_PIXELS = None
+    image = Image.open(src)
+    image.load()
+    small = image.convert("RGB").resize(
+        (max(1, image.width // 4), max(1, image.height // 4)), Image.Resampling.LANCZOS
+    )
+    small.save(out_jpg, "JPEG", quality=JPEG_QUALITY)
+    return small.size
+
+
+@dataclass
+class Settings:
+    """Everything a worker needs; picklable for the process pool."""
+
+    jp2_dir: Path
+    out_dir: Path
+    mirror: str = DEFAULT_MIRROR
+    bucket: str | None = None
+    streams: int = 2
+    upload: bool = False
+    dry_run: bool = False
+
+
+def broken_log_path(out_dir: Path) -> Path:
+    return out_dir / "broken.log"
+
+
+def log_broken(out_dir: Path, plan: ItemPlan, sheet: Sheet, reason: str) -> None:
+    """Append one tab-separated line: item, stem, source, reason."""
+    with open(broken_log_path(out_dir), "a") as handle:
+        handle.write(f"{plan.item}\t{sheet.stem}\t{sheet.source}\t{reason}\n")
+
+
+def sheet_outputs(dest: Path, sheet: Sheet) -> tuple[Path, Path | None]:
+    """(25% JPEG path, raw full-resolution path or None) for a sheet."""
+    quarter = dest / f"{sheet.key}.jpg"
+    raw = dest / "raw" / f"{sheet.key}.jpg" if is_candidate(sheet.key) else None
+    return quarter, raw
+
+
+def process_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> dict | None:
+    """Fetch and decode one sheet; returns its metadata row, or None if broken."""
+    dest = item_dir(settings.out_dir, plan)
+    quarter, raw = sheet_outputs(dest, sheet)
+    row = asdict(sheet)
+    try:
+        if sheet.source.startswith("torrent"):
+            local = jp2_path(settings.jp2_dir, sheet)
+            if sheet.source == "torrent-master-tif":
+                local = local.with_suffix(".tif")
+            if not (
+                local.exists()
+                and (not sheet.bytes or local.stat().st_size == sheet.bytes)
+            ):
+                fetch(source_url(settings.mirror, sheet), local, sheet.bytes)
+            if not quarter.exists():
+                if local.suffix == ".jp2":
+                    decode_jp2(local, quarter, QUARTER_REDUCE)
+                else:
+                    scale_to_quarter(local, quarter)
+            if raw and not raw.exists():
+                if local.suffix == ".jp2":
+                    decode_jp2(local, raw, 0)
+                else:
+                    Image.MAX_IMAGE_PIXELS = None
+                    Image.open(local).convert("RGB").save(
+                        raw, "JPEG", quality=JPEG_QUALITY
+                    )
+        else:  # loc-iiif: the sheet has no file in the torrent
+            if not quarter.exists():
+                fetch(source_url(settings.mirror, sheet), quarter)
+            if raw and not raw.exists():
+                fetch(source_url(settings.mirror, sheet, full=True), raw)
+        with Image.open(quarter) as image:
+            row["width"], row["height"] = image.size
+        row["raw"] = raw is not None
+        return row
+    except Exception as error:  # noqa: BLE001 -- any failure is a broken sheet, logged and skipped
+        log_broken(
+            settings.out_dir,
+            plan,
+            sheet,
+            f"{error.__class__.__name__}: {str(error)[:200]}",
+        )
+        for path in (quarter, raw):
+            if path and path.exists() and path.stat().st_size == 0:
+                path.unlink()
+        return None
+
+
+def write_metadata(
+    dest: Path, plan: ItemPlan, rows: list[dict], broken: list[str]
+) -> None:
+    """The item's metadata.json: catalog fields plus the sheet table."""
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "metadata.json").write_text(
+        json.dumps(
+            {
+                "item": plan.item,
+                "loc_url": f"https://www.loc.gov/item/{plan.item}/",
+                "state": plan.state,
+                "year": plan.year,
+                "city": plan.city,
+                "storage_dir": plan.sheets[0].storage_dir if plan.sheets else None,
+                "jpeg_quality": JPEG_QUALITY,
+                "scale_percent": 25,
+                "sheets": rows,
+                "broken": broken,
+            },
+            indent=1,
+        )
+    )
+
+
+def upload_item(dest: Path, plan: ItemPlan, bucket: str) -> None:
+    """``aws s3 sync`` the item directory to its prefix, then mark it uploaded."""
+    subprocess.run(
+        [
+            "aws",
+            "s3",
+            "sync",
+            str(dest),
+            s3_prefix(bucket, plan),
+            "--exclude",
+            ".*",
+            "--only-show-errors",
+        ],
+        check=True,
+    )
+    (dest / UPLOADED).touch()
+
+
+def process_item(args: tuple[ItemPlan, Settings]) -> dict:
+    """Do one item end to end; returns a progress record."""
+    plan, settings = args
+    dest = item_dir(settings.out_dir, plan)
+    started = time.time()
+    if settings.dry_run:
+        return {"item": plan.item, "sheets": len(plan.sheets), "dry_run": True}
+    if not (dest / DONE).exists():
+        rows: list[dict] = []
+        broken: list[str] = []
+        with ThreadPoolExecutor(max_workers=settings.streams) as pool:
+            for sheet, row in zip(
+                plan.sheets,
+                pool.map(lambda s: process_sheet(plan, s, settings), plan.sheets),
+            ):
+                if row is None:
+                    broken.append(sheet.stem)
+                else:
+                    rows.append(row)
+        write_metadata(dest, plan, rows, broken)
+        (dest / DONE).touch()
+    if settings.upload and settings.bucket and not (dest / UPLOADED).exists():
+        upload_item(dest, plan, settings.bucket)
+    return {
+        "item": plan.item,
+        "sheets": len(plan.sheets),
+        "seconds": round(time.time() - started, 1),
+        "uploaded": (dest / UPLOADED).exists(),
+    }
+
+
+def select_items(
+    plans: dict[str, ItemPlan], args: argparse.Namespace
+) -> list[ItemPlan]:
+    """The items to run, filtered by --states / --items, in a stable order."""
+    states = set(args.states.split(",")) if args.states else None
+    wanted = set(args.items.split(",")) if args.items else None
+    chosen = [
+        plan
+        for plan in plans.values()
+        if (states is None or plan.state in states)
+        and (wanted is None or plan.item in wanted)
+    ]
+    chosen.sort(key=lambda plan: (plan.state, plan.year, plan.item))
+    return chosen[: args.limit] if args.limit else chosen
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "mapping",
+        type=Path,
+        help="Mapping TSV (item, state, year, ..., stem, page_key, source, bytes, storage_dir).",
+    )
+    parser.add_argument(
+        "--jp2-dir",
+        type=Path,
+        required=True,
+        help="Local mirror of the torrent's storage-services tree.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        required=True,
+        help="Staging root; by-state/<state>/<year>/<item>/ goes under it.",
+    )
+    parser.add_argument(
+        "--mirror", default=DEFAULT_MIRROR, help="HTTP root serving the torrent's tree."
+    )
+    parser.add_argument(
+        "--bucket",
+        default=None,
+        help="s3://bucket to sync finished items to (with --upload).",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="aws s3 sync each item after it completes.",
+    )
+    parser.add_argument(
+        "--upload-only",
+        action="store_true",
+        help="Only sync items already marked done.",
+    )
+    parser.add_argument(
+        "--workers", type=int, default=4, help="Items processed at once."
+    )
+    parser.add_argument(
+        "--streams", type=int, default=2, help="Concurrent sheet downloads per item."
+    )
+    parser.add_argument(
+        "--states",
+        default=None,
+        help="Comma-separated catalog state folders to include.",
+    )
+    parser.add_argument(
+        "--items", default=None, help="Comma-separated item ids to include."
+    )
+    parser.add_argument(
+        "--limit", type=int, default=0, help="Stop after this many items (0 = all)."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List the items and sheet counts; touch nothing.",
+    )
+    args = parser.parse_args()
+
+    if not opj_available():
+        print(
+            "warning: opj_decompress not found; decoding with Pillow (several times slower)",
+            file=sys.stderr,
+        )
+    plans = load_mapping(args.mapping)
+    chosen = select_items(plans, args)
+    settings = Settings(
+        jp2_dir=args.jp2_dir,
+        out_dir=args.out_dir,
+        mirror=args.mirror,
+        bucket=args.bucket,
+        streams=args.streams,
+        upload=args.upload or args.upload_only,
+        dry_run=args.dry_run,
+    )
+    if args.upload_only:
+        chosen = [
+            plan for plan in chosen if (item_dir(args.out_dir, plan) / DONE).exists()
+        ]
+    total_sheets = sum(len(plan.sheets) for plan in chosen)
+    total_bytes = sum(sheet.bytes for plan in chosen for sheet in plan.sheets)
+    print(
+        f"{len(chosen)} items, {total_sheets:,} sheets, {total_bytes / 1e9:,.1f} GB of JP2",
+        file=sys.stderr,
+    )
+    if args.dry_run:
+        for plan in chosen[:20]:
+            print(
+                f"  {plan.item} {plan.state}/{plan.year} {len(plan.sheets)} sheets -> {item_dir(args.out_dir, plan)}"
+            )
+        return
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    done = 0
+    started = time.time()
+    with (
+        open(args.out_dir / "progress.jsonl", "a") as progress,
+        Pool(args.workers) as pool,
+    ):
+        for record in pool.imap_unordered(
+            process_item, [(plan, settings) for plan in chosen]
+        ):
+            progress.write(json.dumps(record) + "\n")
+            progress.flush()
+            done += 1
+            if done % 25 == 0 or done == len(chosen):
+                elapsed = time.time() - started
+                remaining = (len(chosen) - done) * elapsed / done / 3600
+                print(
+                    f"{done}/{len(chosen)} items, {elapsed / 3600:.1f} h elapsed, "
+                    f"{remaining:.1f} h remaining at this rate",
+                    file=sys.stderr,
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -45,6 +45,7 @@ download or decode after retries is logged as broken and left out of its item.
 
 import argparse
 import csv
+import http.client
 import json
 import random
 import re
@@ -52,6 +53,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -65,6 +67,7 @@ from concurrent.futures import (
 )
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from PIL import Image
 from tqdm import tqdm
@@ -77,6 +80,7 @@ LOC_IIIF = "https://tile.loc.gov/image-services/iiif"
 JPEG_QUALITY = 95  # what mapsnap scale writes; the pipeline is tuned on it
 QUARTER_REDUCE = 2  # JPEG 2000 resolution levels to drop: 1/4 linear = 25%
 RETRIES = 4
+RETRY_DELAY = 5.0  # seconds, times the attempt number
 DONE, UPLOADED = ".done", ".uploaded"
 
 
@@ -201,26 +205,81 @@ def sheet_outputs(staging_item: Path, sheet: Sheet) -> tuple[Path, Path | None]:
     return quarter, raw
 
 
+_connections = threading.local()
+
+
+def mirror_connection(host: str, port: int | None) -> http.client.HTTPConnection:
+    """This thread's persistent HTTP/1.1 connection to the mirror, opened on first use.
+
+    One connection per thread, reused across files: the mirror's uplink is
+    fast, but each new TCP connection pays a handshake and slow start that an
+    8 MB file never gets past, which cost two thirds of the throughput when
+    every request opened its own.
+    """
+    key = (host, port)
+    conn = getattr(_connections, "conn", None)
+    if conn is None or getattr(_connections, "key", None) != key:
+        if conn is not None:
+            conn.close()
+        conn = http.client.HTTPConnection(host, port, timeout=300)
+        _connections.conn, _connections.key = conn, key
+    return conn
+
+
+def drop_connection() -> None:
+    """Close this thread's mirror connection after an error, so the next fetch reconnects."""
+    conn = getattr(_connections, "conn", None)
+    if conn is not None:
+        conn.close()
+    _connections.conn = None
+
+
+def fetch_http(url: str, partial: Path) -> None:
+    """GET ``url`` over the thread's keep-alive connection, streaming the body to ``partial``."""
+    parts = urlsplit(url)
+    conn = mirror_connection(parts.hostname or "", parts.port)
+    path = parts.path + (f"?{parts.query}" if parts.query else "")
+    conn.request("GET", path, headers={"Connection": "keep-alive"})
+    response = conn.getresponse()
+    try:
+        if response.status != 200:
+            response.read()
+            raise OSError(f"HTTP {response.status}")
+        with open(partial, "wb") as out:
+            while chunk := response.read(1 << 20):
+                out.write(chunk)
+    finally:
+        response.close()
+
+
 def fetch(url: str, dest: Path, expected_bytes: int = 0) -> None:
-    """Download ``url`` to ``dest`` with retries; verify the byte count when known."""
+    """Download ``url`` to ``dest`` with retries; verify the byte count when known.
+
+    Plain-http URLs (the mirror) reuse a per-thread keep-alive connection;
+    anything else (LoC's IIIF over https, file:// in tests) goes through urllib.
+    """
     dest.parent.mkdir(parents=True, exist_ok=True)
     last: Exception | None = None
     partial = dest.with_suffix(dest.suffix + ".part")
     for attempt in range(RETRIES):
         try:
-            with (
-                urllib.request.urlopen(url, timeout=300) as response,
-                open(partial, "wb") as out,
-            ):
-                shutil.copyfileobj(response, out, 1 << 20)
+            if urlsplit(url).scheme == "http":
+                fetch_http(url, partial)
+            else:
+                with (
+                    urllib.request.urlopen(url, timeout=300) as response,
+                    open(partial, "wb") as out,
+                ):
+                    shutil.copyfileobj(response, out, 1 << 20)
             size = partial.stat().st_size
             if expected_bytes and size != expected_bytes:
                 raise OSError(f"size {size} != listed {expected_bytes}")
             partial.replace(dest)
             return
-        except (OSError, urllib.error.URLError) as error:
+        except (OSError, urllib.error.URLError, http.client.HTTPException) as error:
             last = error
-            time.sleep(5 * (attempt + 1))
+            drop_connection()
+            time.sleep(RETRY_DELAY * (attempt + 1))
     partial.unlink(missing_ok=True)
     raise OSError(f"{url}: {last}")
 
@@ -382,10 +441,11 @@ def metadata_document(plan: ItemPlan, rows: list[dict], broken: list[str]) -> di
 
 def decode_item(
     plan: ItemPlan, fetched: list[bool], settings: Settings
-) -> tuple[int, int]:
+) -> tuple[int, int, int]:
     """Decode every fetched sheet, write metadata to staging and state, mark done.
 
-    Returns (sheets decoded, sheets broken). Runs in a worker process.
+    Returns (sheets decoded, sheets broken, bytes now waiting in staging).
+    Runs in a worker process.
     """
     rows: list[dict] = []
     broken: list[str] = []
@@ -401,7 +461,12 @@ def decode_item(
         directory.mkdir(parents=True, exist_ok=True)
         (directory / "metadata.json").write_text(document)
     (settings.out_dir / item_relative(plan) / DONE).touch()
-    return len(rows), len(broken)
+    staged = sum(
+        path.stat().st_size
+        for path in (settings.staging_dir / item_relative(plan)).rglob("*")
+        if path.is_file()
+    )
+    return len(rows), len(broken), staged
 
 
 # ---------------------------------------------------------------- stage 3: upload
@@ -480,10 +545,11 @@ def run_pipeline(
     items: list[ItemPlan],
     settings: Settings,
     *,
-    streams: int = 8,
+    streams: int = 12,
     decode_workers: int = 4,
-    prefetch_items: int = 6,
+    prefetch_items: int = 16,
     upload_workers: int = 2,
+    max_staging_bytes: float = 250e9,
     progress: bool = True,
 ) -> dict[str, int]:
     """Drive the three stages concurrently over ``items``; returns totals.
@@ -491,9 +557,12 @@ def run_pipeline(
     Downloads are submitted sheet by sheet for up to ``prefetch_items`` items
     ahead of decoding, so small items do not starve the connections; an item
     moves to decoding when all its sheets are on disk, and to upload when its
-    metadata is written. One tqdm bar counts decoded sheets (the download
-    stage paces it), with downloaded gigabytes, uploaded items, and broken
-    sheets in the postfix.
+    metadata is written. The upload stage is decoupled: downloads and decodes
+    never wait for the uplink. New items are held back only while more than
+    ``max_staging_bytes`` of decoded output is waiting to upload, so a slow
+    uplink costs staging disk rather than download throughput. One tqdm bar
+    counts decoded sheets, with downloaded gigabytes, uploaded items, the
+    staging backlog, and broken sheets in the postfix.
     """
     todo = deque(item for item in items if not item_complete(item, settings))
     total_sheets = sum(len(item.sheets) for item in todo)
@@ -509,7 +578,8 @@ def run_pipeline(
     item_fetch: dict[str, list[bool | None]] = {}
     decodes: dict[Future, ItemPlan] = {}
     uploads: dict[Future, ItemPlan] = {}
-    in_flight: set[str] = set()
+    item_staged: dict[str, int] = {}
+    staged_bytes = 0
     settings.out_dir.mkdir(parents=True, exist_ok=True)
 
     def start_decode(plan: ItemPlan) -> None:
@@ -523,9 +593,12 @@ def run_pipeline(
         ThreadPoolExecutor(max_workers=upload_workers) as upload_pool,
     ):
         while todo or downloads or decodes or uploads:
-            while todo and len(in_flight) < prefetch_items:
+            while (
+                todo
+                and len(item_fetch) + len(decodes) < prefetch_items
+                and staged_bytes < max_staging_bytes
+            ):
                 plan = todo.popleft()
-                in_flight.add(plan.item)
                 item_fetch[plan.item] = [None] * len(plan.sheets)
                 if not plan.sheets:
                     start_decode(plan)
@@ -549,31 +622,31 @@ def run_pipeline(
                         start_decode(plan)
                 elif future in decodes:
                     plan = decodes.pop(future)
-                    decoded, broken = future.result()
+                    decoded, broken, staged = future.result()
                     totals["items"] += 1
                     totals["sheets"] += decoded
                     totals["broken"] += broken
                     bar.update(len(plan.sheets))
-                    if True:
-                        progress_log.write(
-                            json.dumps(
-                                {"item": plan.item, "sheets": decoded, "broken": broken}
-                            )
-                            + "\n"
+                    progress_log.write(
+                        json.dumps(
+                            {"item": plan.item, "sheets": decoded, "broken": broken}
                         )
-                        progress_log.flush()
+                        + "\n"
+                    )
+                    progress_log.flush()
                     if settings.upload and settings.bucket:
+                        item_staged[plan.item] = staged
+                        staged_bytes += staged
                         uploads[upload_pool.submit(upload_item, plan, settings)] = plan
-                    else:
-                        in_flight.discard(plan.item)
                 else:
                     plan = uploads.pop(future)
                     future.result()
                     totals["uploaded"] += 1
-                    in_flight.discard(plan.item)
+                    staged_bytes -= item_staged.pop(plan.item, 0)
             bar.set_postfix(
                 dl=f"{totals['bytes'] / 1e9:.1f}GB",
                 up=totals["uploaded"],
+                staged=f"{staged_bytes / 1e9:.1f}GB",
                 broken=totals["broken"],
                 refresh=False,
             )
@@ -629,8 +702,8 @@ def main() -> None:
     parser.add_argument(
         "--streams",
         type=int,
-        default=8,
-        help="Concurrent downloads (the mirror saturates near 8).",
+        default=12,
+        help="Concurrent keep-alive downloads from the mirror.",
     )
     parser.add_argument(
         "--decode-workers", type=int, default=4, help="Decode processes."
@@ -638,8 +711,14 @@ def main() -> None:
     parser.add_argument(
         "--prefetch-items",
         type=int,
-        default=6,
-        help="Items downloading ahead of decoding.",
+        default=16,
+        help="Items downloading or decoding at once (the upload queue is unbounded).",
+    )
+    parser.add_argument(
+        "--max-staging-gb",
+        type=float,
+        default=250.0,
+        help="Pause downloads while this much decoded output waits for upload.",
     )
     parser.add_argument(
         "--states",
@@ -713,6 +792,7 @@ def main() -> None:
         streams=args.streams,
         decode_workers=args.decode_workers,
         prefetch_items=args.prefetch_items,
+        max_staging_bytes=args.max_staging_gb * 1e9,
     )
     print(
         f"done: {totals['items']} items, {totals['sheets']:,} sheets, {totals['broken']} broken, "

--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -1,43 +1,44 @@
 """Build the mapsnap Sanborn mirror from full-resolution LoC JP2s.
 
-Source of truth is the Library of Congress `storage-services` tree as served by
-the torrent's HTTP mirror: every sheet is a JP2 whose filename carries the
+Source of truth is the Library of Congress ``storage-services`` tree as served
+by the torrent's HTTP mirror: every sheet is a JP2 whose filename carries the
 sheet's own identity (``06246_1914-0051``), so no sequence-number mapping is
-involved. The plan comes from a mapping table (one row per sheet: item, state,
-year, city, sequence, stem, page key, source, bytes, storage dir) built from the
+involved. The plan is a mapping table (one row per sheet: item, state, year,
+city, sequence, stem, page key, source, bytes, storage dir) built from the
 torrent listing and the loc.gov catalog.
 
-Per item (one LoC catalog record, normally one volume):
+Three stages run concurrently, each bounded by a different resource:
 
-  * download each kept sheet's JP2 to ``--jp2-dir`` mirroring the torrent tree
-    (``storage-services/service/<dir>/<stem>.jp2``), verified against the
-    listed byte count, so the copy stays a valid torrent payload;
-  * decode it at the JPEG 2000 quarter-resolution level, which IS the pipeline's
-    25% working scale, to ``<out>/by-state/<state>/<year>/<item>/p<key>.jpg``
-    (JPEG quality 95, as ``mapsnap scale`` writes);
-  * for key-map candidates (page 0 and page 1 families, letter pages -- see
-    ``keymap.identify.candidate_keys``) also decode at full resolution to
-    ``raw/p<key>.jpg``, as the ``data/`` volumes keep them;
-  * write ``metadata.json`` (the catalog fields and the sheet table) and a
-    ``.done`` marker; optionally ``aws s3 sync`` the item directory to the
-    bucket and mark ``.uploaded``.
+  1. download (network, ``--streams`` connections): each kept sheet's JP2 goes
+     to ``--jp2-dir`` mirroring the torrent tree
+     (``storage-services/service/<dir>/<stem>.jp2``), verified against the
+     listed byte count, so the copy stays a valid torrent payload and is kept;
+  2. decode (CPU, ``--decode-workers`` processes): the JP2 is decoded at the
+     JPEG 2000 quarter-resolution level -- the pipeline's 25% working scale --
+     to ``<staging>/by-state/<state>/<year>/<item>/p<key>.jpg`` (JPEG quality
+     95, what ``mapsnap scale`` writes); page-0 sheets (``p0``, ``p0b``,
+     ``p0L``) and letter pages, the key-map candidates, are also decoded at
+     full resolution to ``raw/p<key>.jpg``;
+  3. upload (your uplink, two ``aws s3 sync`` at a time): the item directory
+     goes to ``<bucket>/by-state/<state>/<year>/<item>/`` and its staging
+     copy is deleted (``--keep-staging`` to retain it).
 
-Sheets whose page key does not start with a digit (covr, ind1, cbd, titl, note)
-are skipped: nothing in the pipeline reads them. A sheet whose download or
-decode fails after retries is appended to ``broken.log`` (tab-separated: item,
-stem, source, reason) and left out of the item; the item still completes.
+State lives only on local disk, under ``--out-dir``: per item a copy of
+``metadata.json`` (catalog fields plus the sheet table) with ``.done`` and
+``.uploaded`` markers, plus ``broken.log`` (tab-separated item, stem, source,
+reason) and ``progress.jsonl``. Resuming never lists S3: an item with its
+marker is skipped, a JP2 on disk at the listed size is not re-fetched, and an
+output already in staging is not re-decoded.
 
-Resumable and parallel: items with a ``.done`` marker are skipped, a JP2 on
-disk at the listed size is not re-fetched, an existing output is not re-decoded;
-``--workers`` items run at once, each fetching ``--streams`` sheets at a time.
-The HTTP mirror sustains about 20 MB/s in aggregate, so the run is bound by it:
-about two days for the whole collection.
+Sheets whose page key does not start with a digit (covr, ind1, cbd, titl,
+note) are skipped: nothing in the pipeline reads them. A sheet that fails to
+download or decode after retries is logged as broken and left out of its item.
 
     mapsnap loc-mirror ~/Downloads/loc-sanborn-maps.mapping.tsv \\
         --jp2-dir /Volumes/fivetera/loc-sanborn-maps/jp2 \\
         --out-dir /Volumes/fivetera/mapsnap-sanborn \\
-        --bucket s3://mapsnap-sanborn --workers 4 --streams 2
-    mapsnap loc-mirror MAPPING.tsv ... --upload-only     # sync finished items later
+        --staging-dir /Volumes/fivetera/mapsnap-sanborn/staging \\
+        --bucket s3://mapsnap-sanborn --upload
 """
 
 import argparse
@@ -51,15 +52,22 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
-from concurrent.futures import ThreadPoolExecutor
+from collections import deque
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    Future,
+    ProcessPoolExecutor,
+    ThreadPoolExecutor,
+    wait,
+)
 from dataclasses import asdict, dataclass, field
-from multiprocessing import Pool
 from pathlib import Path
 
 from PIL import Image
+from tqdm import tqdm
 
 from mapsnap.keymap.fit_keymap import page_number
-from mapsnap.keymap.identify import CANDIDATE_PAGE_NUMBERS, is_letter_page
+from mapsnap.keymap.identify import is_letter_page
 
 DEFAULT_MIRROR = "http://50.35.157.188:27182"
 LOC_IIIF = "https://tile.loc.gov/image-services/iiif"
@@ -94,18 +102,36 @@ class ItemPlan:
     sheets: list[Sheet] = field(default_factory=list)
 
 
+@dataclass
+class Settings:
+    """Everything the stages need; picklable for the process pool."""
+
+    jp2_dir: Path
+    out_dir: Path
+    staging_dir: Path
+    mirror: str = DEFAULT_MIRROR
+    bucket: str | None = None
+    upload: bool = False
+    keep_staging: bool = False
+
+
 def keep_sheet(key: str) -> bool:
     """Whether the pipeline can use this sheet: numbered pages and letter pages only."""
     return re.match(r"p\d", key) is not None or is_letter_page(key)
 
 
 def is_candidate(key: str) -> bool:
-    """Whether the sheet is a key-map candidate, mirroring keymap.identify.candidate_keys."""
+    """Whether a raw copy is kept: the page-0 family (p0, p0b, p0L) and letter pages.
+
+    keymap.identify also nominates the page-1 family, but page 0 is the key
+    map wherever one exists, and raw copies of every volume's sheet 1 would
+    cost 34,000 full-resolution decodes for candidates that are almost all
+    ordinary map pages.
+    """
     if is_letter_page(key):
         return True
     base = re.sub(r"[a-j]$", "", key) if re.match(r"p\d+[a-j]$", key) else key
-    number = page_number(base)
-    return number is not None and number in CANDIDATE_PAGE_NUMBERS
+    return page_number(base) == 0
 
 
 def load_mapping(path: Path) -> dict[str, ItemPlan]:
@@ -132,47 +158,53 @@ def load_mapping(path: Path) -> dict[str, ItemPlan]:
     return plans
 
 
-def item_dir(out_dir: Path, plan: ItemPlan) -> Path:
-    """``<out>/by-state/<state>/<year>/<item>``, the same shape as the S3 prefix."""
-    return out_dir / "by-state" / plan.state / plan.year / plan.item
+def item_relative(plan: ItemPlan) -> Path:
+    """``by-state/<state>/<year>/<item>``: the item's path under staging, state, and the bucket."""
+    return Path("by-state") / plan.state / plan.year / plan.item
 
 
 def s3_prefix(bucket: str, plan: ItemPlan) -> str:
-    """The item's destination prefix, e.g. ``s3://mapsnap-sanborn/by-state/alabama/1922/sanborn00081_001``."""
-    return f"{bucket.rstrip('/')}/by-state/{plan.state}/{plan.year}/{plan.item}"
+    """The item's destination, e.g. ``s3://mapsnap-sanborn/by-state/alabama/1922/sanborn00081_001``."""
+    return f"{bucket.rstrip('/')}/{item_relative(plan).as_posix()}"
 
 
 def jp2_path(jp2_dir: Path, sheet: Sheet) -> Path:
-    """Where the sheet's JP2 lives locally, mirroring the torrent tree."""
+    """Where the sheet's JP2 (or TIFF master) lives locally, mirroring the torrent tree."""
+    branch = "master" if sheet.source.startswith("torrent-master") else "service"
+    suffix = ".tif" if sheet.source == "torrent-master-tif" else ".jp2"
     return (
         jp2_dir
         / "storage-services"
-        / "service"
+        / branch
         / sheet.storage_dir
-        / f"{sheet.stem}.jp2"
+        / f"{sheet.stem}{suffix}"
     )
 
 
 def source_url(mirror: str, sheet: Sheet, full: bool = False) -> str:
     """The URL to fetch a sheet from: the mirror's JP2/TIFF, or LoC's IIIF for the rest."""
-    if sheet.source == "torrent-jp2":
-        return f"{mirror}/storage-services/service/{sheet.storage_dir}/{sheet.stem}.jp2"
-    if sheet.source == "torrent-master-tif":
-        return f"{mirror}/storage-services/master/{sheet.storage_dir}/{sheet.stem}.tif"
-    if sheet.source == "torrent-master-jp2":
-        return f"{mirror}/storage-services/master/{sheet.storage_dir}/{sheet.stem}.jp2"
+    if sheet.source.startswith("torrent"):
+        branch = "master" if sheet.source.startswith("torrent-master") else "service"
+        suffix = ".tif" if sheet.source == "torrent-master-tif" else ".jp2"
+        return f"{mirror}/storage-services/{branch}/{sheet.storage_dir}/{sheet.stem}{suffix}"
     service = "service:" + sheet.storage_dir.replace("/", ":")
-    size = "full" if full else "pct:25"
-    return f"{LOC_IIIF}/{service}:{sheet.stem}/full/{size}/0/default.jpg"
+    return f"{LOC_IIIF}/{service}:{sheet.stem}/full/{'full' if full else 'pct:25'}/0/default.jpg"
+
+
+def sheet_outputs(staging_item: Path, sheet: Sheet) -> tuple[Path, Path | None]:
+    """(25% JPEG path, raw full-resolution path or None) for a sheet."""
+    quarter = staging_item / f"{sheet.key}.jpg"
+    raw = staging_item / "raw" / f"{sheet.key}.jpg" if is_candidate(sheet.key) else None
+    return quarter, raw
 
 
 def fetch(url: str, dest: Path, expected_bytes: int = 0) -> None:
     """Download ``url`` to ``dest`` with retries; verify the byte count when known."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     last: Exception | None = None
+    partial = dest.with_suffix(dest.suffix + ".part")
     for attempt in range(RETRIES):
         try:
-            partial = dest.with_suffix(dest.suffix + ".part")
             with (
                 urllib.request.urlopen(url, timeout=300) as response,
                 open(partial, "wb") as out,
@@ -186,7 +218,58 @@ def fetch(url: str, dest: Path, expected_bytes: int = 0) -> None:
         except (OSError, urllib.error.URLError) as error:
             last = error
             time.sleep(5 * (attempt + 1))
+    partial.unlink(missing_ok=True)
     raise OSError(f"{url}: {last}")
+
+
+def broken_log_path(out_dir: Path) -> Path:
+    return out_dir / "broken.log"
+
+
+def log_broken(out_dir: Path, plan: ItemPlan, sheet: Sheet, reason: str) -> None:
+    """Append one tab-separated line: item, stem, source, reason."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(broken_log_path(out_dir), "a") as handle:
+        handle.write(f"{plan.item}\t{sheet.stem}\t{sheet.source}\t{reason}\n")
+
+
+# ---------------------------------------------------------------- stage 1: download
+
+
+def fetch_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> bool:
+    """Bring the sheet's source to disk; False (and a broken-log line) on failure.
+
+    Torrent sources land in the JP2 mirror; the few LoC-only sheets are fetched
+    already rendered, straight into staging.
+    """
+    try:
+        if sheet.source.startswith("torrent"):
+            local = jp2_path(settings.jp2_dir, sheet)
+            if local.exists() and (
+                not sheet.bytes or local.stat().st_size == sheet.bytes
+            ):
+                return True
+            fetch(source_url(settings.mirror, sheet), local, sheet.bytes)
+        else:
+            quarter, raw = sheet_outputs(
+                settings.staging_dir / item_relative(plan), sheet
+            )
+            if not quarter.exists():
+                fetch(source_url(settings.mirror, sheet), quarter)
+            if raw and not raw.exists():
+                fetch(source_url(settings.mirror, sheet, full=True), raw)
+        return True
+    except Exception as error:  # noqa: BLE001 -- any failure is a broken sheet
+        log_broken(
+            settings.out_dir,
+            plan,
+            sheet,
+            f"{error.__class__.__name__}: {str(error)[:200]}",
+        )
+        return False
+
+
+# ---------------------------------------------------------------- stage 2: decode
 
 
 def opj_available() -> bool:
@@ -195,7 +278,7 @@ def opj_available() -> bool:
 
 
 def decode_jp2(jp2: Path, out_jpg: Path, reduce: int) -> tuple[int, int]:
-    """Decode a JP2 at ``reduce`` resolution levels down and write a JPEG; returns its size.
+    """Decode a JP2 ``reduce`` resolution levels down and write a JPEG; returns its size.
 
     Uses ``opj_decompress`` (fast, multithreaded) when present, else Pillow.
     """
@@ -207,7 +290,7 @@ def decode_jp2(jp2: Path, out_jpg: Path, reduce: int) -> tuple[int, int]:
                 [
                     "opj_decompress",
                     "-threads",
-                    "4",
+                    "2",
                     "-i",
                     str(jp2),
                     "-r",
@@ -229,7 +312,7 @@ def decode_jp2(jp2: Path, out_jpg: Path, reduce: int) -> tuple[int, int]:
 
 
 def scale_to_quarter(src: Path, out_jpg: Path) -> tuple[int, int]:
-    """Write a 25% JPEG of a full-resolution TIFF or JPEG (the non-JP2 sources)."""
+    """Write a 25% JPEG of a full-resolution TIFF (the master-only sheets)."""
     out_jpg.parent.mkdir(parents=True, exist_ok=True)
     Image.MAX_IMAGE_PIXELS = None
     image = Image.open(src)
@@ -241,51 +324,13 @@ def scale_to_quarter(src: Path, out_jpg: Path) -> tuple[int, int]:
     return small.size
 
 
-@dataclass
-class Settings:
-    """Everything a worker needs; picklable for the process pool."""
-
-    jp2_dir: Path
-    out_dir: Path
-    mirror: str = DEFAULT_MIRROR
-    bucket: str | None = None
-    streams: int = 2
-    upload: bool = False
-    dry_run: bool = False
-
-
-def broken_log_path(out_dir: Path) -> Path:
-    return out_dir / "broken.log"
-
-
-def log_broken(out_dir: Path, plan: ItemPlan, sheet: Sheet, reason: str) -> None:
-    """Append one tab-separated line: item, stem, source, reason."""
-    with open(broken_log_path(out_dir), "a") as handle:
-        handle.write(f"{plan.item}\t{sheet.stem}\t{sheet.source}\t{reason}\n")
-
-
-def sheet_outputs(dest: Path, sheet: Sheet) -> tuple[Path, Path | None]:
-    """(25% JPEG path, raw full-resolution path or None) for a sheet."""
-    quarter = dest / f"{sheet.key}.jpg"
-    raw = dest / "raw" / f"{sheet.key}.jpg" if is_candidate(sheet.key) else None
-    return quarter, raw
-
-
-def process_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> dict | None:
-    """Fetch and decode one sheet; returns its metadata row, or None if broken."""
-    dest = item_dir(settings.out_dir, plan)
-    quarter, raw = sheet_outputs(dest, sheet)
+def decode_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> dict | None:
+    """Produce the sheet's outputs in staging; returns its metadata row, None if broken."""
+    quarter, raw = sheet_outputs(settings.staging_dir / item_relative(plan), sheet)
     row = asdict(sheet)
     try:
         if sheet.source.startswith("torrent"):
             local = jp2_path(settings.jp2_dir, sheet)
-            if sheet.source == "torrent-master-tif":
-                local = local.with_suffix(".tif")
-            if not (
-                local.exists()
-                and (not sheet.bytes or local.stat().st_size == sheet.bytes)
-            ):
-                fetch(source_url(settings.mirror, sheet), local, sheet.bytes)
             if not quarter.exists():
                 if local.suffix == ".jp2":
                     decode_jp2(local, quarter, QUARTER_REDUCE)
@@ -299,16 +344,11 @@ def process_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> dict | No
                     Image.open(local).convert("RGB").save(
                         raw, "JPEG", quality=JPEG_QUALITY
                     )
-        else:  # loc-iiif: the sheet has no file in the torrent
-            if not quarter.exists():
-                fetch(source_url(settings.mirror, sheet), quarter)
-            if raw and not raw.exists():
-                fetch(source_url(settings.mirror, sheet, full=True), raw)
         with Image.open(quarter) as image:
             row["width"], row["height"] = image.size
         row["raw"] = raw is not None
         return row
-    except Exception as error:  # noqa: BLE001 -- any failure is a broken sheet, logged and skipped
+    except Exception as error:  # noqa: BLE001 -- any failure is a broken sheet
         log_broken(
             settings.out_dir,
             plan,
@@ -321,77 +361,87 @@ def process_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> dict | No
         return None
 
 
-def write_metadata(
-    dest: Path, plan: ItemPlan, rows: list[dict], broken: list[str]
-) -> None:
-    """The item's metadata.json: catalog fields plus the sheet table."""
-    dest.mkdir(parents=True, exist_ok=True)
-    (dest / "metadata.json").write_text(
-        json.dumps(
-            {
-                "item": plan.item,
-                "loc_url": f"https://www.loc.gov/item/{plan.item}/",
-                "state": plan.state,
-                "year": plan.year,
-                "city": plan.city,
-                "storage_dir": plan.sheets[0].storage_dir if plan.sheets else None,
-                "jpeg_quality": JPEG_QUALITY,
-                "scale_percent": 25,
-                "sheets": rows,
-                "broken": broken,
-            },
-            indent=1,
-        )
-    )
+def metadata_document(plan: ItemPlan, rows: list[dict], broken: list[str]) -> dict:
+    """The item's metadata.json content: catalog fields plus the sheet table."""
+    return {
+        "item": plan.item,
+        "loc_url": f"https://www.loc.gov/item/{plan.item}/",
+        "state": plan.state,
+        "year": plan.year,
+        "city": plan.city,
+        "storage_dir": plan.sheets[0].storage_dir if plan.sheets else None,
+        "jpeg_quality": JPEG_QUALITY,
+        "scale_percent": 25,
+        "sheets": rows,
+        "broken": broken,
+    }
 
 
-def upload_item(dest: Path, plan: ItemPlan, bucket: str) -> None:
-    """``aws s3 sync`` the item directory to its prefix, then mark it uploaded."""
+def decode_item(
+    plan: ItemPlan, fetched: list[bool], settings: Settings
+) -> tuple[int, int]:
+    """Decode every fetched sheet, write metadata to staging and state, mark done.
+
+    Returns (sheets decoded, sheets broken). Runs in a worker process.
+    """
+    rows: list[dict] = []
+    broken: list[str] = []
+    for sheet, ok in zip(plan.sheets, fetched):
+        row = decode_sheet(plan, sheet, settings) if ok else None
+        if row is None:
+            broken.append(sheet.stem)
+        else:
+            rows.append(row)
+    document = json.dumps(metadata_document(plan, rows, broken), indent=1)
+    for root in (settings.staging_dir, settings.out_dir):
+        directory = root / item_relative(plan)
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "metadata.json").write_text(document)
+    (settings.out_dir / item_relative(plan) / DONE).touch()
+    return len(rows), len(broken)
+
+
+# ---------------------------------------------------------------- stage 3: upload
+
+
+def upload_item(plan: ItemPlan, settings: Settings) -> None:
+    """``aws s3 sync`` the staging directory to its prefix, mark uploaded, drop the staging copy."""
+    assert settings.bucket
+    staging = settings.staging_dir / item_relative(plan)
     subprocess.run(
         [
             "aws",
             "s3",
             "sync",
-            str(dest),
-            s3_prefix(bucket, plan),
-            "--exclude",
-            ".*",
+            str(staging),
+            s3_prefix(settings.bucket, plan),
             "--only-show-errors",
         ],
         check=True,
     )
-    (dest / UPLOADED).touch()
+    (settings.out_dir / item_relative(plan) / UPLOADED).touch()
+    if not settings.keep_staging:
+        shutil.rmtree(staging, ignore_errors=True)
+        # Drop the now-empty year and state directories too, up to the staging root.
+        parent = staging.parent
+        while (
+            parent != settings.staging_dir
+            and parent.exists()
+            and not any(parent.iterdir())
+        ):
+            parent.rmdir()
+            parent = parent.parent
 
 
-def process_item(args: tuple[ItemPlan, Settings]) -> dict:
-    """Do one item end to end; returns a progress record."""
-    plan, settings = args
-    dest = item_dir(settings.out_dir, plan)
-    started = time.time()
-    if settings.dry_run:
-        return {"item": plan.item, "sheets": len(plan.sheets), "dry_run": True}
-    if not (dest / DONE).exists():
-        rows: list[dict] = []
-        broken: list[str] = []
-        with ThreadPoolExecutor(max_workers=settings.streams) as pool:
-            for sheet, row in zip(
-                plan.sheets,
-                pool.map(lambda s: process_sheet(plan, s, settings), plan.sheets),
-            ):
-                if row is None:
-                    broken.append(sheet.stem)
-                else:
-                    rows.append(row)
-        write_metadata(dest, plan, rows, broken)
-        (dest / DONE).touch()
-    if settings.upload and settings.bucket and not (dest / UPLOADED).exists():
-        upload_item(dest, plan, settings.bucket)
-    return {
-        "item": plan.item,
-        "sheets": len(plan.sheets),
-        "seconds": round(time.time() - started, 1),
-        "uploaded": (dest / UPLOADED).exists(),
-    }
+# ---------------------------------------------------------------- orchestration
+
+
+def item_complete(plan: ItemPlan, settings: Settings) -> bool:
+    """Whether resume can skip the item outright, from local markers only."""
+    state = settings.out_dir / item_relative(plan)
+    if settings.upload:
+        return (state / UPLOADED).exists()
+    return (state / DONE).exists()
 
 
 def select_items(
@@ -410,6 +460,111 @@ def select_items(
     return chosen[: args.limit] if args.limit else chosen
 
 
+def run_pipeline(
+    items: list[ItemPlan],
+    settings: Settings,
+    *,
+    streams: int = 8,
+    decode_workers: int = 4,
+    prefetch_items: int = 6,
+    upload_workers: int = 2,
+    progress: bool = True,
+) -> dict[str, int]:
+    """Drive the three stages concurrently over ``items``; returns totals.
+
+    Downloads are submitted sheet by sheet for up to ``prefetch_items`` items
+    ahead of decoding, so small items do not starve the connections; an item
+    moves to decoding when all its sheets are on disk, and to upload when its
+    metadata is written. One tqdm bar counts decoded sheets (the download
+    stage paces it), with downloaded gigabytes, uploaded items, and broken
+    sheets in the postfix.
+    """
+    todo = deque(item for item in items if not item_complete(item, settings))
+    total_sheets = sum(len(item.sheets) for item in todo)
+    totals = {"items": 0, "sheets": 0, "broken": 0, "uploaded": 0, "bytes": 0}
+    bar = tqdm(
+        total=total_sheets,
+        unit="sheet",
+        smoothing=0,
+        disable=not progress,
+        dynamic_ncols=True,
+    )
+    downloads: dict[Future, tuple[ItemPlan, int]] = {}
+    item_fetch: dict[str, list[bool | None]] = {}
+    decodes: dict[Future, ItemPlan] = {}
+    uploads: dict[Future, ItemPlan] = {}
+    in_flight: set[str] = set()
+    settings.out_dir.mkdir(parents=True, exist_ok=True)
+
+    def start_decode(plan: ItemPlan) -> None:
+        fetched = [bool(ok) for ok in item_fetch.pop(plan.item)]
+        decodes[decode_pool.submit(decode_item, plan, fetched, settings)] = plan
+
+    with (
+        open(settings.out_dir / "progress.jsonl", "a") as progress_log,
+        ThreadPoolExecutor(max_workers=streams) as fetch_pool,
+        ProcessPoolExecutor(max_workers=decode_workers) as decode_pool,
+        ThreadPoolExecutor(max_workers=upload_workers) as upload_pool,
+    ):
+        while todo or downloads or decodes or uploads:
+            while todo and len(in_flight) < prefetch_items:
+                plan = todo.popleft()
+                in_flight.add(plan.item)
+                item_fetch[plan.item] = [None] * len(plan.sheets)
+                if not plan.sheets:
+                    start_decode(plan)
+                for index, sheet in enumerate(plan.sheets):
+                    downloads[fetch_pool.submit(fetch_sheet, plan, sheet, settings)] = (
+                        plan,
+                        index,
+                    )
+            done, _ = wait(
+                list(downloads) + list(decodes) + list(uploads),
+                timeout=1.0,
+                return_when=FIRST_COMPLETED,
+            )
+            for future in done:
+                if future in downloads:
+                    plan, index = downloads.pop(future)
+                    item_fetch[plan.item][index] = future.result()
+                    if future.result():
+                        totals["bytes"] += plan.sheets[index].bytes
+                    if all(ok is not None for ok in item_fetch[plan.item]):
+                        start_decode(plan)
+                elif future in decodes:
+                    plan = decodes.pop(future)
+                    decoded, broken = future.result()
+                    totals["items"] += 1
+                    totals["sheets"] += decoded
+                    totals["broken"] += broken
+                    bar.update(len(plan.sheets))
+                    if True:
+                        progress_log.write(
+                            json.dumps(
+                                {"item": plan.item, "sheets": decoded, "broken": broken}
+                            )
+                            + "\n"
+                        )
+                        progress_log.flush()
+                    if settings.upload and settings.bucket:
+                        uploads[upload_pool.submit(upload_item, plan, settings)] = plan
+                    else:
+                        in_flight.discard(plan.item)
+                else:
+                    plan = uploads.pop(future)
+                    future.result()
+                    totals["uploaded"] += 1
+                    in_flight.discard(plan.item)
+            bar.set_postfix(
+                dl=f"{totals['bytes'] / 1e9:.1f}GB",
+                up=totals["uploaded"],
+                broken=totals["broken"],
+                refresh=False,
+            )
+    bar.close()
+    return totals
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -423,13 +578,19 @@ def main() -> None:
         "--jp2-dir",
         type=Path,
         required=True,
-        help="Local mirror of the torrent's storage-services tree.",
+        help="Local mirror of the torrent's storage-services tree (kept).",
     )
     parser.add_argument(
         "--out-dir",
         type=Path,
         required=True,
-        help="Staging root; by-state/<state>/<year>/<item>/ goes under it.",
+        help="State root: per-item metadata.json + markers, broken.log, progress.jsonl.",
+    )
+    parser.add_argument(
+        "--staging-dir",
+        type=Path,
+        default=None,
+        help="Where decoded images wait for upload (default <out-dir>/staging).",
     )
     parser.add_argument(
         "--mirror", default=DEFAULT_MIRROR, help="HTTP root serving the torrent's tree."
@@ -442,18 +603,27 @@ def main() -> None:
     parser.add_argument(
         "--upload",
         action="store_true",
-        help="aws s3 sync each item after it completes.",
+        help="aws s3 sync each item after it is decoded, then drop its staging copy.",
     )
     parser.add_argument(
-        "--upload-only",
+        "--keep-staging",
         action="store_true",
-        help="Only sync items already marked done.",
+        help="Keep the staging copy after upload.",
     )
     parser.add_argument(
-        "--workers", type=int, default=4, help="Items processed at once."
+        "--streams",
+        type=int,
+        default=8,
+        help="Concurrent downloads (the mirror saturates near 8).",
     )
     parser.add_argument(
-        "--streams", type=int, default=2, help="Concurrent sheet downloads per item."
+        "--decode-workers", type=int, default=4, help="Decode processes."
+    )
+    parser.add_argument(
+        "--prefetch-items",
+        type=int,
+        default=6,
+        help="Items downloading ahead of decoding.",
     )
     parser.add_argument(
         "--states",
@@ -478,54 +648,43 @@ def main() -> None:
             "warning: opj_decompress not found; decoding with Pillow (several times slower)",
             file=sys.stderr,
         )
-    plans = load_mapping(args.mapping)
-    chosen = select_items(plans, args)
     settings = Settings(
         jp2_dir=args.jp2_dir,
         out_dir=args.out_dir,
+        staging_dir=args.staging_dir or args.out_dir / "staging",
         mirror=args.mirror,
         bucket=args.bucket,
-        streams=args.streams,
-        upload=args.upload or args.upload_only,
-        dry_run=args.dry_run,
+        upload=args.upload,
+        keep_staging=args.keep_staging,
     )
-    if args.upload_only:
-        chosen = [
-            plan for plan in chosen if (item_dir(args.out_dir, plan) / DONE).exists()
-        ]
-    total_sheets = sum(len(plan.sheets) for plan in chosen)
-    total_bytes = sum(sheet.bytes for plan in chosen for sheet in plan.sheets)
+    if settings.upload and not settings.bucket:
+        sys.exit("--upload needs --bucket")
+    chosen = select_items(load_mapping(args.mapping), args)
+    pending = [plan for plan in chosen if not item_complete(plan, settings)]
     print(
-        f"{len(chosen)} items, {total_sheets:,} sheets, {total_bytes / 1e9:,.1f} GB of JP2",
+        f"{len(chosen)} items selected, {len(pending)} to do: "
+        f"{sum(len(p.sheets) for p in pending):,} sheets, "
+        f"{sum(s.bytes for p in pending for s in p.sheets) / 1e9:,.1f} GB of JP2",
         file=sys.stderr,
     )
     if args.dry_run:
-        for plan in chosen[:20]:
-            print(
-                f"  {plan.item} {plan.state}/{plan.year} {len(plan.sheets)} sheets -> {item_dir(args.out_dir, plan)}"
-            )
+        for plan in pending[:20]:
+            print(f"  {plan.item} {plan.state}/{plan.year} {len(plan.sheets)} sheets")
         return
     args.out_dir.mkdir(parents=True, exist_ok=True)
-    done = 0
-    started = time.time()
-    with (
-        open(args.out_dir / "progress.jsonl", "a") as progress,
-        Pool(args.workers) as pool,
-    ):
-        for record in pool.imap_unordered(
-            process_item, [(plan, settings) for plan in chosen]
-        ):
-            progress.write(json.dumps(record) + "\n")
-            progress.flush()
-            done += 1
-            if done % 25 == 0 or done == len(chosen):
-                elapsed = time.time() - started
-                remaining = (len(chosen) - done) * elapsed / done / 3600
-                print(
-                    f"{done}/{len(chosen)} items, {elapsed / 3600:.1f} h elapsed, "
-                    f"{remaining:.1f} h remaining at this rate",
-                    file=sys.stderr,
-                )
+    settings.staging_dir.mkdir(parents=True, exist_ok=True)
+    totals = run_pipeline(
+        chosen,
+        settings,
+        streams=args.streams,
+        decode_workers=args.decode_workers,
+        prefetch_items=args.prefetch_items,
+    )
+    print(
+        f"done: {totals['items']} items, {totals['sheets']:,} sheets, {totals['broken']} broken, "
+        f"{totals['uploaded']} uploaded; broken sheets in {broken_log_path(args.out_dir)}",
+        file=sys.stderr,
+    )
 
 
 if __name__ == "__main__":

--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -288,6 +288,16 @@ def broken_log_path(out_dir: Path) -> Path:
     return out_dir / "broken.log"
 
 
+def log_error(out_dir: Path, stage: str, item: str, error: BaseException) -> None:
+    """Append a stage failure to errors.log; the item is left for the next resume."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "errors.log", "a") as handle:
+        handle.write(
+            f"{time.strftime('%Y-%m-%d %H:%M:%S')}\t{stage}\t{item}\t"
+            f"{error.__class__.__name__}: {str(error)[:300]}\n"
+        )
+
+
 def log_broken(out_dir: Path, plan: ItemPlan, sheet: Sheet, reason: str) -> None:
     """Append one tab-separated line: item, stem, source, reason."""
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -461,12 +471,11 @@ def decode_item(
         directory.mkdir(parents=True, exist_ok=True)
         (directory / "metadata.json").write_text(document)
     (settings.out_dir / item_relative(plan) / DONE).touch()
-    staged = sum(
-        path.stat().st_size
-        for path in (settings.staging_dir / item_relative(plan)).rglob("*")
-        if path.is_file()
+    return (
+        len(rows),
+        len(broken),
+        staged_size(settings.staging_dir / item_relative(plan)),
     )
-    return len(rows), len(broken), staged
 
 
 # ---------------------------------------------------------------- stage 3: upload
@@ -490,18 +499,38 @@ def upload_item(plan: ItemPlan, settings: Settings) -> None:
     (settings.out_dir / item_relative(plan) / UPLOADED).touch()
     if not settings.keep_staging:
         shutil.rmtree(staging, ignore_errors=True)
-        # Drop the now-empty year and state directories too, up to the staging root.
-        parent = staging.parent
-        while (
-            parent != settings.staging_dir
-            and parent.exists()
-            and not any(parent.iterdir())
-        ):
-            parent.rmdir()
-            parent = parent.parent
+        prune_empty_parents(staging.parent, settings.staging_dir)
+
+
+def prune_empty_parents(directory: Path, root: Path) -> None:
+    """Remove ``directory`` and its parents up to ``root`` while they are empty.
+
+    Other threads prune and create siblings concurrently (two uploads finishing
+    under one state directory; a decode writing a new year directory), so a
+    directory can vanish or fill between the check and the rmdir. Either way
+    the right response is to stop.
+    """
+    while directory != root:
+        try:
+            directory.rmdir()
+        except OSError:
+            return
+        directory = directory.parent
 
 
 # ---------------------------------------------------------------- orchestration
+
+
+def staged_size(directory: Path) -> int:
+    """Bytes of files under a staging item directory (0 if absent)."""
+    return sum(path.stat().st_size for path in directory.rglob("*") if path.is_file())
+
+
+def awaiting_upload(plan: ItemPlan, settings: Settings) -> bool:
+    """Decoded on a previous run with its staging copy intact: only the upload is left."""
+    state = settings.out_dir / item_relative(plan)
+    staging = settings.staging_dir / item_relative(plan)
+    return (state / DONE).exists() and (staging / "metadata.json").exists()
 
 
 def item_complete(plan: ItemPlan, settings: Settings) -> bool:
@@ -560,20 +589,60 @@ def run_pipeline(
     metadata is written. The upload stage is decoupled: downloads and decodes
     never wait for the uplink. New items are held back only while more than
     ``max_staging_bytes`` of decoded output is waiting to upload, so a slow
-    uplink costs staging disk rather than download throughput. One tqdm bar
-    counts decoded sheets, with downloaded gigabytes, uploaded items, the
-    staging backlog, and broken sheets in the postfix.
+    uplink costs staging disk rather than download throughput. A stage failure
+    is logged to errors.log and the item is left for the next resume; it never
+    ends the run. One tqdm bar counts decoded sheets, with downloaded
+    gigabytes, uploaded items, the staging backlog, broken sheets, and stage
+    errors in the postfix.
     """
     todo = deque(item for item in items if not item_complete(item, settings))
-    total_sheets = sum(len(item.sheets) for item in todo)
-    totals = {"items": 0, "sheets": 0, "broken": 0, "uploaded": 0, "bytes": 0}
+    totals = {
+        "items": 0,
+        "sheets": 0,
+        "broken": 0,
+        "uploaded": 0,
+        "bytes": 0,
+        "errors": 0,
+    }
     bar = tqdm(
-        total=total_sheets,
+        total=sum(len(item.sheets) for item in todo),
         unit="sheet",
         smoothing=0,
         disable=not progress,
         dynamic_ncols=True,
     )
+    # Closed on every exit path: a live bar's __del__ during interpreter
+    # teardown after an exception segfaults CPython 3.13 in tqdm's formatter.
+    try:
+        run_stages(
+            todo,
+            settings,
+            totals,
+            bar,
+            streams=streams,
+            decode_workers=decode_workers,
+            prefetch_items=prefetch_items,
+            upload_workers=upload_workers,
+            max_staging_bytes=max_staging_bytes,
+        )
+    finally:
+        bar.close()
+    return totals
+
+
+def run_stages(
+    todo: deque[ItemPlan],
+    settings: Settings,
+    totals: dict[str, int],
+    bar: tqdm,
+    *,
+    streams: int,
+    decode_workers: int,
+    prefetch_items: int,
+    upload_workers: int,
+    max_staging_bytes: float,
+) -> None:
+    """The coordinator loop behind run_pipeline; mutates ``totals`` and drives ``bar``."""
     downloads: dict[Future, tuple[ItemPlan, int]] = {}
     item_fetch: dict[str, list[bool | None]] = {}
     decodes: dict[Future, ItemPlan] = {}
@@ -581,17 +650,17 @@ def run_pipeline(
     item_staged: dict[str, int] = {}
     staged_bytes = 0
     settings.out_dir.mkdir(parents=True, exist_ok=True)
-
-    def start_decode(plan: ItemPlan) -> None:
-        fetched = [bool(ok) for ok in item_fetch.pop(plan.item)]
-        decodes[decode_pool.submit(decode_item, plan, fetched, settings)] = plan
-
     with (
         open(settings.out_dir / "progress.jsonl", "a") as progress_log,
         ThreadPoolExecutor(max_workers=streams) as fetch_pool,
         ProcessPoolExecutor(max_workers=decode_workers) as decode_pool,
         ThreadPoolExecutor(max_workers=upload_workers) as upload_pool,
     ):
+
+        def start_decode(plan: ItemPlan) -> None:
+            fetched = [bool(ok) for ok in item_fetch.pop(plan.item)]
+            decodes[decode_pool.submit(decode_item, plan, fetched, settings)] = plan
+
         while todo or downloads or decodes or uploads:
             while (
                 todo
@@ -599,14 +668,22 @@ def run_pipeline(
                 and staged_bytes < max_staging_bytes
             ):
                 plan = todo.popleft()
+                if (
+                    settings.upload
+                    and settings.bucket
+                    and awaiting_upload(plan, settings)
+                ):
+                    staged = staged_size(settings.staging_dir / item_relative(plan))
+                    item_staged[plan.item] = staged
+                    staged_bytes += staged
+                    uploads[upload_pool.submit(upload_item, plan, settings)] = plan
+                    continue
                 item_fetch[plan.item] = [None] * len(plan.sheets)
                 if not plan.sheets:
                     start_decode(plan)
                 for index, sheet in enumerate(plan.sheets):
-                    downloads[fetch_pool.submit(fetch_sheet, plan, sheet, settings)] = (
-                        plan,
-                        index,
-                    )
+                    future = fetch_pool.submit(fetch_sheet, plan, sheet, settings)
+                    downloads[future] = (plan, index)
             done, _ = wait(
                 list(downloads) + list(decodes) + list(uploads),
                 timeout=1.0,
@@ -615,14 +692,28 @@ def run_pipeline(
             for future in done:
                 if future in downloads:
                     plan, index = downloads.pop(future)
-                    item_fetch[plan.item][index] = future.result()
-                    if future.result():
+                    try:
+                        fetched = bool(future.result())
+                    except Exception as error:  # noqa: BLE001 -- logged; the sheet counts as broken
+                        log_error(
+                            settings.out_dir, "download", plan.sheets[index].stem, error
+                        )
+                        totals["errors"] += 1
+                        fetched = False
+                    item_fetch[plan.item][index] = fetched
+                    if fetched:
                         totals["bytes"] += plan.sheets[index].bytes
                     if all(ok is not None for ok in item_fetch[plan.item]):
                         start_decode(plan)
                 elif future in decodes:
                     plan = decodes.pop(future)
-                    decoded, broken, staged = future.result()
+                    try:
+                        decoded, broken, staged = future.result()
+                    except Exception as error:  # noqa: BLE001 -- logged; retried on resume
+                        log_error(settings.out_dir, "decode", plan.item, error)
+                        totals["errors"] += 1
+                        bar.update(len(plan.sheets))
+                        continue
                     totals["items"] += 1
                     totals["sheets"] += decoded
                     totals["broken"] += broken
@@ -640,18 +731,22 @@ def run_pipeline(
                         uploads[upload_pool.submit(upload_item, plan, settings)] = plan
                 else:
                     plan = uploads.pop(future)
-                    future.result()
-                    totals["uploaded"] += 1
                     staged_bytes -= item_staged.pop(plan.item, 0)
+                    try:
+                        future.result()
+                    except Exception as error:  # noqa: BLE001 -- staging kept; re-synced on resume
+                        log_error(settings.out_dir, "upload", plan.item, error)
+                        totals["errors"] += 1
+                        continue
+                    totals["uploaded"] += 1
             bar.set_postfix(
                 dl=f"{totals['bytes'] / 1e9:.1f}GB",
                 up=totals["uploaded"],
                 staged=f"{staged_bytes / 1e9:.1f}GB",
                 broken=totals["broken"],
+                errors=totals["errors"],
                 refresh=False,
             )
-    bar.close()
-    return totals
 
 
 def main() -> None:

--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -37,6 +37,7 @@ note) are skipped: nothing in the pipeline reads them. A sheet that fails to
 download or decode after retries is logged as broken and left out of its item.
 
     mapsnap loc-mirror ~/Downloads/loc-sanborn-maps.mapping.tsv \\
+        --mirror http://<host>:<port> \\
         --jp2-dir /Volumes/fivetera/loc-sanborn-maps/jp2 \\
         --out-dir /Volumes/fivetera/mapsnap-sanborn \\
         --staging-dir /Volumes/fivetera/mapsnap-sanborn/staging \\
@@ -75,7 +76,6 @@ from tqdm import tqdm
 from mapsnap.keymap.fit_keymap import page_number
 from mapsnap.keymap.identify import is_letter_page
 
-DEFAULT_MIRROR = "http://50.35.157.188:27182"
 LOC_IIIF = "https://tile.loc.gov/image-services/iiif"
 JPEG_QUALITY = 95  # what mapsnap scale writes; the pipeline is tuned on it
 QUARTER_REDUCE = 2  # JPEG 2000 resolution levels to drop: 1/4 linear = 25%
@@ -122,7 +122,7 @@ class Settings:
     jp2_dir: Path
     out_dir: Path
     staging_dir: Path
-    mirror: str = DEFAULT_MIRROR
+    mirror: str  # HTTP root serving the torrent's storage-services tree
     bucket: str | None = None
     upload: bool = False
     keep_staging: bool = False
@@ -804,7 +804,12 @@ def main() -> None:
         help="Where decoded images wait for upload (default <out-dir>/staging).",
     )
     parser.add_argument(
-        "--mirror", default=DEFAULT_MIRROR, help="HTTP root serving the torrent's tree."
+        "--mirror",
+        required=True,
+        metavar="URL",
+        help="HTTP root serving the torrent's storage-services tree, e.g. "
+        "http://host:port (no default: the mirror is somebody's machine, not "
+        "a property of this program).",
     )
     parser.add_argument(
         "--bucket",

--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -30,7 +30,9 @@ reason) and ``progress.jsonl``. Resuming never lists S3: an item with its
 marker is skipped, a JP2 on disk at the listed size is not re-fetched, and an
 output already in staging is not re-decoded.
 
-Sheets whose page key does not start with a digit (covr, ind1, cbd, titl,
+Items are processed in a seeded random order, so however far the run has
+got, the finished subset is a uniform sample of the collection
+(``--sequential`` for state, year, item order). Sheets whose page key does not start with a digit (covr, ind1, cbd, titl,
 note) are skipped: nothing in the pipeline reads them. A sheet that fails to
 download or decode after retries is logged as broken and left out of its item.
 
@@ -44,6 +46,7 @@ download or decode after retries is logged as broken and left out of its item.
 import argparse
 import csv
 import json
+import random
 import re
 import shutil
 import subprocess
@@ -445,19 +448,32 @@ def item_complete(plan: ItemPlan, settings: Settings) -> bool:
 
 
 def select_items(
-    plans: dict[str, ItemPlan], args: argparse.Namespace
+    plans: dict[str, ItemPlan],
+    *,
+    states: str | None = None,
+    items: str | None = None,
+    limit: int = 0,
+    seed: int | None = 0,
 ) -> list[ItemPlan]:
-    """The items to run, filtered by --states / --items, in a stable order."""
-    states = set(args.states.split(",")) if args.states else None
-    wanted = set(args.items.split(",")) if args.items else None
+    """The items to run, filtered by state folders and ids.
+
+    The order is a random permutation seeded by ``seed`` (so a restart walks the
+    same sequence, and any prefix of the run is a uniform sample of the
+    collection, which the state-by-state order would not be); ``seed=None``
+    keeps the state, year, item order. ``limit`` truncates after ordering.
+    """
+    wanted_states = set(states.split(",")) if states else None
+    wanted_items = set(items.split(",")) if items else None
     chosen = [
         plan
         for plan in plans.values()
-        if (states is None or plan.state in states)
-        and (wanted is None or plan.item in wanted)
+        if (wanted_states is None or plan.state in wanted_states)
+        and (wanted_items is None or plan.item in wanted_items)
     ]
     chosen.sort(key=lambda plan: (plan.state, plan.year, plan.item))
-    return chosen[: args.limit] if args.limit else chosen
+    if seed is not None:
+        random.Random(seed).shuffle(chosen)
+    return chosen[:limit] if limit else chosen
 
 
 def run_pipeline(
@@ -637,6 +653,18 @@ def main() -> None:
         "--limit", type=int, default=0, help="Stop after this many items (0 = all)."
     )
     parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Seed of the random item order (the default order), so a restart "
+        "walks the same sequence and any prefix is a uniform sample.",
+    )
+    parser.add_argument(
+        "--sequential",
+        action="store_true",
+        help="Process items in state, year, item order instead of at random.",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="List the items and sheet counts; touch nothing.",
@@ -659,7 +687,13 @@ def main() -> None:
     )
     if settings.upload and not settings.bucket:
         sys.exit("--upload needs --bucket")
-    chosen = select_items(load_mapping(args.mapping), args)
+    chosen = select_items(
+        load_mapping(args.mapping),
+        states=args.states,
+        items=args.items,
+        limit=args.limit,
+        seed=None if args.sequential else args.seed,
+    )
     pending = [plan for plan in chosen if not item_complete(plan, settings)]
     print(
         f"{len(chosen)} items selected, {len(pending)} to do: "

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -1,6 +1,7 @@
 """Tests for the LoC JP2 mirror builder: rules, layout, decode, the pipeline, resume, upload."""
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -347,6 +348,24 @@ def test_fetch_reuses_one_keep_alive_connection_per_thread(
             fetch(f"{base}/a.bin", tmp_path / "a2.bin", expected_bytes=999)
     finally:
         server.shutdown()
+
+
+def test_mirror_url_must_be_given(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """--mirror has no default: the mirror is somebody's machine, not a constant."""
+    mapping = tmp_path / "map.tsv"
+    mapping.write_text(HEADER)
+    argv = [
+        "mapsnap-loc-mirror",
+        str(mapping),
+        "--jp2-dir",
+        str(tmp_path / "jp2"),
+        "--out-dir",
+        str(tmp_path / "state"),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit) as excinfo:
+        loc_mirror.main()
+    assert excinfo.value.code == 2  # argparse usage error
 
 
 def test_prune_stops_at_the_root_and_survives_races(tmp_path: Path):

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -218,6 +218,7 @@ def test_pipeline_decodes_logs_broken_and_resumes(tmp_path: Path):
         "uploaded": 0,
         "bytes": pytest.approx(totals["bytes"]),
         "errors": 0,
+        "retries": 0,
     }
     staged = settings.staging_dir / item_relative(items[0])
     assert Image.open(staged / "p0.jpg").size == (50, 40)
@@ -364,28 +365,57 @@ def test_prune_stops_at_the_root_and_survives_races(tmp_path: Path):
 
 
 @needs_jp2
-def test_upload_failure_is_logged_and_the_item_waits_for_resume(
+def test_failed_uploads_are_retried_in_the_run(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
+    # aws fails twice per item (an expired session), then works: the running
+    # process retries with backoff, keeps the staging copy meanwhile, and
+    # never needs a restart. Every failure is still logged.
     items, settings, _ = make_volume(tmp_path)
     settings.bucket, settings.upload = "s3://bucket", True
+    monkeypatch.setattr(loc_mirror, "UPLOAD_RETRY_DELAY", 0.05)
+    calls: dict[str, int] = {}
 
-    def failing_run(cmd, check):
+    def flaky_run(cmd, check):
+        calls[cmd[4]] = calls.get(cmd[4], 0) + 1
+        if calls[cmd[4]] <= 2:
+            raise RuntimeError("Your session has expired")
+
+    monkeypatch.setattr(loc_mirror.subprocess, "run", flaky_run)
+    totals = run_pipeline(items, settings, streams=2, decode_workers=1, progress=False)
+    assert totals["uploaded"] == 2 and totals["errors"] == 4 and totals["retries"] == 4
+    assert all(n == 3 for n in calls.values())
+    state = settings.out_dir / item_relative(items[0])
+    assert (state / DONE).exists() and (state / UPLOADED).exists()
+    assert not (settings.staging_dir / item_relative(items[0])).exists()
+    assert (settings.out_dir / "errors.log").read_text().count("\tupload\t") == 4
+
+
+@needs_jp2
+def test_upload_failure_survives_a_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # If the run ends while uploads are still failing, the item is done but
+    # not uploaded, its staging copy is kept, and the next run goes straight
+    # to the upload stage without re-decoding.
+    items, settings, _ = make_volume(tmp_path)
+    settings.bucket, settings.upload = "s3://bucket", True
+    monkeypatch.setattr(loc_mirror, "UPLOAD_RETRY_DELAY", 0.05)
+    monkeypatch.setattr(loc_mirror, "UPLOAD_RETRY_MAX", 0.05)
+    attempts = {"n": 0}
+
+    def failing_then_stop(cmd, check):
+        attempts["n"] += 1
+        if attempts["n"] > 6:
+            raise KeyboardInterrupt  # the operator gives up on this run
         raise RuntimeError("aws exploded")
 
-    monkeypatch.setattr(loc_mirror.subprocess, "run", failing_run)
-    totals = run_pipeline(items, settings, streams=2, decode_workers=1, progress=False)
-    assert totals["items"] == 2 and totals["uploaded"] == 0 and totals["errors"] == 2
+    monkeypatch.setattr(loc_mirror.subprocess, "run", failing_then_stop)
+    with pytest.raises(KeyboardInterrupt):
+        run_pipeline(items, settings, streams=2, decode_workers=1, progress=False)
     state = settings.out_dir / item_relative(items[0])
     assert (state / DONE).exists() and not (state / UPLOADED).exists()
-    assert (
-        settings.staging_dir / item_relative(items[0]) / "p0.jpg"
-    ).exists()  # kept for the retry
-    assert (
-        "upload\tsanborn00081_001\tRuntimeError"
-        in (settings.out_dir / "errors.log").read_text()
-    )
-    # Resume with a working aws: only the upload runs, from the retained staging copy.
+    assert (settings.staging_dir / item_relative(items[0]) / "p0.jpg").exists()
     synced: list[str] = []
     monkeypatch.setattr(
         loc_mirror.subprocess, "run", lambda cmd, check: synced.append(cmd[4])

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -322,7 +322,7 @@ def test_fetch_reuses_one_keep_alive_connection_per_thread(
         def __init__(self, *args, **kwargs):
             super().__init__(*args, directory=str(root), **kwargs)
 
-        def log_message(self, *args):
+        def log_message(self, format: str, *args) -> None:
             pass
 
     server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -22,6 +22,7 @@ from mapsnap.loc_mirror import (
     load_mapping,
     run_pipeline,
     s3_prefix,
+    select_items,
     sheet_outputs,
     source_url,
 )
@@ -279,3 +280,24 @@ def test_pipeline_uploads_then_drops_staging(
         ]
         == 0
     )
+
+
+def test_select_items_random_order_is_seeded_and_optional():
+    plans = {
+        f"sanborn{i:05d}_001": ItemPlan(
+            f"sanborn{i:05d}_001", "alabama" if i % 2 else "ohio", "1900", ""
+        )
+        for i in range(40)
+    }
+    first = [p.item for p in select_items(plans, seed=0)]
+    assert first == [
+        p.item for p in select_items(plans, seed=0)
+    ]  # a restart replays it
+    assert first != [p.item for p in select_items(plans, seed=1)]
+    assert sorted(first) == sorted(plans)
+    ordered = [(p.state, p.item) for p in select_items(plans, seed=None)]
+    assert ordered == sorted(ordered)
+    assert [p.state for p in select_items(plans, states="ohio", seed=0)] == [
+        "ohio"
+    ] * 20
+    assert [p.item for p in select_items(plans, limit=5, seed=0)] == first[:5]

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -1,0 +1,193 @@
+"""Tests for the LoC JP2 mirror builder: planning, layout, decode, resume, broken sheets."""
+
+from pathlib import Path
+
+import pytest
+from PIL import Image, features
+
+from mapsnap.loc_mirror import (
+    DONE,
+    ItemPlan,
+    Settings,
+    Sheet,
+    broken_log_path,
+    decode_jp2,
+    is_candidate,
+    item_dir,
+    jp2_path,
+    keep_sheet,
+    load_mapping,
+    process_item,
+    s3_prefix,
+    sheet_outputs,
+    source_url,
+)
+
+HEADER = "item\tstate\tyear\tcity\tseq\tstem\tpage_key\tsource\tbytes\tstorage_dir\n"
+
+
+def test_keep_and_candidate_rules():
+    assert keep_sheet("p101s") and keep_sheet("p0") and keep_sheet("pa")
+    assert (
+        not keep_sheet("pcovr") and not keep_sheet("pind1") and not keep_sheet("ptitl")
+    )
+    assert (
+        is_candidate("p0")
+        and is_candidate("p0b")
+        and is_candidate("p1")
+        and is_candidate("pa")
+    )
+    assert is_candidate("p1a") and is_candidate("p0L")
+    assert (
+        not is_candidate("p2") and not is_candidate("p101s") and not is_candidate("p10")
+    )
+
+
+def test_load_mapping_keeps_numbered_and_letter_sheets(tmp_path: Path):
+    tsv = tmp_path / "map.tsv"
+    tsv.write_text(
+        HEADER
+        + "sanborn00081_001\talabama\t1922\tmobile\t1\t00081_1922-0000\tp0\ttorrent-jp2\t100\tgmd/x/g1\n"
+        + "sanborn00081_001\talabama\t1922\tmobile\t2\t00081_1922-covr\tpcovr\ttorrent-jp2\t50\tgmd/x/g1\n"
+        + "sanborn00081_001\talabama\t1922\tmobile\t3\t00081_1922-0001s\tp1s\ttorrent-jp2\t70\tgmd/x/g1\n"
+        + "sanborn00081_001\talabama\t1922\tmobile\t4\t\tp\tghost\t0\t\n"
+    )
+    plans = load_mapping(tsv)
+    plan = plans["sanborn00081_001"]
+    assert [s.key for s in plan.sheets] == ["p0", "p1s"]
+    assert plan.state == "alabama" and plan.year == "1922"
+
+
+def test_layout_matches_the_s3_prefix_shape(tmp_path: Path):
+    plan = ItemPlan("sanborn00081_001", "alabama", "1922", "mobile")
+    sheet = Sheet(
+        1,
+        "00081_1922-0123",
+        "p123",
+        "torrent-jp2",
+        10,
+        "gmd/gmd390m/g3904m/g3904mm/g000811922",
+    )
+    assert (
+        item_dir(tmp_path, plan) == tmp_path / "by-state/alabama/1922/sanborn00081_001"
+    )
+    assert (
+        s3_prefix("s3://mapsnap-sanborn", plan)
+        == "s3://mapsnap-sanborn/by-state/alabama/1922/sanborn00081_001"
+    )
+    assert (
+        jp2_path(tmp_path, sheet)
+        == tmp_path
+        / "storage-services/service"
+        / sheet.storage_dir
+        / "00081_1922-0123.jp2"
+    )
+    assert (
+        source_url("http://m", sheet)
+        == "http://m/storage-services/service/gmd/gmd390m/g3904m/g3904mm/g000811922/00081_1922-0123.jp2"
+    )
+    iiif = Sheet(
+        1,
+        "00081_1922-0124",
+        "p124",
+        "loc-iiif",
+        0,
+        "gmd/gmd390m/g3904m/g3904mm/g000811922",
+    )
+    assert source_url("http://m", iiif).endswith(
+        ":00081_1922-0124/full/pct:25/0/default.jpg"
+    )
+    assert source_url("http://m", iiif, full=True).endswith("/full/full/0/default.jpg")
+    quarter, raw = sheet_outputs(
+        item_dir(tmp_path, plan), Sheet(1, "x-0000", "p0", "torrent-jp2", 1, "d")
+    )
+    assert quarter.name == "p0.jpg" and raw is not None and raw.parent.name == "raw"
+    assert sheet_outputs(item_dir(tmp_path, plan), sheet)[1] is None
+
+
+def write_jp2(path: Path, width: int = 200, height: int = 160) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    image = Image.new("RGB", (width, height), (240, 230, 200))
+    for x in range(0, width, 20):
+        for y in range(height):
+            image.putpixel((x, y), (30, 30, 30))
+    image.save(
+        path, "JPEG2000", quality_mode="rates", quality_layers=[10], num_resolutions=4
+    )
+
+
+@pytest.mark.skipif(not features.check("jpg_2000"), reason="Pillow lacks JPEG 2000")
+def test_decode_jp2_quarter_and_full(tmp_path: Path):
+    jp2 = tmp_path / "s.jp2"
+    write_jp2(jp2)
+    assert decode_jp2(jp2, tmp_path / "q.jpg", 2) == (50, 40)
+    assert decode_jp2(jp2, tmp_path / "f.jpg", 0) == (200, 160)
+    assert Image.open(tmp_path / "q.jpg").size == (50, 40)
+
+
+@pytest.mark.skipif(not features.check("jpg_2000"), reason="Pillow lacks JPEG 2000")
+def test_process_item_is_resumable_and_logs_broken_sheets(tmp_path: Path):
+    # A file:// "mirror" holding one good JP2 and one corrupt one.
+    mirror = tmp_path / "mirror"
+    good = mirror / "storage-services/service/gmd/x/g1/00081_1922-0000.jp2"
+    bad = mirror / "storage-services/service/gmd/x/g1/00081_1922-0001.jp2"
+    write_jp2(good)
+    bad.write_bytes(b"not a jp2")
+    plan = ItemPlan(
+        "sanborn00081_001",
+        "alabama",
+        "1922",
+        "mobile",
+        [
+            Sheet(
+                1,
+                "00081_1922-0000",
+                "p0",
+                "torrent-jp2",
+                good.stat().st_size,
+                "gmd/x/g1",
+            ),
+            Sheet(
+                2,
+                "00081_1922-0001",
+                "p1",
+                "torrent-jp2",
+                bad.stat().st_size,
+                "gmd/x/g1",
+            ),
+        ],
+    )
+    settings = Settings(
+        jp2_dir=tmp_path / "jp2",
+        out_dir=tmp_path / "out",
+        mirror=mirror.as_uri(),
+        streams=2,
+    )
+    record = process_item((plan, settings))
+    dest = item_dir(settings.out_dir, plan)
+    assert record["sheets"] == 2 and (dest / DONE).exists()
+    assert (dest / "p0.jpg").exists() and (dest / "raw" / "p0.jpg").exists()
+    assert Image.open(dest / "p0.jpg").size == (50, 40)
+    assert not (dest / "p1.jpg").exists()
+    assert (
+        settings.jp2_dir / "storage-services/service/gmd/x/g1/00081_1922-0000.jp2"
+    ).exists()
+    log = broken_log_path(settings.out_dir).read_text()
+    assert log.startswith("sanborn00081_001\t00081_1922-0001\ttorrent-jp2\t")
+    import json
+
+    meta = json.loads((dest / "metadata.json").read_text())
+    assert [s["key"] for s in meta["sheets"]] == ["p0"] and meta["broken"] == [
+        "00081_1922-0001"
+    ]
+    assert meta["sheets"][0]["width"] == 50 and meta["sheets"][0]["raw"] is True
+    # Second run: nothing re-fetched or re-decoded (the mirror can even be gone).
+    (dest / "p0.jpg").write_bytes(b"sentinel")
+    settings_offline = Settings(
+        jp2_dir=settings.jp2_dir,
+        out_dir=settings.out_dir,
+        mirror="http://127.0.0.1:9",
+        streams=1,
+    )
+    process_item((plan, settings_offline))
+    assert (dest / "p0.jpg").read_bytes() == b"sentinel"

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -1,29 +1,33 @@
-"""Tests for the LoC JP2 mirror builder: planning, layout, decode, resume, broken sheets."""
+"""Tests for the LoC JP2 mirror builder: rules, layout, decode, the pipeline, resume, upload."""
 
+import json
 from pathlib import Path
 
 import pytest
 from PIL import Image, features
 
+from mapsnap import loc_mirror
 from mapsnap.loc_mirror import (
     DONE,
+    UPLOADED,
     ItemPlan,
     Settings,
     Sheet,
     broken_log_path,
     decode_jp2,
     is_candidate,
-    item_dir,
+    item_relative,
     jp2_path,
     keep_sheet,
     load_mapping,
-    process_item,
+    run_pipeline,
     s3_prefix,
     sheet_outputs,
     source_url,
 )
 
 HEADER = "item\tstate\tyear\tcity\tseq\tstem\tpage_key\tsource\tbytes\tstorage_dir\n"
+DIR = "gmd/x/g1"
 
 
 def test_keep_and_candidate_rules():
@@ -31,15 +35,15 @@ def test_keep_and_candidate_rules():
     assert (
         not keep_sheet("pcovr") and not keep_sheet("pind1") and not keep_sheet("ptitl")
     )
+    # Raw copies: the page-0 family and letter pages only; page 1 is not a candidate here.
     assert (
         is_candidate("p0")
         and is_candidate("p0b")
-        and is_candidate("p1")
+        and is_candidate("p0L")
         and is_candidate("pa")
     )
-    assert is_candidate("p1a") and is_candidate("p0L")
     assert (
-        not is_candidate("p2") and not is_candidate("p101s") and not is_candidate("p10")
+        not is_candidate("p1") and not is_candidate("p1a") and not is_candidate("p101s")
     )
 
 
@@ -47,15 +51,14 @@ def test_load_mapping_keeps_numbered_and_letter_sheets(tmp_path: Path):
     tsv = tmp_path / "map.tsv"
     tsv.write_text(
         HEADER
-        + "sanborn00081_001\talabama\t1922\tmobile\t1\t00081_1922-0000\tp0\ttorrent-jp2\t100\tgmd/x/g1\n"
-        + "sanborn00081_001\talabama\t1922\tmobile\t2\t00081_1922-covr\tpcovr\ttorrent-jp2\t50\tgmd/x/g1\n"
-        + "sanborn00081_001\talabama\t1922\tmobile\t3\t00081_1922-0001s\tp1s\ttorrent-jp2\t70\tgmd/x/g1\n"
+        + f"sanborn00081_001\talabama\t1922\tmobile\t1\t00081_1922-0000\tp0\ttorrent-jp2\t100\t{DIR}\n"
+        + f"sanborn00081_001\talabama\t1922\tmobile\t2\t00081_1922-covr\tpcovr\ttorrent-jp2\t50\t{DIR}\n"
+        + f"sanborn00081_001\talabama\t1922\tmobile\t3\t00081_1922-0001s\tp1s\ttorrent-jp2\t70\t{DIR}\n"
         + "sanborn00081_001\talabama\t1922\tmobile\t4\t\tp\tghost\t0\t\n"
     )
-    plans = load_mapping(tsv)
-    plan = plans["sanborn00081_001"]
+    plan = load_mapping(tsv)["sanborn00081_001"]
     assert [s.key for s in plan.sheets] == ["p0", "p1s"]
-    assert plan.state == "alabama" and plan.year == "1922"
+    assert (plan.state, plan.year, plan.city) == ("alabama", "1922", "mobile")
 
 
 def test_layout_matches_the_s3_prefix_shape(tmp_path: Path):
@@ -68,9 +71,7 @@ def test_layout_matches_the_s3_prefix_shape(tmp_path: Path):
         10,
         "gmd/gmd390m/g3904m/g3904mm/g000811922",
     )
-    assert (
-        item_dir(tmp_path, plan) == tmp_path / "by-state/alabama/1922/sanborn00081_001"
-    )
+    assert item_relative(plan) == Path("by-state/alabama/1922/sanborn00081_001")
     assert (
         s3_prefix("s3://mapsnap-sanborn", plan)
         == "s3://mapsnap-sanborn/by-state/alabama/1922/sanborn00081_001"
@@ -86,23 +87,26 @@ def test_layout_matches_the_s3_prefix_shape(tmp_path: Path):
         source_url("http://m", sheet)
         == "http://m/storage-services/service/gmd/gmd390m/g3904m/g3904mm/g000811922/00081_1922-0123.jp2"
     )
-    iiif = Sheet(
-        1,
-        "00081_1922-0124",
-        "p124",
-        "loc-iiif",
-        0,
-        "gmd/gmd390m/g3904m/g3904mm/g000811922",
+    tif = Sheet(
+        1, "00081_1922-0124", "p124", "torrent-master-tif", 0, sheet.storage_dir
     )
+    assert (
+        jp2_path(tmp_path, tif)
+        .as_posix()
+        .endswith(
+            "storage-services/master/" + sheet.storage_dir + "/00081_1922-0124.tif"
+        )
+    )
+    iiif = Sheet(1, "00081_1922-0125", "p125", "loc-iiif", 0, sheet.storage_dir)
     assert source_url("http://m", iiif).endswith(
-        ":00081_1922-0124/full/pct:25/0/default.jpg"
+        ":00081_1922-0125/full/pct:25/0/default.jpg"
     )
     assert source_url("http://m", iiif, full=True).endswith("/full/full/0/default.jpg")
     quarter, raw = sheet_outputs(
-        item_dir(tmp_path, plan), Sheet(1, "x-0000", "p0", "torrent-jp2", 1, "d")
+        tmp_path, Sheet(1, "x-0000", "p0", "torrent-jp2", 1, "d")
     )
     assert quarter.name == "p0.jpg" and raw is not None and raw.parent.name == "raw"
-    assert sheet_outputs(item_dir(tmp_path, plan), sheet)[1] is None
+    assert sheet_outputs(tmp_path, sheet)[1] is None
 
 
 def write_jp2(path: Path, width: int = 200, height: int = 160) -> None:
@@ -116,7 +120,12 @@ def write_jp2(path: Path, width: int = 200, height: int = 160) -> None:
     )
 
 
-@pytest.mark.skipif(not features.check("jpg_2000"), reason="Pillow lacks JPEG 2000")
+needs_jp2 = pytest.mark.skipif(
+    not features.check("jpg_2000"), reason="Pillow lacks JPEG 2000"
+)
+
+
+@needs_jp2
 def test_decode_jp2_quarter_and_full(tmp_path: Path):
     jp2 = tmp_path / "s.jp2"
     write_jp2(jp2)
@@ -125,69 +134,148 @@ def test_decode_jp2_quarter_and_full(tmp_path: Path):
     assert Image.open(tmp_path / "q.jpg").size == (50, 40)
 
 
-@pytest.mark.skipif(not features.check("jpg_2000"), reason="Pillow lacks JPEG 2000")
-def test_process_item_is_resumable_and_logs_broken_sheets(tmp_path: Path):
-    # A file:// "mirror" holding one good JP2 and one corrupt one.
+def make_volume(tmp_path: Path) -> tuple[list[ItemPlan], Settings, Path]:
+    """A file:// mirror with two items: one good sheet, one page-0 sheet, one corrupt sheet."""
     mirror = tmp_path / "mirror"
-    good = mirror / "storage-services/service/gmd/x/g1/00081_1922-0000.jp2"
-    bad = mirror / "storage-services/service/gmd/x/g1/00081_1922-0001.jp2"
-    write_jp2(good)
-    bad.write_bytes(b"not a jp2")
-    plan = ItemPlan(
-        "sanborn00081_001",
-        "alabama",
-        "1922",
-        "mobile",
-        [
-            Sheet(
-                1,
-                "00081_1922-0000",
-                "p0",
-                "torrent-jp2",
-                good.stat().st_size,
-                "gmd/x/g1",
-            ),
-            Sheet(
-                2,
-                "00081_1922-0001",
-                "p1",
-                "torrent-jp2",
-                bad.stat().st_size,
-                "gmd/x/g1",
-            ),
-        ],
+    files = {
+        "00081_1922-0000": True,
+        "00081_1922-0001": False,  # corrupt
+        "00082_1922-0005": True,
+    }
+    for stem, good in files.items():
+        path = mirror / "storage-services/service" / DIR / f"{stem}.jp2"
+        if good:
+            write_jp2(path)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"not a jp2")
+    size = lambda stem: (
+        (mirror / "storage-services/service" / DIR / f"{stem}.jp2").stat().st_size
     )
+    items = [
+        ItemPlan(
+            "sanborn00081_001",
+            "alabama",
+            "1922",
+            "mobile",
+            [
+                Sheet(
+                    1,
+                    "00081_1922-0000",
+                    "p0",
+                    "torrent-jp2",
+                    size("00081_1922-0000"),
+                    DIR,
+                ),
+                Sheet(
+                    2,
+                    "00081_1922-0001",
+                    "p1",
+                    "torrent-jp2",
+                    size("00081_1922-0001"),
+                    DIR,
+                ),
+            ],
+        ),
+        ItemPlan(
+            "sanborn00082_001",
+            "alabama",
+            "1922",
+            "selma",
+            [
+                Sheet(
+                    1,
+                    "00082_1922-0005",
+                    "p5",
+                    "torrent-jp2",
+                    size("00082_1922-0005"),
+                    DIR,
+                )
+            ],
+        ),
+    ]
     settings = Settings(
         jp2_dir=tmp_path / "jp2",
-        out_dir=tmp_path / "out",
+        out_dir=tmp_path / "state",
+        staging_dir=tmp_path / "staging",
         mirror=mirror.as_uri(),
-        streams=2,
     )
-    record = process_item((plan, settings))
-    dest = item_dir(settings.out_dir, plan)
-    assert record["sheets"] == 2 and (dest / DONE).exists()
-    assert (dest / "p0.jpg").exists() and (dest / "raw" / "p0.jpg").exists()
-    assert Image.open(dest / "p0.jpg").size == (50, 40)
-    assert not (dest / "p1.jpg").exists()
-    assert (
-        settings.jp2_dir / "storage-services/service/gmd/x/g1/00081_1922-0000.jp2"
-    ).exists()
-    log = broken_log_path(settings.out_dir).read_text()
-    assert log.startswith("sanborn00081_001\t00081_1922-0001\ttorrent-jp2\t")
-    import json
+    return items, settings, mirror
 
-    meta = json.loads((dest / "metadata.json").read_text())
+
+@needs_jp2
+def test_pipeline_decodes_logs_broken_and_resumes(tmp_path: Path):
+    items, settings, _ = make_volume(tmp_path)
+    totals = run_pipeline(items, settings, streams=2, decode_workers=1, progress=False)
+    assert totals == {
+        "items": 2,
+        "sheets": 2,
+        "broken": 1,
+        "uploaded": 0,
+        "bytes": pytest.approx(totals["bytes"]),
+    }
+    staged = settings.staging_dir / item_relative(items[0])
+    assert Image.open(staged / "p0.jpg").size == (50, 40)
+    assert Image.open(staged / "raw" / "p0.jpg").size == (200, 160)
+    assert not (staged / "p1.jpg").exists()
+    state = settings.out_dir / item_relative(items[0])
+    assert (state / DONE).exists() and not (state / UPLOADED).exists()
+    meta = json.loads((state / "metadata.json").read_text())
     assert [s["key"] for s in meta["sheets"]] == ["p0"] and meta["broken"] == [
         "00081_1922-0001"
     ]
     assert meta["sheets"][0]["width"] == 50 and meta["sheets"][0]["raw"] is True
-    # Second run: nothing re-fetched or re-decoded (the mirror can even be gone).
-    (dest / "p0.jpg").write_bytes(b"sentinel")
-    settings_offline = Settings(
+    assert (staged / "metadata.json").read_text() == (
+        state / "metadata.json"
+    ).read_text()
+    assert (
+        broken_log_path(settings.out_dir)
+        .read_text()
+        .startswith("sanborn00081_001\t00081_1922-0001\ttorrent-jp2\t")
+    )
+    assert (
+        settings.jp2_dir / "storage-services/service" / DIR / "00081_1922-0000.jp2"
+    ).exists()
+    # Resume with the mirror gone: both items are complete from local markers alone.
+    offline = Settings(
         jp2_dir=settings.jp2_dir,
         out_dir=settings.out_dir,
+        staging_dir=settings.staging_dir,
         mirror="http://127.0.0.1:9",
-        streams=1,
     )
-    process_item((plan, settings_offline))
-    assert (dest / "p0.jpg").read_bytes() == b"sentinel"
+    assert (
+        run_pipeline(items, offline, streams=1, decode_workers=1, progress=False)[
+            "items"
+        ]
+        == 0
+    )
+
+
+@needs_jp2
+def test_pipeline_uploads_then_drops_staging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    items, settings, _ = make_volume(tmp_path)
+    settings.bucket, settings.upload = "s3://bucket", True
+    synced: list[tuple[str, str]] = []
+
+    def fake_run(cmd, check):
+        synced.append((cmd[3], cmd[4]))
+
+    monkeypatch.setattr(loc_mirror.subprocess, "run", fake_run)
+    totals = run_pipeline(items, settings, streams=2, decode_workers=1, progress=False)
+    assert totals["uploaded"] == 2
+    assert sorted(dest for _, dest in synced) == [
+        "s3://bucket/by-state/alabama/1922/sanborn00081_001",
+        "s3://bucket/by-state/alabama/1922/sanborn00082_001",
+    ]
+    assert (settings.out_dir / item_relative(items[0]) / UPLOADED).exists()
+    assert not (settings.staging_dir / item_relative(items[0])).exists()
+    assert not (settings.staging_dir / "by-state").exists()  # empty parents pruned
+    # A second run finds every item uploaded and does nothing.
+    assert (
+        run_pipeline(items, settings, streams=1, decode_workers=1, progress=False)[
+            "items"
+        ]
+        == 0
+    )

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -22,6 +22,7 @@ from mapsnap.loc_mirror import (
     jp2_path,
     keep_sheet,
     load_mapping,
+    prune_empty_parents,
     run_pipeline,
     s3_prefix,
     select_items,
@@ -216,6 +217,7 @@ def test_pipeline_decodes_logs_broken_and_resumes(tmp_path: Path):
         "broken": 1,
         "uploaded": 0,
         "bytes": pytest.approx(totals["bytes"]),
+        "errors": 0,
     }
     staged = settings.staging_dir / item_relative(items[0])
     assert Image.open(staged / "p0.jpg").size == (50, 40)
@@ -344,3 +346,49 @@ def test_fetch_reuses_one_keep_alive_connection_per_thread(
             fetch(f"{base}/a.bin", tmp_path / "a2.bin", expected_bytes=999)
     finally:
         server.shutdown()
+
+
+def test_prune_stops_at_the_root_and_survives_races(tmp_path: Path):
+    root = tmp_path / "staging"
+    leaf = root / "by-state" / "colorado" / "1905"
+    leaf.mkdir(parents=True)
+    (root / "by-state" / "ohio").mkdir()
+    prune_empty_parents(leaf, root)
+    assert not (root / "by-state" / "colorado").exists()
+    assert (
+        root / "by-state" / "ohio"
+    ).exists() and root.exists()  # by-state kept: not empty
+    prune_empty_parents(
+        root / "by-state" / "gone" / "1900", root
+    )  # already removed elsewhere: no error
+
+
+@needs_jp2
+def test_upload_failure_is_logged_and_the_item_waits_for_resume(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    items, settings, _ = make_volume(tmp_path)
+    settings.bucket, settings.upload = "s3://bucket", True
+
+    def failing_run(cmd, check):
+        raise RuntimeError("aws exploded")
+
+    monkeypatch.setattr(loc_mirror.subprocess, "run", failing_run)
+    totals = run_pipeline(items, settings, streams=2, decode_workers=1, progress=False)
+    assert totals["items"] == 2 and totals["uploaded"] == 0 and totals["errors"] == 2
+    state = settings.out_dir / item_relative(items[0])
+    assert (state / DONE).exists() and not (state / UPLOADED).exists()
+    assert (
+        settings.staging_dir / item_relative(items[0]) / "p0.jpg"
+    ).exists()  # kept for the retry
+    assert (
+        "upload\tsanborn00081_001\tRuntimeError"
+        in (settings.out_dir / "errors.log").read_text()
+    )
+    # Resume with a working aws: only the upload runs, from the retained staging copy.
+    synced: list[str] = []
+    monkeypatch.setattr(
+        loc_mirror.subprocess, "run", lambda cmd, check: synced.append(cmd[4])
+    )
+    again = run_pipeline(items, settings, streams=1, decode_workers=1, progress=False)
+    assert again["uploaded"] == 2 and again["items"] == 0 and len(synced) == 2

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -13,8 +13,10 @@ from mapsnap.loc_mirror import (
     ItemPlan,
     Settings,
     Sheet,
+    _connections,
     broken_log_path,
     decode_jp2,
+    fetch,
     is_candidate,
     item_relative,
     jp2_path,
@@ -301,3 +303,44 @@ def test_select_items_random_order_is_seeded_and_optional():
         "ohio"
     ] * 20
     assert [p.item for p in select_items(plans, limit=5, seed=0)] == first[:5]
+
+
+def test_fetch_reuses_one_keep_alive_connection_per_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    import http.server
+    import threading
+
+    root = tmp_path / "srv"
+    root.mkdir()
+    (root / "a.bin").write_bytes(b"a" * 1000)
+    (root / "b.bin").write_bytes(b"b" * 2000)
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"  # keep-alive, as nginx does
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(root), **kwargs)
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{server.server_port}"
+    monkeypatch.setattr(loc_mirror, "RETRY_DELAY", 0.0)
+    try:
+        fetch(f"{base}/a.bin", tmp_path / "a.bin", 1000)
+        first = _connections.conn
+        fetch(f"{base}/b.bin", tmp_path / "b.bin", 2000)
+        assert _connections.conn is first  # same socket, not a new connection per file
+        assert (tmp_path / "b.bin").read_bytes() == b"b" * 2000
+        with pytest.raises(OSError):
+            fetch(f"{base}/missing.bin", tmp_path / "m.bin")
+        assert (
+            not (tmp_path / "m.bin").exists() and not (tmp_path / "m.bin.part").exists()
+        )
+        with pytest.raises(OSError):
+            fetch(f"{base}/a.bin", tmp_path / "a2.bin", expected_bytes=999)
+    finally:
+        server.shutdown()


### PR DESCRIPTION
Initial step towards #354

## What

`mapsnap loc-mirror MAPPING.tsv --jp2-dir … --out-dir … --staging-dir … --bucket s3://mapsnap-sanborn --upload` builds the whole-collection Sanborn dataset from the Library of Congress full-resolution JP2s served by the torrent's HTTP mirror. Every sheet's identity is its own filename (`06246_1914-0051`), so no sequence-number mapping is involved; the plan is a mapping TSV built from the torrent listing and the loc.gov catalog.

Three stages run concurrently, each bounded by a different resource:

1. **download** (threads, `--streams`, the mirror saturates near 8): each kept sheet's JP2 into `--jp2-dir`, mirroring the torrent tree and verified against the listed byte count, so the copy is kept as a valid torrent payload;
2. **decode** (processes, `--decode-workers`): `opj_decompress -r 2`, the JPEG 2000 quarter level, which is exactly the pipeline's 25% working scale, to `<staging>/by-state/<state>/<year>/<item>/p<key>.jpg` at quality 95 (what `mapsnap scale` writes); page-0 sheets and letter pages, the key-map candidates, also at full resolution to `raw/p<key>.jpg`;
3. **upload** (two `aws s3 sync` at a time): the item directory to `<bucket>/by-state/<state>/<year>/<item>/`, then its staging copy is deleted (`--keep-staging` retains it).

Up to `--prefetch-items` items download ahead of decoding so one-sheet volumes do not starve the connections. State lives only on local disk under `--out-dir`: per item `metadata.json` (catalog fields plus the sheet table: sequence, stem, key, source, bytes, dimensions, raw flag) with `.done` and `.uploaded` markers, plus `broken.log` (item, stem, source, reason) and `progress.jsonl`; resume never lists S3. Sheets without a numbered page key (covr, ind1, cbd, titl, note) are skipped. The 161 TIFF-only masters and 17 tile.loc.gov-only sheets are handled through the mapping's `source` column. One tqdm bar (`smoothing=0`) counts decoded sheets with downloaded GB, uploaded items, and broken sheets in the postfix.

## Verification

- `uv run pytest mapsnap/loc_mirror_test.py`: keep/candidate rules, mapping load, layout vs the S3 prefix, quarter and full decode of a generated JP2, the pipeline over a `file://` mirror with a corrupt sheet (outputs, metadata in both staging and state, broken log, resume with the mirror unreachable), and the upload stage with a stubbed `aws` (marker, staging removal, second run idle).
- Real runs: Alaska (27 items / 92 sheets / 0.7 GB in 104 s, resume 5 s) and Baja California with `--upload` (4 items / 32 sheets in 35 s, 36 objects in the bucket).
- ruff, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)