### PR TITLE
loc-mirror: use the mirror's pre-rendered 25% JPEGs, falling back to the JP2

### DIFF
--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -38,7 +38,14 @@ JP2 or TIFF is in ``--jp2-dir``), so the sheets with no local full-resolution
 copy can be listed later. Resuming never lists S3: an item with its marker is
 skipped, a JP2 on disk at the listed size is not re-fetched (and is used in
 preference to the mirror's JPEG), and an output already in staging is not
-re-decoded.
+re-decoded. ``--retry-broken`` clears the markers of finished items whose
+metadata lists broken sheets, so those run again (the sync re-uploads only
+what changed).
+
+The progress bar counts sheets through the decode stage; its postfix shows
+what actually gates the finish once the mirror's JPEGs carry most sheets:
+the uplink, as ``up_rate`` (averaged over the last ten minutes) and ``up_eta``
+(the staging backlog plus the undecoded remainder at that rate).
 
 Items are processed in a seeded random order, so however far the run has
 got, the finished subset is a uniform sample of the collection
@@ -100,6 +107,7 @@ RETRY_DELAY = 5.0  # seconds, times the attempt number
 # renewal should not need a restart.
 UPLOAD_RETRY_DELAY = 60.0
 UPLOAD_RETRY_MAX = 600.0
+UPLOAD_RATE_WINDOW = 600.0  # seconds of completed uploads the bar's rate averages over
 DONE, UPLOADED = ".done", ".uploaded"
 
 
@@ -666,6 +674,41 @@ def item_complete(plan: ItemPlan, settings: Settings) -> bool:
     return (state / DONE).exists()
 
 
+def broken_sheets(plan: ItemPlan, settings: Settings) -> list[str]:
+    """Stems the item's recorded metadata lists as broken (empty if never decoded)."""
+    metadata = settings.out_dir / item_relative(plan) / "metadata.json"
+    if not metadata.exists():
+        return []
+    return list(json.loads(metadata.read_text()).get("broken", []))
+
+
+def retry_broken(plan: ItemPlan, settings: Settings) -> list[str]:
+    """Clear a finished item's markers when it has broken sheets; returns their stems.
+
+    The item then runs again from the download stage. A broken sheet starts
+    over: whatever it left in staging is removed (a half-written file from a
+    killed run must not pass for a finished output), and so is its local JP2
+    or TIFF, since a source that failed to decode is suspect and the mirror's
+    pre-rendered JPEG may now exist for it. Items with no broken sheets are
+    untouched.
+    """
+    broken = broken_sheets(plan, settings)
+    if not broken:
+        return []
+    staging_item = settings.staging_dir / item_relative(plan)
+    for sheet in plan.sheets:
+        if sheet.stem in broken:
+            for path in sheet_outputs(staging_item, sheet):
+                if path is not None:
+                    path.unlink(missing_ok=True)
+            if sheet.source.startswith("torrent"):
+                jp2_path(settings.jp2_dir, sheet).unlink(missing_ok=True)
+    state = settings.out_dir / item_relative(plan)
+    for marker in (DONE, UPLOADED):
+        (state / marker).unlink(missing_ok=True)
+    return broken
+
+
 def select_items(
     plans: dict[str, ItemPlan],
     *,
@@ -695,6 +738,41 @@ def select_items(
     return chosen[:limit] if limit else chosen
 
 
+class UploadMeter:
+    """Rolling upload throughput from completed items, for the bar's upload ETA.
+
+    Bytes are credited when an item's sync finishes and averaged over the
+    last ``window`` seconds (or since ``start`` while the window is still
+    filling), so the rate tracks the uplink as it is now, not the run's
+    history.
+    """
+
+    def __init__(self, start: float, window: float = UPLOAD_RATE_WINDOW) -> None:
+        self.start = start
+        self.window = window
+        self.completed: deque[tuple[float, int]] = deque()
+        self.any_completed = False
+
+    def add(self, now: float, nbytes: int) -> None:
+        self.completed.append((now, nbytes))
+        self.any_completed = True
+
+    def rate(self, now: float) -> float | None:
+        """Bytes per second over the window: None before the first completed upload, 0.0 when stalled."""
+        while self.completed and self.completed[0][0] < now - self.window:
+            self.completed.popleft()
+        span = min(self.window, now - self.start)
+        if not self.any_completed or span <= 0:
+            return None
+        return sum(nbytes for _, nbytes in self.completed) / span
+
+
+def format_hours(seconds: float) -> str:
+    """A duration as ``h:mm``."""
+    minutes = int(seconds // 60)
+    return f"{minutes // 60}:{minutes % 60:02d}"
+
+
 def run_pipeline(
     items: list[ItemPlan],
     settings: Settings,
@@ -717,9 +795,11 @@ def run_pipeline(
     uplink costs staging disk rather than download throughput. A stage failure
     is logged to errors.log and never ends the run: a failed upload (an expired
     AWS session, say) is retried by this process with backoff, its staging copy
-    kept; a failed decode is left for the next resume. One tqdm bar counts decoded sheets, with downloaded
-    gigabytes, uploaded items, the staging backlog, broken sheets, and stage
-    errors in the postfix.
+    kept; a failed decode is left for the next resume. One tqdm bar counts
+    sheets through decoding, with downloaded gigabytes, uploaded items, the
+    staging backlog, broken sheets, stage errors and, when uploading, the
+    rolling upload rate and the ETA for the backlog plus the undecoded
+    remainder in the postfix.
     """
     todo = deque(item for item in items if not item_complete(item, settings))
     totals = {
@@ -779,6 +859,10 @@ def run_stages(
     staged_bytes = 0
     # Failed uploads wait here as (not-before time, attempt, item) until retried.
     retry_queue: deque[tuple[float, int, ItemPlan]] = deque()
+    meter = UploadMeter(time.time())
+    total_sheets = sum(len(plan.sheets) for plan in todo)
+    handled_sheets = 0  # through decoding (or straight to upload on a resume)
+    decoded_sheets = decoded_bytes = 0  # this run's decode output: bytes per sheet
     settings.out_dir.mkdir(parents=True, exist_ok=True)
     with (
         open(settings.out_dir / "progress.jsonl", "a") as progress_log,
@@ -819,6 +903,8 @@ def run_stages(
                     item_staged[plan.item] = staged
                     staged_bytes += staged
                     uploads[upload_pool.submit(upload_item, plan, settings)] = (plan, 0)
+                    bar.update(len(plan.sheets))
+                    handled_sheets += len(plan.sheets)
                     continue
                 item_fetch[plan.item] = [None] * len(plan.sheets)
                 item_pending[plan.item] = len(plan.sheets)
@@ -857,11 +943,15 @@ def run_stages(
                         log_error(settings.out_dir, "decode", plan.item, error)
                         totals["errors"] += 1
                         bar.update(len(plan.sheets))
+                        handled_sheets += len(plan.sheets)
                         continue
                     totals["items"] += 1
                     totals["sheets"] += decoded
                     totals["broken"] += broken
                     bar.update(len(plan.sheets))
+                    handled_sheets += len(plan.sheets)
+                    decoded_sheets += decoded
+                    decoded_bytes += staged
                     progress_log.write(
                         json.dumps(
                             {"item": plan.item, "sheets": decoded, "broken": broken}
@@ -887,16 +977,28 @@ def run_stages(
                         retry_queue.append((time.time() + delay, attempt + 1, plan))
                         continue
                     totals["uploaded"] += 1
-                    staged_bytes -= item_staged.pop(plan.item, 0)
-            bar.set_postfix(
-                dl=f"{totals['bytes'] / 1e9:.1f}GB",
-                up=totals["uploaded"],
-                staged=f"{staged_bytes / 1e9:.1f}GB",
-                broken=totals["broken"],
-                errors=totals["errors"],
-                retry=len(retry_queue),
-                refresh=False,
-            )
+                    item_bytes = item_staged.pop(plan.item, 0)
+                    staged_bytes -= item_bytes
+                    meter.add(time.time(), item_bytes)
+            postfix: dict[str, object] = {
+                "dl": f"{totals['bytes'] / 1e9:.1f}GB",
+                "up": totals["uploaded"],
+                "staged": f"{staged_bytes / 1e9:.1f}GB",
+                "broken": totals["broken"],
+                "errors": totals["errors"],
+                "retry": len(retry_queue),
+            }
+            if settings.upload:
+                rate = meter.rate(time.time())
+                per_sheet = decoded_bytes / decoded_sheets if decoded_sheets else 0.0
+                pending_bytes = (
+                    staged_bytes + (total_sheets - handled_sheets) * per_sheet
+                )
+                postfix["up_rate"] = (
+                    f"{rate / 1e6:.2f}MB/s" if rate is not None else "?"
+                )
+                postfix["up_eta"] = format_hours(pending_bytes / rate) if rate else "?"
+            bar.set_postfix(postfix, refresh=False)
 
 
 def main() -> None:
@@ -1001,6 +1103,13 @@ def main() -> None:
         help="Process items in state, year, item order instead of at random.",
     )
     parser.add_argument(
+        "--retry-broken",
+        action="store_true",
+        help="Run finished items whose metadata lists broken sheets again: their "
+        "markers are cleared, so they take the whole pipeline (the sync "
+        "re-uploads only what changed).",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="List the items and sheet counts; touch nothing.",
@@ -1030,6 +1139,17 @@ def main() -> None:
         limit=args.limit,
         seed=None if args.sequential else args.seed,
     )
+    if args.retry_broken:
+        lookup = broken_sheets if args.dry_run else retry_broken
+        retried = {
+            plan.item: stems for plan in chosen if (stems := lookup(plan, settings))
+        }
+        print(
+            f"--retry-broken: {sum(len(v) for v in retried.values())} broken sheets "
+            f"in {len(retried)} items {'would be' if args.dry_run else 'will be'} "
+            "retried",
+            file=sys.stderr,
+        )
     pending = [plan for plan in chosen if not item_complete(plan, settings)]
     print(
         f"{len(chosen)} items selected, {len(pending)} to do: "

--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -980,6 +980,11 @@ def run_stages(
                     item_bytes = item_staged.pop(plan.item, 0)
                     staged_bytes -= item_bytes
                     meter.add(time.time(), item_bytes)
+            # Redraw only when something finished: tqdm repaints on update(),
+            # and once decoding is done nothing updates the bar, so a postfix
+            # set without a refresh would freeze at the last decoded sheet
+            # while the upload backlog drains for a day.
+            finished_something = bool(done)
             postfix: dict[str, object] = {
                 "dl": f"{totals['bytes'] / 1e9:.1f}GB",
                 "up": totals["uploaded"],
@@ -998,7 +1003,7 @@ def run_stages(
                     f"{rate / 1e6:.2f}MB/s" if rate is not None else "?"
                 )
                 postfix["up_eta"] = format_hours(pending_bytes / rate) if rate else "?"
-            bar.set_postfix(postfix, refresh=False)
+            bar.set_postfix(postfix, refresh=finished_something)
 
 
 def main() -> None:

--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -9,16 +9,21 @@ torrent listing and the loc.gov catalog.
 
 Three stages run concurrently, each bounded by a different resource:
 
-  1. download (network, ``--streams`` connections): each kept sheet's JP2 goes
-     to ``--jp2-dir`` mirroring the torrent tree
-     (``storage-services/service/<dir>/<stem>.jp2``), verified against the
-     listed byte count, so the copy stays a valid torrent payload and is kept;
-  2. decode (CPU, ``--decode-workers`` processes): the JP2 is decoded at the
+  1. download (network, ``--streams`` connections): a map sheet whose 25%
+     JPEG the mirror has already rendered
+     (``storage-services/master/<dir>/<stem>.jpg``) is fetched as that JPEG,
+     straight into staging; otherwise its JP2 goes to ``--jp2-dir`` mirroring
+     the torrent tree (``storage-services/service/<dir>/<stem>.jp2``),
+     verified against the listed byte count, so the copy stays a valid torrent
+     payload and is kept. The key-map candidates below always take the JP2
+     route, since their raw copy needs the full resolution;
+  2. decode (CPU, ``--decode-workers`` processes): a JP2 is decoded at the
      JPEG 2000 quarter-resolution level -- the pipeline's 25% working scale --
      to ``<staging>/by-state/<state>/<year>/<item>/p<key>.jpg`` (JPEG quality
-     95, what ``mapsnap scale`` writes); page-0 sheets (``p0``, ``p0b``,
-     ``p0L``) and letter pages, the key-map candidates, are also decoded at
-     full resolution to ``raw/p<key>.jpg``;
+     95, what ``mapsnap scale`` writes; the mirror's pre-rendered JPEGs are
+     the same decode); page-0 sheets (``p0``, ``p0b``, ``p0L``) and letter
+     pages, the key-map candidates, are also decoded at full resolution to
+     ``raw/p<key>.jpg``;
   3. upload (your uplink, two ``aws s3 sync`` at a time): the item directory
      goes to ``<bucket>/by-state/<state>/<year>/<item>/`` and its staging
      copy is deleted (``--keep-staging`` to retain it).
@@ -26,9 +31,13 @@ Three stages run concurrently, each bounded by a different resource:
 State lives only on local disk, under ``--out-dir``: per item a copy of
 ``metadata.json`` (catalog fields plus the sheet table) with ``.done`` and
 ``.uploaded`` markers, plus ``broken.log`` (tab-separated item, stem, source,
-reason) and ``progress.jsonl``. Resuming never lists S3: an item with its
-marker is skipped, a JP2 on disk at the listed size is not re-fetched, and an
-output already in staging is not re-decoded.
+reason) and ``progress.jsonl``. Each sheet row of ``metadata.json`` records
+``prerendered`` (its 25% JPEG arrived ready-made) and ``source_on_disk`` (its
+JP2 or TIFF is in ``--jp2-dir``), so the sheets with no local full-resolution
+copy can be listed later. Resuming never lists S3: an item with its marker is
+skipped, a JP2 on disk at the listed size is not re-fetched (and is used in
+preference to the mirror's JPEG), and an output already in staging is not
+re-decoded.
 
 Items are processed in a seeded random order, so however far the run has
 got, the finished subset is a uniform sample of the collection
@@ -68,6 +77,7 @@ from concurrent.futures import (
 )
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import Protocol
 from urllib.parse import urlsplit
 
 from PIL import Image
@@ -126,6 +136,18 @@ class Settings:
     bucket: str | None = None
     upload: bool = False
     keep_staging: bool = False
+
+
+@dataclass(frozen=True)
+class Fetched:
+    """What the download stage brought to disk for one sheet."""
+
+    prerendered: bool  # the 25% JPEG arrived ready-made (mirror JPEG or LoC IIIF)
+    bytes: int  # downloaded by this call
+
+
+class NotFound(OSError):
+    """The URL does not exist (HTTP 404, a missing file): an answer, not retried."""
 
 
 def keep_sheet(key: str) -> bool:
@@ -204,6 +226,11 @@ def source_url(mirror: str, sheet: Sheet, full: bool = False) -> str:
     return f"{LOC_IIIF}/{service}:{sheet.stem}/full/{'full' if full else 'pct:25'}/0/default.jpg"
 
 
+def quarter_url(mirror: str, sheet: Sheet) -> str:
+    """The mirror's pre-rendered 25% JPEG of a torrent sheet: the master tree, ``.jpg`` suffix."""
+    return f"{mirror}/storage-services/master/{sheet.storage_dir}/{sheet.stem}.jpg"
+
+
 def sheet_outputs(staging_item: Path, sheet: Sheet) -> tuple[Path, Path | None]:
     """(25% JPEG path, raw full-resolution path or None) for a sheet."""
     quarter = staging_item / f"{sheet.key}.jpg"
@@ -240,8 +267,33 @@ def drop_connection() -> None:
     _connections.conn = None
 
 
-def fetch_http(url: str, partial: Path) -> None:
-    """GET ``url`` over the thread's keep-alive connection, streaming the body to ``partial``."""
+class Body(Protocol):
+    """A response body read in chunks (http.client's and urllib's both are)."""
+
+    def read(self, amt: int, /) -> bytes: ...
+
+
+def stream_body(response: Body, partial: Path, content_length: str | None) -> int:
+    """Copy a response body to ``partial``; returns its size.
+
+    A body shorter than its Content-Length raises OSError: http.client ends a
+    truncated body silently, and a short file would otherwise pass as an image.
+    """
+    written = 0
+    with open(partial, "wb") as out:
+        while chunk := response.read(1 << 20):
+            out.write(chunk)
+            written += len(chunk)
+    if content_length and written != int(content_length):
+        raise OSError(f"short body: {written} of {content_length} bytes")
+    return written
+
+
+def fetch_http(url: str, partial: Path) -> int:
+    """GET ``url`` over the thread's keep-alive connection into ``partial``; returns its size.
+
+    A 404 raises NotFound, its body drained first so the connection stays reusable.
+    """
     parts = urlsplit(url)
     conn = mirror_connection(parts.hostname or "", parts.port)
     path = parts.path + (f"?{parts.query}" if parts.query else "")
@@ -250,19 +302,41 @@ def fetch_http(url: str, partial: Path) -> None:
     try:
         if response.status != 200:
             response.read()
+            if response.status == 404:
+                raise NotFound(f"HTTP 404 {url}")
             raise OSError(f"HTTP {response.status}")
-        with open(partial, "wb") as out:
-            while chunk := response.read(1 << 20):
-                out.write(chunk)
+        return stream_body(response, partial, response.getheader("Content-Length"))
     finally:
         response.close()
 
 
-def fetch(url: str, dest: Path, expected_bytes: int = 0) -> None:
-    """Download ``url`` to ``dest`` with retries; verify the byte count when known.
+def fetch_urllib(url: str, partial: Path) -> int:
+    """GET ``url`` through urllib (https, file://) into ``partial``; returns its size.
+
+    A 404, or a file:// path that does not exist, raises NotFound.
+    """
+    try:
+        with urllib.request.urlopen(url, timeout=300) as response:
+            return stream_body(
+                response, partial, response.headers.get("Content-Length")
+            )
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            raise NotFound(f"HTTP 404 {url}") from error
+        raise
+    except urllib.error.URLError as error:
+        if isinstance(error.reason, FileNotFoundError):
+            raise NotFound(f"missing {url}") from error
+        raise
+
+
+def fetch(url: str, dest: Path, expected_bytes: int = 0) -> int:
+    """Download ``url`` to ``dest`` with retries; returns its size, checked when listed.
 
     Plain-http URLs (the mirror) reuse a per-thread keep-alive connection;
-    anything else (LoC's IIIF over https, file:// in tests) goes through urllib.
+    anything else (LoC's IIIF over https, file:// in tests) goes through
+    urllib. NotFound is raised at once, without retries: a 404 is the mirror's
+    answer (no such rendering), not a failure.
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
     last: Exception | None = None
@@ -270,18 +344,16 @@ def fetch(url: str, dest: Path, expected_bytes: int = 0) -> None:
     for attempt in range(RETRIES):
         try:
             if urlsplit(url).scheme == "http":
-                fetch_http(url, partial)
+                size = fetch_http(url, partial)
             else:
-                with (
-                    urllib.request.urlopen(url, timeout=300) as response,
-                    open(partial, "wb") as out,
-                ):
-                    shutil.copyfileobj(response, out, 1 << 20)
-            size = partial.stat().st_size
+                size = fetch_urllib(url, partial)
             if expected_bytes and size != expected_bytes:
                 raise OSError(f"size {size} != listed {expected_bytes}")
             partial.replace(dest)
-            return
+            return size
+        except NotFound:
+            partial.unlink(missing_ok=True)
+            raise
         except (OSError, urllib.error.URLError, http.client.HTTPException) as error:
             last = error
             drop_connection()
@@ -314,29 +386,35 @@ def log_broken(out_dir: Path, plan: ItemPlan, sheet: Sheet, reason: str) -> None
 # ---------------------------------------------------------------- stage 1: download
 
 
-def fetch_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> bool:
-    """Bring the sheet's source to disk; False (and a broken-log line) on failure.
+def fetch_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> Fetched | None:
+    """Bring the sheet's inputs to disk; None (and a broken-log line) on failure.
 
-    Torrent sources land in the JP2 mirror; the few LoC-only sheets are fetched
-    already rendered, straight into staging.
+    A torrent sheet whose full-resolution source is already in the JP2 mirror
+    needs nothing more. Otherwise a plain map sheet tries the mirror's
+    pre-rendered 25% JPEG first, straight into staging, and only when the
+    mirror has none does its JP2 come down. Key-map candidates need the full
+    resolution for their raw copy, so they always take the JP2. The few
+    LoC-only sheets are fetched already rendered from LoC's IIIF.
     """
     try:
-        if sheet.source.startswith("torrent"):
-            local = jp2_path(settings.jp2_dir, sheet)
-            if local.exists() and (
-                not sheet.bytes or local.stat().st_size == sheet.bytes
-            ):
-                return True
-            fetch(source_url(settings.mirror, sheet), local, sheet.bytes)
-        else:
-            quarter, raw = sheet_outputs(
-                settings.staging_dir / item_relative(plan), sheet
-            )
-            if not quarter.exists():
-                fetch(source_url(settings.mirror, sheet), quarter)
-            if raw and not raw.exists():
-                fetch(source_url(settings.mirror, sheet, full=True), raw)
-        return True
+        if not sheet.source.startswith("torrent"):
+            return fetch_loc_sheet(plan, sheet, settings)
+        quarter, raw = sheet_outputs(settings.staging_dir / item_relative(plan), sheet)
+        local = jp2_path(settings.jp2_dir, sheet)
+        if local.exists() and (not sheet.bytes or local.stat().st_size == sheet.bytes):
+            return Fetched(prerendered=False, bytes=0)
+        if raw is None:
+            if quarter.exists():  # staged ready-made on an earlier run
+                return Fetched(prerendered=True, bytes=0)
+            try:
+                size = fetch(quarter_url(settings.mirror, sheet), quarter)
+                return Fetched(prerendered=True, bytes=size)
+            except NotFound:
+                pass
+        elif quarter.exists() and raw.exists():
+            return Fetched(prerendered=False, bytes=0)
+        size = fetch(source_url(settings.mirror, sheet), local, sheet.bytes)
+        return Fetched(prerendered=False, bytes=size)
     except Exception as error:  # noqa: BLE001 -- any failure is a broken sheet
         log_broken(
             settings.out_dir,
@@ -344,7 +422,18 @@ def fetch_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> bool:
             sheet,
             f"{error.__class__.__name__}: {str(error)[:200]}",
         )
-        return False
+        return None
+
+
+def fetch_loc_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> Fetched:
+    """A LoC-only sheet: its 25% rendering (and raw copy, for a candidate) straight into staging."""
+    quarter, raw = sheet_outputs(settings.staging_dir / item_relative(plan), sheet)
+    size = 0
+    if not quarter.exists():
+        size += fetch(source_url(settings.mirror, sheet), quarter)
+    if raw and not raw.exists():
+        size += fetch(source_url(settings.mirror, sheet, full=True), raw)
+    return Fetched(prerendered=True, bytes=size)
 
 
 # ---------------------------------------------------------------- stage 2: decode
@@ -402,13 +491,23 @@ def scale_to_quarter(src: Path, out_jpg: Path) -> tuple[int, int]:
     return small.size
 
 
-def decode_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> dict | None:
-    """Produce the sheet's outputs in staging; returns its metadata row, None if broken."""
+def decode_sheet(
+    plan: ItemPlan, sheet: Sheet, settings: Settings, fetched: Fetched
+) -> dict | None:
+    """Produce the sheet's outputs in staging; returns its metadata row, None if broken.
+
+    Whatever the download stage staged ready-made (a pre-rendered 25% JPEG) is
+    kept as is; the rest is decoded from the local JP2 or TIFF.
+    """
     quarter, raw = sheet_outputs(settings.staging_dir / item_relative(plan), sheet)
     row = asdict(sheet)
+    local = (
+        jp2_path(settings.jp2_dir, sheet)
+        if sheet.source.startswith("torrent")
+        else None
+    )
     try:
-        if sheet.source.startswith("torrent"):
-            local = jp2_path(settings.jp2_dir, sheet)
+        if local is not None:
             if not quarter.exists():
                 if local.suffix == ".jp2":
                     decode_jp2(local, quarter, QUARTER_REDUCE)
@@ -425,6 +524,8 @@ def decode_sheet(plan: ItemPlan, sheet: Sheet, settings: Settings) -> dict | Non
         with Image.open(quarter) as image:
             row["width"], row["height"] = image.size
         row["raw"] = raw is not None
+        row["prerendered"] = fetched.prerendered
+        row["source_on_disk"] = local is not None and local.exists()
         return row
     except Exception as error:  # noqa: BLE001 -- any failure is a broken sheet
         log_broken(
@@ -456,7 +557,7 @@ def metadata_document(plan: ItemPlan, rows: list[dict], broken: list[str]) -> di
 
 
 def decode_item(
-    plan: ItemPlan, fetched: list[bool], settings: Settings
+    plan: ItemPlan, fetched: list[Fetched | None], settings: Settings
 ) -> tuple[int, int, int]:
     """Decode every fetched sheet, write metadata to staging and state, mark done.
 
@@ -465,8 +566,8 @@ def decode_item(
     """
     rows: list[dict] = []
     broken: list[str] = []
-    for sheet, ok in zip(plan.sheets, fetched):
-        row = decode_sheet(plan, sheet, settings) if ok else None
+    for sheet, result in zip(plan.sheets, fetched):
+        row = decode_sheet(plan, sheet, settings, result) if result else None
         if row is None:
             broken.append(sheet.stem)
         else:
@@ -652,7 +753,8 @@ def run_stages(
 ) -> None:
     """The coordinator loop behind run_pipeline; mutates ``totals`` and drives ``bar``."""
     downloads: dict[Future, tuple[ItemPlan, int]] = {}
-    item_fetch: dict[str, list[bool | None]] = {}
+    item_fetch: dict[str, list[Fetched | None]] = {}
+    item_pending: dict[str, int] = {}  # downloads still out, per item in item_fetch
     decodes: dict[Future, ItemPlan] = {}
     uploads: dict[Future, tuple[ItemPlan, int]] = {}
     item_staged: dict[str, int] = {}
@@ -668,7 +770,8 @@ def run_stages(
     ):
 
         def start_decode(plan: ItemPlan) -> None:
-            fetched = [bool(ok) for ok in item_fetch.pop(plan.item)]
+            fetched = item_fetch.pop(plan.item)
+            item_pending.pop(plan.item, None)
             decodes[decode_pool.submit(decode_item, plan, fetched, settings)] = plan
 
         while todo or downloads or decodes or uploads or retry_queue:
@@ -700,6 +803,7 @@ def run_stages(
                     uploads[upload_pool.submit(upload_item, plan, settings)] = (plan, 0)
                     continue
                 item_fetch[plan.item] = [None] * len(plan.sheets)
+                item_pending[plan.item] = len(plan.sheets)
                 if not plan.sheets:
                     start_decode(plan)
                 for index, sheet in enumerate(plan.sheets):
@@ -714,17 +818,18 @@ def run_stages(
                 if future in downloads:
                     plan, index = downloads.pop(future)
                     try:
-                        fetched = bool(future.result())
+                        result: Fetched | None = future.result()
                     except Exception as error:  # noqa: BLE001 -- logged; the sheet counts as broken
                         log_error(
                             settings.out_dir, "download", plan.sheets[index].stem, error
                         )
                         totals["errors"] += 1
-                        fetched = False
-                    item_fetch[plan.item][index] = fetched
-                    if fetched:
-                        totals["bytes"] += plan.sheets[index].bytes
-                    if all(ok is not None for ok in item_fetch[plan.item]):
+                        result = None
+                    item_fetch[plan.item][index] = result
+                    item_pending[plan.item] -= 1
+                    if result:
+                        totals["bytes"] += result.bytes
+                    if item_pending[plan.item] == 0:
                         start_decode(plan)
                 elif future in decodes:
                     plan = decodes.pop(future)
@@ -903,8 +1008,9 @@ def main() -> None:
     pending = [plan for plan in chosen if not item_complete(plan, settings)]
     print(
         f"{len(chosen)} items selected, {len(pending)} to do: "
-        f"{sum(len(p.sheets) for p in pending):,} sheets, "
-        f"{sum(s.bytes for p in pending for s in p.sheets) / 1e9:,.1f} GB of JP2",
+        f"{sum(len(p.sheets) for p in pending):,} sheets, up to "
+        f"{sum(s.bytes for p in pending for s in p.sheets) / 1e9:,.1f} GB of JP2 "
+        "(a sheet the mirror has pre-rendered downloads its ~1 MB JPEG instead)",
         file=sys.stderr,
     )
     if args.dry_run:

--- a/mapsnap/loc_mirror.py
+++ b/mapsnap/loc_mirror.py
@@ -10,13 +10,14 @@ torrent listing and the loc.gov catalog.
 Three stages run concurrently, each bounded by a different resource:
 
   1. download (network, ``--streams`` connections): a map sheet whose 25%
-     JPEG the mirror has already rendered
-     (``storage-services/master/<dir>/<stem>.jpg``) is fetched as that JPEG,
-     straight into staging; otherwise its JP2 goes to ``--jp2-dir`` mirroring
-     the torrent tree (``storage-services/service/<dir>/<stem>.jp2``),
-     verified against the listed byte count, so the copy stays a valid torrent
-     payload and is kept. The key-map candidates below always take the JP2
-     route, since their raw copy needs the full resolution;
+     JPEG the mirror has already rendered (beside its source, with a ``.jpg``
+     suffix: ``storage-services/service/<dir>/<stem>.jpg``, or under
+     ``master/`` for the TIFF-only sheets) is fetched as that JPEG, straight
+     into staging; otherwise its JP2 goes to ``--jp2-dir`` mirroring the
+     torrent tree (``storage-services/service/<dir>/<stem>.jp2``), verified
+     against the listed byte count, so the copy stays a valid torrent payload
+     and is kept. The key-map candidates below always take the JP2 route,
+     since their raw copy needs the full resolution;
   2. decode (CPU, ``--decode-workers`` processes): a JP2 is decoded at the
      JPEG 2000 quarter-resolution level -- the pipeline's 25% working scale --
      to ``<staging>/by-state/<state>/<year>/<item>/p<key>.jpg`` (JPEG quality
@@ -24,9 +25,9 @@ Three stages run concurrently, each bounded by a different resource:
      the same decode); page-0 sheets (``p0``, ``p0b``, ``p0L``) and letter
      pages, the key-map candidates, are also decoded at full resolution to
      ``raw/p<key>.jpg``;
-  3. upload (your uplink, two ``aws s3 sync`` at a time): the item directory
-     goes to ``<bucket>/by-state/<state>/<year>/<item>/`` and its staging
-     copy is deleted (``--keep-staging`` to retain it).
+  3. upload (your uplink, ``--upload-workers`` ``aws s3 sync`` at a time):
+     the item directory goes to ``<bucket>/by-state/<state>/<year>/<item>/``
+     and its staging copy is deleted (``--keep-staging`` to retain it).
 
 State lives only on local disk, under ``--out-dir``: per item a copy of
 ``metadata.json`` (catalog fields plus the sheet table) with ``.done`` and
@@ -87,6 +88,8 @@ from mapsnap.keymap.fit_keymap import page_number
 from mapsnap.keymap.identify import is_letter_page
 
 LOC_IIIF = "https://tile.loc.gov/image-services/iiif"
+# tile.loc.gov answers 403 to urllib's default User-Agent; an honest one is fine.
+USER_AGENT = "mapsnap loc-mirror/1.0 (+https://github.com/danvk/mapsnap)"
 JPEG_QUALITY = 95  # what mapsnap scale writes; the pipeline is tuned on it
 QUARTER_REDUCE = 2  # JPEG 2000 resolution levels to drop: 1/4 linear = 25%
 RETRIES = 4
@@ -203,32 +206,38 @@ def s3_prefix(bucket: str, plan: ItemPlan) -> str:
     return f"{bucket.rstrip('/')}/{item_relative(plan).as_posix()}"
 
 
+def source_relative(sheet: Sheet, suffix: str | None = None) -> str:
+    """A torrent sheet's path under ``storage-services``: its branch, directory, stem, suffix.
+
+    JP2s live in the ``service`` tree, the TIFF-only sheets in ``master``;
+    ``suffix`` overrides the source's own (``.jpg`` for the pre-rendered copy).
+    """
+    branch = "master" if sheet.source.startswith("torrent-master") else "service"
+    if suffix is None:
+        suffix = ".tif" if sheet.source == "torrent-master-tif" else ".jp2"
+    return f"storage-services/{branch}/{sheet.storage_dir}/{sheet.stem}{suffix}"
+
+
 def jp2_path(jp2_dir: Path, sheet: Sheet) -> Path:
     """Where the sheet's JP2 (or TIFF master) lives locally, mirroring the torrent tree."""
-    branch = "master" if sheet.source.startswith("torrent-master") else "service"
-    suffix = ".tif" if sheet.source == "torrent-master-tif" else ".jp2"
-    return (
-        jp2_dir
-        / "storage-services"
-        / branch
-        / sheet.storage_dir
-        / f"{sheet.stem}{suffix}"
-    )
+    return jp2_dir / source_relative(sheet)
 
 
 def source_url(mirror: str, sheet: Sheet, full: bool = False) -> str:
     """The URL to fetch a sheet from: the mirror's JP2/TIFF, or LoC's IIIF for the rest."""
     if sheet.source.startswith("torrent"):
-        branch = "master" if sheet.source.startswith("torrent-master") else "service"
-        suffix = ".tif" if sheet.source == "torrent-master-tif" else ".jp2"
-        return f"{mirror}/storage-services/{branch}/{sheet.storage_dir}/{sheet.stem}{suffix}"
+        return f"{mirror}/{source_relative(sheet)}"
     service = "service:" + sheet.storage_dir.replace("/", ":")
     return f"{LOC_IIIF}/{service}:{sheet.stem}/full/{'full' if full else 'pct:25'}/0/default.jpg"
 
 
 def quarter_url(mirror: str, sheet: Sheet) -> str:
-    """The mirror's pre-rendered 25% JPEG of a torrent sheet: the master tree, ``.jpg`` suffix."""
-    return f"{mirror}/storage-services/master/{sheet.storage_dir}/{sheet.stem}.jpg"
+    """The mirror's pre-rendered 25% JPEG of a torrent sheet: beside its source, ``.jpg`` suffix.
+
+    The render job wrote each JPEG next to the file it came from, so a JP2's
+    copy is in the ``service`` tree and a TIFF master's in ``master``.
+    """
+    return f"{mirror}/{source_relative(sheet, '.jpg')}"
 
 
 def sheet_outputs(staging_item: Path, sheet: Sheet) -> tuple[Path, Path | None]:
@@ -315,8 +324,9 @@ def fetch_urllib(url: str, partial: Path) -> int:
 
     A 404, or a file:// path that does not exist, raises NotFound.
     """
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     try:
-        with urllib.request.urlopen(url, timeout=300) as response:
+        with urllib.request.urlopen(request, timeout=300) as response:
             return stream_body(
                 response, partial, response.headers.get("Content-Length")
             )
@@ -444,12 +454,23 @@ def opj_available() -> bool:
     return shutil.which("opj_decompress") is not None
 
 
+def save_jpeg(image: Image.Image, out_jpg: Path) -> None:
+    """Write ``image`` as a quality-95 JPEG, atomically.
+
+    Written under a ``.part`` name and renamed, so a run killed mid-write
+    leaves no half file that a resume would take for a finished output.
+    """
+    out_jpg.parent.mkdir(parents=True, exist_ok=True)
+    partial = out_jpg.with_suffix(out_jpg.suffix + ".part")
+    image.convert("RGB").save(partial, "JPEG", quality=JPEG_QUALITY)
+    partial.replace(out_jpg)
+
+
 def decode_jp2(jp2: Path, out_jpg: Path, reduce: int) -> tuple[int, int]:
     """Decode a JP2 ``reduce`` resolution levels down and write a JPEG; returns its size.
 
     Uses ``opj_decompress`` (fast, multithreaded) when present, else Pillow.
     """
-    out_jpg.parent.mkdir(parents=True, exist_ok=True)
     if opj_available():
         with tempfile.TemporaryDirectory() as tmp:
             ppm = Path(tmp) / "decoded.ppm"
@@ -474,20 +495,19 @@ def decode_jp2(jp2: Path, out_jpg: Path, reduce: int) -> tuple[int, int]:
         image = Image.open(jp2)
         image.reduce = reduce  # type: ignore[attr-defined]
         image.load()
-    image.convert("RGB").save(out_jpg, "JPEG", quality=JPEG_QUALITY)
+    save_jpeg(image, out_jpg)
     return image.size
 
 
 def scale_to_quarter(src: Path, out_jpg: Path) -> tuple[int, int]:
     """Write a 25% JPEG of a full-resolution TIFF (the master-only sheets)."""
-    out_jpg.parent.mkdir(parents=True, exist_ok=True)
     Image.MAX_IMAGE_PIXELS = None
     image = Image.open(src)
     image.load()
     small = image.convert("RGB").resize(
         (max(1, image.width // 4), max(1, image.height // 4)), Image.Resampling.LANCZOS
     )
-    small.save(out_jpg, "JPEG", quality=JPEG_QUALITY)
+    save_jpeg(small, out_jpg)
     return small.size
 
 
@@ -518,9 +538,7 @@ def decode_sheet(
                     decode_jp2(local, raw, 0)
                 else:
                     Image.MAX_IMAGE_PIXELS = None
-                    Image.open(local).convert("RGB").save(
-                        raw, "JPEG", quality=JPEG_QUALITY
-                    )
+                    save_jpeg(Image.open(local), raw)
         with Image.open(quarter) as image:
             row["width"], row["height"] = image.size
         row["raw"] = raw is not None
@@ -941,6 +959,13 @@ def main() -> None:
         "--decode-workers", type=int, default=4, help="Decode processes."
     )
     parser.add_argument(
+        "--upload-workers",
+        type=int,
+        default=2,
+        help="Concurrent `aws s3 sync` processes (the uplink is the bottleneck "
+        "once the mirror's pre-rendered JPEGs carry most sheets).",
+    )
+    parser.add_argument(
         "--prefetch-items",
         type=int,
         default=16,
@@ -1025,6 +1050,7 @@ def main() -> None:
         streams=args.streams,
         decode_workers=args.decode_workers,
         prefetch_items=args.prefetch_items,
+        upload_workers=args.upload_workers,
         max_staging_bytes=args.max_staging_gb * 1e9,
     )
     print(

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -16,10 +16,13 @@ from mapsnap.loc_mirror import (
     NotFound,
     Settings,
     Sheet,
+    UploadMeter,
     _connections,
     broken_log_path,
+    broken_sheets,
     decode_jp2,
     fetch,
+    format_hours,
     is_candidate,
     item_relative,
     jp2_path,
@@ -27,6 +30,7 @@ from mapsnap.loc_mirror import (
     load_mapping,
     prune_empty_parents,
     quarter_url,
+    retry_broken,
     run_pipeline,
     s3_prefix,
     select_items,
@@ -341,6 +345,44 @@ def test_prerendered_jpeg_is_copied_and_the_jp2_skipped(tmp_path: Path):
         ]
         == 0
     )
+
+
+@needs_jp2
+def test_retry_broken_reruns_only_items_with_broken_sheets(tmp_path: Path):
+    # First run: p1's JP2 is corrupt, so item 1 finishes with p1 broken.
+    items, settings, mirror = make_volume(tmp_path)
+    run_pipeline(items, settings, streams=2, decode_workers=1, progress=False)
+    state = settings.out_dir / item_relative(items[0])
+    assert broken_sheets(items[0], settings) == ["00081_1922-0001"]
+    assert broken_sheets(items[1], settings) == []
+    assert (state / DONE).exists()  # reading the list touches nothing
+    # The mirror gains a pre-rendered JPEG for p1; --retry-broken clears
+    # item 1's markers only, and the rerun recovers the sheet.
+    write_jpeg(mirror / "storage-services/service" / DIR / "00081_1922-0001.jpg")
+    assert retry_broken(items[0], settings) == ["00081_1922-0001"]
+    assert retry_broken(items[1], settings) == []
+    assert not (state / DONE).exists()
+    assert (settings.out_dir / item_relative(items[1]) / DONE).exists()
+    totals = run_pipeline(items, settings, streams=2, decode_workers=1, progress=False)
+    assert totals["items"] == 1 and totals["sheets"] == 2 and totals["broken"] == 0
+    assert broken_sheets(items[0], settings) == []
+    staged = settings.staging_dir / item_relative(items[0])
+    assert Image.open(staged / "p1.jpg").size == (50, 40)
+    assert Image.open(staged / "p0.jpg").size == (50, 40)  # kept from the first run
+
+
+def test_upload_meter_averages_over_its_window():
+    meter = UploadMeter(start=0.0, window=100.0)
+    assert meter.rate(10.0) is None  # nothing uploaded yet
+    meter.add(10.0, 1_000_000)
+    assert meter.rate(10.0) == pytest.approx(100_000)  # over the 10 s since start
+    meter.add(50.0, 3_000_000)
+    assert meter.rate(50.0) == pytest.approx(80_000)
+    # Once the window is full, only completions inside it count.
+    assert meter.rate(150.0) == pytest.approx(30_000)  # the 10 s entry aged out
+    assert meter.rate(151.0) == 0.0  # the 50 s one too: stalled, not unknown
+    assert format_hours(3725) == "1:02" and format_hours(0) == "0:00"
+    assert format_hours(49 * 3600) == "49:00"
 
 
 def test_missing_url_is_not_retried(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -95,10 +95,10 @@ def test_layout_matches_the_s3_prefix_shape(tmp_path: Path):
         source_url("http://m", sheet)
         == "http://m/storage-services/service/gmd/gmd390m/g3904m/g3904mm/g000811922/00081_1922-0123.jp2"
     )
-    # The mirror's pre-rendered 25% JPEGs sit in the master tree with a .jpg suffix.
+    # The mirror's pre-rendered 25% JPEG sits beside its source with a .jpg suffix.
     assert (
         quarter_url("http://m", sheet)
-        == "http://m/storage-services/master/gmd/gmd390m/g3904m/g3904mm/g000811922/00081_1922-0123.jpg"
+        == "http://m/storage-services/service/gmd/gmd390m/g3904m/g3904mm/g000811922/00081_1922-0123.jpg"
     )
     tif = Sheet(
         1, "00081_1922-0124", "p124", "torrent-master-tif", 0, sheet.storage_dir
@@ -109,6 +109,9 @@ def test_layout_matches_the_s3_prefix_shape(tmp_path: Path):
         .endswith(
             "storage-services/master/" + sheet.storage_dir + "/00081_1922-0124.tif"
         )
+    )
+    assert quarter_url("http://m", tif).endswith(
+        "storage-services/master/" + sheet.storage_dir + "/00081_1922-0124.jpg"
     )
     iiif = Sheet(1, "00081_1922-0125", "p125", "loc-iiif", 0, sheet.storage_dir)
     assert source_url("http://m", iiif).endswith(
@@ -158,7 +161,8 @@ def make_volume(
 ) -> tuple[list[ItemPlan], Settings, Path]:
     """A file:// mirror with two items: one good sheet, one page-0 sheet, one corrupt sheet.
 
-    ``prerendered`` names the stems the mirror also serves as ready-made 25% JPEGs.
+    ``prerendered`` names the stems the mirror also serves as ready-made 25%
+    JPEGs, beside their JP2s.
     """
     mirror = tmp_path / "mirror"
     files = {
@@ -174,7 +178,7 @@ def make_volume(
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_bytes(b"not a jp2")
     for stem in prerendered:
-        write_jpeg(mirror / "storage-services/master" / DIR / f"{stem}.jpg")
+        write_jpeg(mirror / "storage-services/service" / DIR / f"{stem}.jpg")
     size = lambda stem: (
         (mirror / "storage-services/service" / DIR / f"{stem}.jp2").stat().st_size
     )
@@ -284,15 +288,17 @@ def test_pipeline_decodes_logs_broken_and_resumes(tmp_path: Path):
 
 @needs_jp2
 def test_prerendered_jpeg_is_copied_and_the_jp2_skipped(tmp_path: Path):
-    # The mirror has 25% JPEGs for both good sheets. p5, a map sheet, is
-    # copied as is and its JP2 never comes down; p0, a key-map candidate,
-    # ignores the JPEG because its raw copy needs the JP2 anyway.
+    # The mirror has 25% JPEGs for every sheet. p5, a map sheet, is copied
+    # as is and its JP2 never comes down; p1's JPEG spares it its corrupt
+    # JP2, so nothing is broken; p0, a key-map candidate, ignores the JPEG
+    # because its raw copy needs the JP2 anyway.
     items, settings, mirror = make_volume(
-        tmp_path, prerendered=("00082_1922-0005", "00081_1922-0000")
+        tmp_path,
+        prerendered=("00082_1922-0005", "00081_1922-0001", "00081_1922-0000"),
     )
     totals = run_pipeline(items, settings, streams=2, decode_workers=1, progress=False)
-    assert totals["items"] == 2 and totals["sheets"] == 2 and totals["broken"] == 1
-    ready = mirror / "storage-services/master" / DIR
+    assert totals["items"] == 2 and totals["sheets"] == 3 and totals["broken"] == 0
+    ready = mirror / "storage-services/service" / DIR
     map_item, map_sheet = items[1], items[1].sheets[0]
     staged = settings.staging_dir / item_relative(map_item) / "p5.jpg"
     assert staged.read_bytes() == (ready / "00082_1922-0005.jpg").read_bytes()
@@ -309,13 +315,18 @@ def test_prerendered_jpeg_is_copied_and_the_jp2_skipped(tmp_path: Path):
     ).read_bytes()
     assert Image.open(key_staged / "raw" / "p0.jpg").size == (200, 160)
     assert jp2_path(settings.jp2_dir, key_sheet).exists()
-    key_row = json.loads(
+    key_rows = json.loads(
         (settings.out_dir / item_relative(key_item) / "metadata.json").read_text()
-    )["sheets"][0]
-    assert key_row["prerendered"] is False and key_row["source_on_disk"] is True
-    # Downloaded bytes: p5's JPEG, p0's JP2, and the corrupt p1 JP2 (it has no JPEG).
-    assert totals["bytes"] == (ready / "00082_1922-0005.jpg").stat().st_size + sum(
-        s.bytes for s in key_item.sheets
+    )["sheets"]
+    assert [r["key"] for r in key_rows] == ["p0", "p1"]
+    assert key_rows[0]["prerendered"] is False and key_rows[0]["source_on_disk"] is True
+    assert key_rows[1]["prerendered"] is True and key_rows[1]["source_on_disk"] is False
+    assert not jp2_path(settings.jp2_dir, key_item.sheets[1]).exists()
+    # Downloaded bytes: p5's and p1's JPEGs plus p0's JP2.
+    assert totals["bytes"] == (
+        (ready / "00082_1922-0005.jpg").stat().st_size
+        + (ready / "00081_1922-0001.jpg").stat().st_size
+        + key_sheet.bytes
     )
     # A resume with the mirror gone skips both items on local markers alone.
     offline = Settings(

--- a/mapsnap/loc_mirror_test.py
+++ b/mapsnap/loc_mirror_test.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ from mapsnap.loc_mirror import (
     DONE,
     UPLOADED,
     ItemPlan,
+    NotFound,
     Settings,
     Sheet,
     _connections,
@@ -24,6 +26,7 @@ from mapsnap.loc_mirror import (
     keep_sheet,
     load_mapping,
     prune_empty_parents,
+    quarter_url,
     run_pipeline,
     s3_prefix,
     select_items,
@@ -92,6 +95,11 @@ def test_layout_matches_the_s3_prefix_shape(tmp_path: Path):
         source_url("http://m", sheet)
         == "http://m/storage-services/service/gmd/gmd390m/g3904m/g3904mm/g000811922/00081_1922-0123.jp2"
     )
+    # The mirror's pre-rendered 25% JPEGs sit in the master tree with a .jpg suffix.
+    assert (
+        quarter_url("http://m", sheet)
+        == "http://m/storage-services/master/gmd/gmd390m/g3904m/g3904mm/g000811922/00081_1922-0123.jpg"
+    )
     tif = Sheet(
         1, "00081_1922-0124", "p124", "torrent-master-tif", 0, sheet.storage_dir
     )
@@ -125,6 +133,12 @@ def write_jp2(path: Path, width: int = 200, height: int = 160) -> None:
     )
 
 
+def write_jpeg(path: Path, width: int = 50, height: int = 40) -> None:
+    """A stand-in for the mirror's pre-rendered 25% JPEG: a flat tint no decode would produce."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (width, height), (90, 140, 200)).save(path, "JPEG", quality=95)
+
+
 needs_jp2 = pytest.mark.skipif(
     not features.check("jpg_2000"), reason="Pillow lacks JPEG 2000"
 )
@@ -139,8 +153,13 @@ def test_decode_jp2_quarter_and_full(tmp_path: Path):
     assert Image.open(tmp_path / "q.jpg").size == (50, 40)
 
 
-def make_volume(tmp_path: Path) -> tuple[list[ItemPlan], Settings, Path]:
-    """A file:// mirror with two items: one good sheet, one page-0 sheet, one corrupt sheet."""
+def make_volume(
+    tmp_path: Path, prerendered: tuple[str, ...] = ()
+) -> tuple[list[ItemPlan], Settings, Path]:
+    """A file:// mirror with two items: one good sheet, one page-0 sheet, one corrupt sheet.
+
+    ``prerendered`` names the stems the mirror also serves as ready-made 25% JPEGs.
+    """
     mirror = tmp_path / "mirror"
     files = {
         "00081_1922-0000": True,
@@ -154,6 +173,8 @@ def make_volume(tmp_path: Path) -> tuple[list[ItemPlan], Settings, Path]:
         else:
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_bytes(b"not a jp2")
+    for stem in prerendered:
+        write_jpeg(mirror / "storage-services/master" / DIR / f"{stem}.jpg")
     size = lambda stem: (
         (mirror / "storage-services/service" / DIR / f"{stem}.jp2").stat().st_size
     )
@@ -232,6 +253,9 @@ def test_pipeline_decodes_logs_broken_and_resumes(tmp_path: Path):
         "00081_1922-0001"
     ]
     assert meta["sheets"][0]["width"] == 50 and meta["sheets"][0]["raw"] is True
+    # No pre-rendered JPEG on this mirror: every sheet came down as its JP2.
+    assert meta["sheets"][0]["prerendered"] is False
+    assert meta["sheets"][0]["source_on_disk"] is True
     assert (staged / "metadata.json").read_text() == (
         state / "metadata.json"
     ).read_text()
@@ -256,6 +280,68 @@ def test_pipeline_decodes_logs_broken_and_resumes(tmp_path: Path):
         ]
         == 0
     )
+
+
+@needs_jp2
+def test_prerendered_jpeg_is_copied_and_the_jp2_skipped(tmp_path: Path):
+    # The mirror has 25% JPEGs for both good sheets. p5, a map sheet, is
+    # copied as is and its JP2 never comes down; p0, a key-map candidate,
+    # ignores the JPEG because its raw copy needs the JP2 anyway.
+    items, settings, mirror = make_volume(
+        tmp_path, prerendered=("00082_1922-0005", "00081_1922-0000")
+    )
+    totals = run_pipeline(items, settings, streams=2, decode_workers=1, progress=False)
+    assert totals["items"] == 2 and totals["sheets"] == 2 and totals["broken"] == 1
+    ready = mirror / "storage-services/master" / DIR
+    map_item, map_sheet = items[1], items[1].sheets[0]
+    staged = settings.staging_dir / item_relative(map_item) / "p5.jpg"
+    assert staged.read_bytes() == (ready / "00082_1922-0005.jpg").read_bytes()
+    assert not jp2_path(settings.jp2_dir, map_sheet).exists()
+    row = json.loads(
+        (settings.out_dir / item_relative(map_item) / "metadata.json").read_text()
+    )["sheets"][0]
+    assert row["prerendered"] is True and row["source_on_disk"] is False
+    assert (row["width"], row["height"], row["raw"]) == (50, 40, False)
+    key_item, key_sheet = items[0], items[0].sheets[0]
+    key_staged = settings.staging_dir / item_relative(key_item)
+    assert (key_staged / "p0.jpg").read_bytes() != (
+        ready / "00081_1922-0000.jpg"
+    ).read_bytes()
+    assert Image.open(key_staged / "raw" / "p0.jpg").size == (200, 160)
+    assert jp2_path(settings.jp2_dir, key_sheet).exists()
+    key_row = json.loads(
+        (settings.out_dir / item_relative(key_item) / "metadata.json").read_text()
+    )["sheets"][0]
+    assert key_row["prerendered"] is False and key_row["source_on_disk"] is True
+    # Downloaded bytes: p5's JPEG, p0's JP2, and the corrupt p1 JP2 (it has no JPEG).
+    assert totals["bytes"] == (ready / "00082_1922-0005.jpg").stat().st_size + sum(
+        s.bytes for s in key_item.sheets
+    )
+    # A resume with the mirror gone skips both items on local markers alone.
+    offline = Settings(
+        jp2_dir=settings.jp2_dir,
+        out_dir=settings.out_dir,
+        staging_dir=settings.staging_dir,
+        mirror="http://127.0.0.1:9",
+    )
+    assert (
+        run_pipeline(items, offline, streams=1, decode_workers=1, progress=False)[
+            "items"
+        ]
+        == 0
+    )
+
+
+def test_missing_url_is_not_retried(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # A 404 (here: a file:// path that does not exist) is the mirror's answer,
+    # not a transient failure: fetch raises NotFound at once instead of
+    # sleeping through four retries.
+    monkeypatch.setattr(loc_mirror, "RETRY_DELAY", 30.0)
+    started = time.monotonic()
+    with pytest.raises(NotFound):
+        fetch((tmp_path / "nope.jpg").as_uri(), tmp_path / "out.jpg")
+    assert time.monotonic() - started < 5
+    assert not (tmp_path / "out.jpg.part").exists()
 
 
 @needs_jp2
@@ -319,6 +405,7 @@ def test_fetch_reuses_one_keep_alive_connection_per_thread(
     root.mkdir()
     (root / "a.bin").write_bytes(b"a" * 1000)
     (root / "b.bin").write_bytes(b"b" * 2000)
+    hits: dict[str, int] = {}
 
     class Handler(http.server.SimpleHTTPRequestHandler):
         protocol_version = "HTTP/1.1"  # keep-alive, as nginx does
@@ -329,23 +416,40 @@ def test_fetch_reuses_one_keep_alive_connection_per_thread(
         def log_message(self, format: str, *args) -> None:
             pass
 
+        def do_GET(self) -> None:
+            hits[self.path] = hits.get(self.path, 0) + 1
+            if self.path == "/short.bin":  # promises 2000 bytes, sends 1000, hangs up
+                self.send_response(200)
+                self.send_header("Content-Length", "2000")
+                self.end_headers()
+                self.wfile.write(b"s" * 1000)
+                self.close_connection = True
+                return
+            super().do_GET()
+
     server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
     threading.Thread(target=server.serve_forever, daemon=True).start()
     base = f"http://127.0.0.1:{server.server_port}"
     monkeypatch.setattr(loc_mirror, "RETRY_DELAY", 0.0)
     try:
-        fetch(f"{base}/a.bin", tmp_path / "a.bin", 1000)
+        assert fetch(f"{base}/a.bin", tmp_path / "a.bin", 1000) == 1000
         first = _connections.conn
         fetch(f"{base}/b.bin", tmp_path / "b.bin", 2000)
         assert _connections.conn is first  # same socket, not a new connection per file
         assert (tmp_path / "b.bin").read_bytes() == b"b" * 2000
-        with pytest.raises(OSError):
+        with pytest.raises(NotFound):
             fetch(f"{base}/missing.bin", tmp_path / "m.bin")
+        assert hits["/missing.bin"] == 1  # a 404 is final: no retries
         assert (
             not (tmp_path / "m.bin").exists() and not (tmp_path / "m.bin.part").exists()
         )
         with pytest.raises(OSError):
             fetch(f"{base}/a.bin", tmp_path / "a2.bin", expected_bytes=999)
+        # A body cut short of its Content-Length is an error, not a small file.
+        with pytest.raises(OSError, match="short body: 1000 of 2000"):
+            fetch(f"{base}/short.bin", tmp_path / "s.bin")
+        assert hits["/short.bin"] == loc_mirror.RETRIES
+        assert not (tmp_path / "s.bin").exists()
     finally:
         server.shutdown()
 


### PR DESCRIPTION
Part of #354.

The HTTP mirror now serves 25% JPEGs beside the masters at `storage-services/master/<dir>/<stem>.jpg`. A sample (`01989_1898-0007`) is byte-for-byte what `loc_mirror` produces itself: same 1613 × 1913 quarter-level decode, same quality-95 tables and 4:2:0 subsampling, 78 dB PSNR against our own file. So `mapsnap loc-mirror` now uses them.

## What changes

- **Download stage.** For a map sheet, the pre-rendered JPEG is tried first and lands straight in staging as `p<key>.jpg`. Only a 404 sends the sheet down the JP2 route as before. Key-map candidates (the page-0 family and letter pages) always fetch the JP2, since their raw copy needs the full resolution. A JP2 already in `--jp2-dir` is used in preference to the mirror's JPEG, so resumes never re-download.
- **No JP2 on fivetera for pre-rendered sheets.** Accepted as the trade. Each `metadata.json` sheet row now records `prerendered` (the 25% JPEG arrived ready-made) and `source_on_disk` (its JP2/TIFF is in `--jp2-dir`), so the sheets without a local full-resolution copy can be listed later.
- **`fetch()`** distinguishes a 404 (`NotFound`, raised at once) from a transient failure (retried with backoff), returns the byte count so the progress bar's `dl=` counts what was actually downloaded, and rejects a body shorter than its Content-Length, which `http.client` otherwise ends silently.

## Verification

- `loc_mirror_test.py`: 14 tests, two new. One runs the pipeline against a file:// mirror with pre-rendered JPEGs and checks the map sheet is copied byte-for-byte with no JP2 fetched while the page-0 sheet ignores the JPEG and produces its raw copy; one checks a missing URL raises `NotFound` without retries. The keep-alive test now also covers a 404 (one request, no retries) and a short body (rejected after the usual retries).
- Live against the mirror: `sanborn01989_003` (Illinois 1898, 14 sheets, all pre-rendered) staged in 3 s with no JP2 directory created. `sanborn01104_001` (Connecticut 1884, page 0 plus four sheets, nothing pre-rendered there yet) fell back to the JP2 for every sheet and produced `raw/p0.jpg`, no errors logged.
- Full suite 1173 passed; repo-wide ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
